### PR TITLE
1:1 멘토링 UI 그리기

### DIFF
--- a/apps/demo-web/app/mentoring/1on1/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/page.tsx
@@ -1,7 +1,252 @@
-export default function OneOnOnePage() {
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
+import { ChevronLeft, Mic, MicOff, Volume2, VolumeX, Send, PhoneOff } from "lucide-react";
+
+interface ChatMessage {
+  id: number;
+  sender: "me" | "other";
+  text: string;
+}
+
+export default function PrivateMentoringPage() {
+  const [isChatMode, setIsChatMode] = useState(false);
+  const [isEndPopupOpen, setIsEndPopupOpen] = useState(false);
+  const [isMicOn, setIsMicOn] = useState(true);
+  const [isSpeakerOn, setIsSpeakerOn] = useState(true);
+  const [chatInput, setChatInput] = useState("");
+  const [elapsedTime, setElapsedTime] = useState(0);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    { id: 1, sender: "other", text: "Let's look at the color system. The \"No-Line\" rule is critical for that premium feel." },
+    { id: 2, sender: "me", text: "Got it. I'm removing all the 1px borders now and using tonal layering instead." },
+    { id: 3, sender: "other", text: "Excellent. Also, make sure the surface hierarchy follows that \"stacked paper\" logic we talked about earlier." },
+    { id: 4, sender: "other", text: "That makes sense. Have you considered the typographic hierarchy for the display font?" },
+    { id: 5, sender: "me", text: "I'm trying to use Manrope for" },
+  ]);
+
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const timerInterval = setInterval(() => {
+      setElapsedTime((prevTime) => prevTime + 1);
+    }, 1000);
+    return () => clearInterval(timerInterval);
+  }, []);
+
+  const formatTime = (totalSeconds: number) => {
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    const seconds = totalSeconds % 60;
+    const pad = (num: number) => String(num).padStart(2, "0");
+    return `${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+  };
+
+  useEffect(() => {
+    if (isChatMode) {
+      messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages, isChatMode]);
+
+  const handleSendMessage = () => {
+    if (!chatInput.trim()) return;
+    setMessages((prev) => [...prev, { id: Date.now(), sender: "me", text: chatInput }]);
+    setChatInput("");
+    setIsChatMode(true);
+  };
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-900 text-white text-2xl">
-      📞 1:1 멘토링 룸 UI 화면입니다.
-    </div>
+    <main className="flex flex-col w-full h-full bg-[#F8F9FA] text-[#1A1A1A] relative font-sans overflow-hidden">
+      
+      {/* 상단 헤더 */}
+      <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative">
+        <button 
+          onClick={() => isChatMode ? setIsChatMode(false) : window.history.back()} 
+          className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+        >
+          <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 text-[#FFCC00]" />
+        </button>
+        
+        <div className="flex flex-col items-center">
+          <h1 className="text-[17px] font-extrabold tracking-tight">멘토 김OO</h1>
+          <span className="text-[12px] font-medium text-gray-500 mt-0.5 font-mono tracking-tight">
+            {formatTime(elapsedTime)}
+          </span>
+        </div>
+        
+        <button onClick={() => setIsEndPopupOpen(true)} className="text-red-500 font-bold text-[15px] p-1">
+          종료
+        </button>
+      </header>
+
+      {/* 내부 가변 콘텐츠 영역 */}
+      <div className="flex-1 relative overflow-hidden flex flex-col">
+        
+        {/* ==========================================
+            💡 전역 상태 알림 플로팅 팝업 컨테이너 (마이크, 스피커)
+            ========================================== */}
+        <div className="absolute top-3.5 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center pointer-events-none">
+          
+          {/* 마이크 사용 중지 팝업 */}
+          {/* 💡 핵심 수정: overflow-hidden을 제거하여 그림자가 잘리지 않게 하고, mb-2를 조건부로 주어 간격을 조절합니다. */}
+          <div className={`transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] origin-top flex justify-center
+            ${!isMicOn ? 'max-h-14 opacity-100 scale-100 translate-y-0 mb-2' : 'max-h-0 opacity-0 scale-95 -translate-y-2 mb-0'}
+          `}>
+            <div className="bg-[#1A1A1A]/90 backdrop-blur-md text-white text-[13px] font-bold px-5 py-2.5 rounded-full flex items-center gap-2 shadow-[0_8px_24px_rgba(0,0,0,0.15)] whitespace-nowrap">
+              <MicOff className="w-4 h-4 text-red-400" />
+              마이크 사용 중지됨
+            </div>
+          </div>
+
+          {/* 스피커 사용 중지 팝업 */}
+          <div className={`transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] origin-top flex justify-center
+            ${!isSpeakerOn ? 'max-h-14 opacity-100 scale-100 translate-y-0 mb-2' : 'max-h-0 opacity-0 scale-95 -translate-y-2 mb-0'}
+          `}>
+            <div className="bg-[#1A1A1A]/90 backdrop-blur-md text-white text-[13px] font-bold px-5 py-2.5 rounded-full flex items-center gap-2 shadow-[0_8px_24px_rgba(0,0,0,0.15)] whitespace-nowrap">
+              <VolumeX className="w-4 h-4 text-red-400" />
+              스피커 사용 중지됨
+            </div>
+          </div>
+
+        </div>
+
+        {/* ------------------------------------
+            A. 1:1 통화 모드 (접힌 상태)
+            ------------------------------------ */}
+        <div className={`absolute inset-0 flex flex-col transition-all duration-500 ease-in-out ${isChatMode ? '-translate-y-full opacity-0 pointer-events-none' : 'translate-y-0 opacity-100'}`}>
+          
+          <div className="flex-1 flex flex-col items-center justify-center px-6 relative z-0">
+            
+            {/* 상단 여백 (수직 중앙 정렬 유지용) */}
+            <div className="flex-1 w-full min-h-[30px]"></div>
+
+            {/* 중앙 프로필 및 컨트롤 영역 */}
+            <div className="flex flex-col items-center shrink-0">
+              <div className="relative flex items-center justify-center w-52 h-52 mb-3">
+                <div className="absolute inset-0 border border-gray-300 rounded-full animate-[ping_3s_ease-out_infinite] opacity-50"></div>
+                <div className="absolute inset-4 border border-gray-200 rounded-full animate-[ping_3s_ease-out_infinite_1s] opacity-70"></div>
+                <div className="absolute inset-8 border border-gray-100 rounded-full animate-[ping_3s_ease-out_infinite_2s]"></div>
+                
+                <div className="relative z-10 w-36 h-36 rounded-full overflow-hidden shadow-2xl border-4 border-white bg-gray-200">
+                  <img src="https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?q=80&w=500&auto=format&fit=crop" alt="Mentor Profile" className="w-full h-full object-cover" />
+                </div>
+              </div>
+
+              <h2 className="text-2xl font-extrabold mb-1">멘토 김OO</h2>
+              <p className="text-gray-500 text-[14px]">Product Design Lead @ Studio</p>
+
+              <div className="flex gap-4 mt-8">
+                <button onClick={() => setIsMicOn(!isMicOn)} className={`w-14 h-14 rounded-full flex items-center justify-center transition-all shadow-md active:scale-95 ${isMicOn ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-white text-gray-700'}`}>
+                  {isMicOn ? <Mic className="w-6 h-6" /> : <MicOff className="w-6 h-6" />}
+                </button>
+                <button onClick={() => setIsSpeakerOn(!isSpeakerOn)} className={`w-14 h-14 rounded-full flex items-center justify-center transition-all shadow-md active:scale-95 ${isSpeakerOn ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-white text-gray-700'}`}>
+                  {isSpeakerOn ? <Volume2 className="w-6 h-6" /> : <VolumeX className="w-6 h-6" />}
+                </button>
+              </div>
+            </div>
+
+            {/* 하단 여백 (수직 중앙 정렬 유지용) */}
+            <div className="flex-1 w-full pb-6"></div>
+          </div>
+
+          {/* 채팅 미리보기 시트 */}
+          <div 
+            onClick={() => setIsChatMode(true)}
+            className="w-full bg-white rounded-t-[32px] shadow-[0_-10px_40px_rgba(0,0,0,0.06)] pt-4 px-5 pb-2 cursor-pointer flex flex-col relative z-10 transition-transform hover:translate-y-[-2px]"
+          >
+            <div className="w-10 h-1.5 bg-gray-200 rounded-full mx-auto mb-5"></div>
+            
+            <div className="flex flex-col gap-3 pointer-events-none">
+              {messages.slice(-2).map((msg) => (
+                <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'}`}>
+                  <div className={`max-w-[85%] px-4 py-3 rounded-2xl text-[14px] leading-snug break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
+                    {msg.text}
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        {/* ------------------------------------
+            B. 전체 텍스트 채팅 모드
+            ------------------------------------ */}
+        <div className={`absolute inset-0 flex flex-col bg-white transition-all duration-500 ease-in-out ${!isChatMode ? 'translate-y-full opacity-0 pointer-events-none' : 'translate-y-0 opacity-100'}`}>
+          <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-4 custom-scrollbar pb-4">
+            <div className="flex justify-center my-2">
+              <span className="bg-gray-100 text-gray-500 text-[11px] font-bold px-3 py-1.5 rounded-full">오늘</span>
+            </div>
+
+            {messages.map((msg) => (
+              <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'} animate-in fade-in slide-in-from-bottom-2`}>
+                <div className={`max-w-[80%] px-4 py-3.5 rounded-2xl text-[15px] leading-relaxed break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
+                  {msg.text}
+                </div>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+        </div>
+
+      </div>
+
+      {/* ==========================================
+          [공통] 전역 하단 입력창
+          ========================================== */}
+      <div className={`w-full px-5 bg-white shrink-0 z-30 transition-all duration-500 ease-in-out flex flex-col justify-end py-3
+        ${isChatMode ? 'border-t border-gray-100 shadow-[0_-10px_20px_rgba(0,0,0,0.02)]' : ''}
+      `}>
+        <div className="relative flex items-center w-full">
+          <input
+            type="text"
+            value={chatInput}
+            onChange={(e) => setChatInput(e.target.value)}
+            onFocus={() => setIsChatMode(true)}
+            placeholder="메시지를 입력하세요"
+            onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
+            className="w-full bg-[#F2F4F6] text-[#1A1A1A] border-none rounded-full py-3.5 pl-5 pr-14 focus:outline-none focus:ring-2 focus:ring-[#FFCC00]/50 placeholder-gray-400 text-[15px] shadow-sm transition-all"
+          />
+          <button 
+            onClick={handleSendMessage}
+            className="absolute right-2 p-2 bg-[#FFCC00] hover:bg-[#E6B800] rounded-full transition-colors active:scale-90 shadow-sm"
+          >
+            <Send className="w-4 h-4 text-[#1A1A1A]" />
+          </button>
+        </div>
+      </div>
+
+      {/* ==========================================
+          종료 팝업 모달
+          ========================================== */}
+      {isEndPopupOpen && (
+        <div className="absolute inset-0 bg-black/60 z-[100] flex items-center justify-center p-6 backdrop-blur-sm animate-in fade-in duration-200">
+          <div className="bg-white w-full max-w-[320px] rounded-[32px] p-8 shadow-2xl animate-in zoom-in-95 duration-200 flex flex-col items-center">
+            
+            <div className="bg-red-50 p-4 rounded-full mb-6">
+              <PhoneOff className="w-8 h-8 text-red-500" strokeWidth={2.5} />
+            </div>
+            
+            <h3 className="text-xl font-extrabold text-[#1A1A1A] text-center mb-3">
+              정말 멘토링을<br/>종료하시겠습니까?
+            </h3>
+            <p className="text-gray-500 text-[13px] text-center mb-8 leading-relaxed break-keep">
+              멘토링을 종료하면 즉시 연결이 끊어집니다.<br />
+              추후 녹음본은 제공되지 않습니다.
+            </p>
+            
+            <div className="flex flex-col gap-3 w-full">
+              <Link href="/" className="w-full bg-[#FFCC00] text-[#1A1A1A] text-[15px] font-bold py-4 rounded-2xl hover:bg-[#E6B800] transition-colors text-center active:scale-[0.98]">
+                멘토링 종료하기
+              </Link>
+              <button onClick={() => setIsEndPopupOpen(false)} className="w-full bg-[#F2F4F6] text-[#1A1A1A] text-[15px] font-bold py-4 rounded-2xl hover:bg-[#E5E7EB] transition-colors active:scale-[0.98]">
+                멘토링 계속 진행
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+    </main>
   );
 }

--- a/apps/demo-web/app/mentoring/1on1/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/page.tsx
@@ -61,9 +61,12 @@ export default function PrivateMentoringPage() {
       
       {/* 상단 헤더 */}
       <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative">
+        {/* 💡 수정된 뒤로가기 버튼: 채팅 모드에서만 나타나며, 중앙 정렬이 깨지지 않도록 투명도로 조절합니다. */}
         <button 
-          onClick={() => isChatMode ? setIsChatMode(false) : window.history.back()} 
-          className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+          onClick={() => setIsChatMode(false)} 
+          className={`p-1 hover:bg-gray-100 rounded-full transition-all duration-300
+            ${isChatMode ? 'opacity-100 cursor-pointer' : 'opacity-0 pointer-events-none'}
+          `}
         >
           <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 text-[#FFCC00]" />
         </button>
@@ -88,8 +91,6 @@ export default function PrivateMentoringPage() {
             ========================================== */}
         <div className="absolute top-3.5 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center pointer-events-none">
           
-          {/* 마이크 사용 중지 팝업 */}
-          {/* 💡 핵심 수정: overflow-hidden을 제거하여 그림자가 잘리지 않게 하고, mb-2를 조건부로 주어 간격을 조절합니다. */}
           <div className={`transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] origin-top flex justify-center
             ${!isMicOn ? 'max-h-14 opacity-100 scale-100 translate-y-0 mb-2' : 'max-h-0 opacity-0 scale-95 -translate-y-2 mb-0'}
           `}>
@@ -99,7 +100,6 @@ export default function PrivateMentoringPage() {
             </div>
           </div>
 
-          {/* 스피커 사용 중지 팝업 */}
           <div className={`transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] origin-top flex justify-center
             ${!isSpeakerOn ? 'max-h-14 opacity-100 scale-100 translate-y-0 mb-2' : 'max-h-0 opacity-0 scale-95 -translate-y-2 mb-0'}
           `}>


### PR DESCRIPTION
## 연관된 이슈

#11 

## 작업 내용

> * 1:1 멘토링 화면 구현.
> * 상대 프로필을 제외하고 멘토/멘티 화면의 다른 점 및 가로 모드가 없어 1가지 UI만 구현함.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항
* 통화 시간이 제대로 출력되는지 확인
* 통화 종료 팝업이 제대로 출력되는지 확인
* 스피커, 마이크 사용 중지 팝업이 제대로 동작하는지 확인
* 메세지 창이 정상적으로 동작하는지 확인(메세지 창 올리기/내리기, 메세지 전송)

**실행 방법**
1. feat/11-mentoring-1on1-ui 브랜치로 체크아웃
2. /apps/demo-web 폴더에서 터미널 실행 후 "npm run dev" 명령어 실행
3. 다음 링크에서 화면 확인: http://localhost:3000/mentoring/1on1