### PR TITLE
임시 메인과 모든 UI 주소 연결

### DIFF
--- a/apps/demo-web/app/mentoring/live/mentee/landscape/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/landscape/page.tsx
@@ -73,7 +73,7 @@ export default function LandscapeLiveMentoringPage() {
         
         {/* 상단 네비게이션 (mb-5 -> mb-3) */}
         <header className="flex items-center justify-between shrink-0 mb-3 pl-1">
-          <Link href="/" className="inline-flex items-center hover:opacity-80 transition-opacity">
+          <Link href="/mentoring/live" className="inline-flex items-center hover:opacity-80 transition-opacity">
             <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-4 h-4 mr-2 text-[#FFCC00]" />
             <span className="font-bold text-[16px]">나가기</span>
           </Link>

--- a/apps/demo-web/app/mentoring/live/mentee/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/page.tsx
@@ -79,7 +79,7 @@ export default function LiveMentoringPage() {
       
       {/* 상단 네비게이션 */}
       <header className="w-full px-5 py-4 flex items-center justify-between shrink-0 z-10">
-        <Link href="/" className="inline-flex items-center hover:opacity-80 transition-opacity">
+        <Link href="/mentoring/live" className="inline-flex items-center hover:opacity-80 transition-opacity">
           <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 mr-2 text-[#FFCC00]" />
           <span className="font-bold text-[17px]">나가기</span>
         </Link>

--- a/apps/demo-web/app/mentoring/live/mentor/landscape/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/landscape/page.tsx
@@ -224,7 +224,7 @@ export default function MentorLandscapeLivePage() {
               <button onClick={() => setIsExitPopupOpen(false)} className="flex-1 bg-gray-800 text-white text-[14px] font-bold py-3 rounded-xl hover:bg-gray-700 transition-colors">
                 취소
               </button>
-              <Link href="/" className="flex-1 bg-red-600 text-white text-[14px] font-bold py-3 rounded-xl hover:bg-red-700 transition-colors text-center">
+              <Link href="/mentoring/live" className="flex-1 bg-red-600 text-white text-[14px] font-bold py-3 rounded-xl hover:bg-red-700 transition-colors text-center">
                 종료
               </Link>
             </div>

--- a/apps/demo-web/app/mentoring/live/mentor/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/page.tsx
@@ -223,7 +223,7 @@ export default function MentorLivePage() {
               <button onClick={() => setIsExitPopupOpen(false)} className="flex-1 bg-gray-800 text-white font-bold py-4 rounded-2xl hover:bg-gray-700 transition-colors">
                 취소
               </button>
-              <Link href="/" className="flex-1 bg-red-600 text-white font-bold py-4 rounded-2xl hover:bg-red-700 transition-colors text-center">
+              <Link href="/mentoring/live" className="flex-1 bg-red-600 text-white font-bold py-4 rounded-2xl hover:bg-red-700 transition-colors text-center">
                 종료
               </Link>
             </div>

--- a/apps/demo-web/app/mentoring/live/page.tsx
+++ b/apps/demo-web/app/mentoring/live/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center bg-zinc-900 text-white p-4">
+      <h1 className="text-4xl font-bold text-yellow-400 mb-5">
+        1:N Live 멘토링 UI 모음
+      </h1>
+
+      {/* 4개의 버튼을 세로로 나열하는 묶음 */}
+      <div className="flex flex-col gap-4 w-full max-w-sm">
+        
+        <Link href="/mentoring/live/mentor" className="px-6 py-4 bg-zinc-800 border border-zinc-700 rounded-xl hover:bg-zinc-700 transition-colors text-center font-bold">
+          🧑‍🏫멘토 ↕️세로 UI
+        </Link>
+
+        <Link href="/mentoring/live/mentor/landscape" className="px-6 py-4 bg-zinc-800 border border-zinc-700 rounded-xl hover:bg-zinc-700 transition-colors text-center font-bold">
+          🧑‍🏫멘토 ↔️가로 UI
+        </Link>
+
+        <Link href="/mentoring/live/mentee" className="px-6 py-4 bg-zinc-800 border border-zinc-700 rounded-xl hover:bg-zinc-700 transition-colors text-center font-bold">
+          🙋멘티 ↕️세로 UI
+        </Link>
+
+        <Link href="/mentoring/live/mentee/landscape" className="px-6 py-4 bg-zinc-800 border border-zinc-700 rounded-xl hover:bg-zinc-700 transition-colors text-center font-bold">
+          🙋멘티 ↔️가로 UI
+        </Link>
+
+        <Link href="/" className="w-fit mx-auto px-5 py-3 bg-[#FFCC00] text-black rounded-xl hover:bg-[#E6B800] transition-colors text-center font-bold">
+          📱 메인으로
+        </Link>
+
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## 연관된 이슈

#18 

## 작업 내용
1:N 라이브 멘토링 UI 모음 화면 제작
각 멘토링 UI의 나가기/종료 버튼에 해당 화면 연결

<img width="254" height="381" alt="image" src="https://github.com/user-attachments/assets/fd4b55f7-10ee-4e03-8b1f-60a1d6dfb27c" />

- 이제 메인 화면에서 "1:N 라이브 멘토링 UI" 버튼을 누르면 위 화면으로 연결됩니다.
- 모든 페이지가 끊김 없이 연결되었습니다.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

- 간단한 수정사항이므로 빠르게 approve 해주시면 감사하겠습니다