### PR TITLE
멘토링 스크립트 편집 UI 그리기

### DIFF
--- a/apps/demo-web/app/mentor/script/page.tsx
+++ b/apps/demo-web/app/mentor/script/page.tsx
@@ -1,7 +1,210 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+import Link from "next/link";
+import { ChevronLeft, Undo2, Save, Send, Bell, MousePointer2, Grab, ShieldCheck, Eraser, EyeOff } from "lucide-react";
+
 export default function ScriptEditPage() {
+  const [isMenteeView, setIsMenteeView] = useState(false);
+  const [isPublishPopupOpen, setIsPublishPopupOpen] = useState(false);
+  
+  // 💡 텍스트 모드가 사라지고, 선택 방식(드래그/원클릭)만 관리합니다.
+  const [editMode, setEditMode] = useState<"drag" | "click">("drag");
+  const [canUndo, setCanUndo] = useState(false);
+  const [clickRangeStart, setClickRangeStart] = useState<Range | null>(null);
+  
+  const editorRef = useRef<HTMLDivElement>(null);
+
+  // 초기 스크립트 데이터 세팅
+  useEffect(() => {
+    if (editorRef.current && !editorRef.current.innerHTML) {
+      editorRef.current.innerHTML = `During our session today, we discussed the strategic roadmap for the upcoming quarter. We focused on three main pillars: operational efficiency, stakeholder communication, and technical debt reduction.<br><br>I noticed that your approach to delegating tasks has improved significantly. However, you should still monitor the velocity of the secondary team when sharing the board with junior designers.`;
+    }
+    updateUndoState();
+  }, []);
+
+  const updateUndoState = () => {
+    setCanUndo(document.queryCommandEnabled('undo'));
+  };
+
+  // 💡 브라우저 네이티브 하이라이트(배경색) 기능을 사용하여 완벽하게 마스킹 적용
+  const applyMask = (color: string) => {
+    if (editorRef.current) editorRef.current.focus();
+    if (!document.execCommand('hiliteColor', false, color)) {
+      document.execCommand('backColor', false, color);
+    }
+    updateUndoState();
+    setClickRangeStart(null);
+  };
+
+  const handleAction = (action: 'mask' | 'erase') => {
+    if (action === 'mask') applyMask('#FFCC00');
+    else if (action === 'erase') applyMask('transparent');
+  };
+
+  const handleUndo = () => {
+    document.execCommand('undo');
+    updateUndoState();
+    setClickRangeStart(null);
+  };
+
+  // 💡 원클릭 모드 로직 (첫 클릭: 시작점, 두 번째 클릭: 범위 선택)
+  const handleEditorClick = (e: React.MouseEvent) => {
+    updateUndoState();
+    if (editMode !== 'click' || isMenteeView) return;
+
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+
+    // 만약 원클릭 모드인데 드래그를 했다면 범위를 일반 선택으로 인정합니다.
+    if (!sel.isCollapsed) {
+      setClickRangeStart(null);
+      return;
+    }
+
+    const currentCaret = sel.getRangeAt(0).cloneRange();
+
+    if (!clickRangeStart) {
+      setClickRangeStart(currentCaret); // 첫 번째 클릭 지점 저장
+    } else {
+      // 두 번째 클릭 시, 첫 번째 지점부터 두 번째 지점까지 선택 범위를 생성합니다.
+      const newRange = document.createRange();
+      const cmp = clickRangeStart.compareBoundaryPoints(Range.START_TO_START, currentCaret);
+      
+      if (cmp <= 0) {
+        newRange.setStart(clickRangeStart.startContainer, clickRangeStart.startOffset);
+        newRange.setEnd(currentCaret.endContainer, currentCaret.endOffset);
+      } else {
+        newRange.setStart(currentCaret.startContainer, currentCaret.startOffset);
+        newRange.setEnd(clickRangeStart.endContainer, clickRangeStart.endOffset);
+      }
+      
+      sel.removeAllRanges();
+      sel.addRange(newRange); // 파란색으로 선택 범위가 활성화됨
+      setClickRangeStart(null);
+    }
+  };
+
+  // 모드가 바뀔 때 원클릭 초기화
+  useEffect(() => {
+    setClickRangeStart(null);
+  }, [editMode]);
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-zinc-900 text-white text-2xl">
-      ✂️ 멘토링 스크립트 수정 및 발행 UI 화면입니다.
-    </div>
+    <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
+      
+      {/* 💡 에디터 핵심 CSS 주입 (멘티 뷰 가림 처리 및 네이티브 선택 영역 디자인) */}
+      <style>{`
+        .editor-container { outline: none; }
+        .editor-container ::selection { background-color: rgba(59, 130, 246, 0.4) !important; color: inherit; }
+        .editor-container span[style*="background-color"] { border-radius: 3px; padding: 2px 0; }
+        .editor-container span[style*="transparent"], .editor-container span[style*="rgba(0, 0, 0, 0)"] { background-color: transparent !important; }
+        
+        /* 멘티 뷰 활성화 시 노란색 배경 글자만 완전히 투명하게 가림 */
+        .editor-container.mentee-view span[style*="rgb(255, 204, 0)"], 
+        .editor-container.mentee-view span[style*="#FFCC00"], 
+        .editor-container.mentee-view span[style*="#ffcc00"] {
+          color: transparent !important; background-color: #FFCC00 !important; user-select: none;
+        }
+      `}</style>
+
+      {/* 1. 상단 헤더 */}
+      <header className="flex items-center justify-between px-5 py-4 border-b border-gray-100 shrink-0 bg-white z-10">
+        <div className="flex items-center gap-3">
+          <Link href="/" className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors">
+            <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 text-[#FFCC00]" />
+          </Link>
+          <h1 className="text-[17px] font-extrabold tracking-tight">스크립트 편집 & 리뷰</h1>
+        </div>
+        
+        <div className="flex items-center gap-2">
+          <span className="text-[12px] font-bold text-gray-500">멘티 뷰 보기</span>
+          <button onClick={() => setIsMenteeView(!isMenteeView)} className={`w-11 h-6 rounded-full p-1 transition-colors duration-300 ${isMenteeView ? 'bg-[#FFCC00]' : 'bg-gray-200'}`}>
+            <div className={`w-4 h-4 bg-white rounded-full shadow-sm transition-transform duration-300 ${isMenteeView ? 'translate-x-5' : 'translate-x-0'}`} />
+          </button>
+        </div>
+      </header>
+
+      {/* 2. 편집 툴바 */}
+      <div className={`flex items-center justify-between px-5 py-3 border-b border-gray-100 border-dashed bg-[#FAFAFA] shrink-0 transition-all duration-300 overflow-hidden
+        ${isMenteeView ? 'max-h-0 opacity-0 py-0' : 'max-h-20 opacity-100'}
+      `}>
+        <div className="flex bg-gray-200/60 p-1 rounded-xl">
+          <button onClick={() => setEditMode("drag")} className={`px-4 py-1.5 text-[13px] font-bold rounded-lg transition-all flex items-center gap-1.5 ${editMode === "drag" ? 'bg-[#FFCC00] text-[#1A1A1A] shadow-sm' : 'text-gray-500'}`}>
+            <Grab className="w-3.5 h-3.5" /> 드래그
+          </button>
+          <button onClick={() => setEditMode("click")} className={`px-4 py-1.5 text-[13px] font-bold rounded-lg transition-all flex items-center gap-1.5 ${editMode === "click" ? 'bg-[#FFCC00] text-[#1A1A1A] shadow-sm' : 'text-gray-500'}`}>
+            <MousePointer2 className="w-3.5 h-3.5" /> 원클릭
+          </button>
+        </div>
+        
+        <div className="flex items-center gap-2">
+          {/* 💡 onMouseDown 이벤트에 e.preventDefault()를 넣어 버튼 클릭 시 에디터 포커스가 풀리지 않도록 합니다. */}
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-[#1A1A1A] text-white p-2 rounded-lg transition-colors hover:bg-black shadow-sm" title="선택된 영역 마스킹">
+            <EyeOff className="w-4 h-4" />
+          </button>
+          
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('erase')} className="bg-red-50 text-red-500 hover:bg-red-100 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹 해제">
+            <Eraser className="w-4 h-4" />
+          </button>
+
+          <div className="h-4 w-[1px] bg-gray-300 mx-1" />
+          
+          <button onMouseDown={(e) => e.preventDefault()} onClick={handleUndo} disabled={!canUndo} className={`p-2 rounded-lg transition-colors ${canUndo ? 'text-gray-700 hover:bg-gray-200' : 'text-gray-300 cursor-not-allowed'}`} title="실행 취소">
+            <Undo2 className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* 3. 본문 영역 */}
+      <div className="flex-1 overflow-y-auto px-6 py-8 bg-white custom-scrollbar">
+        <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
+          Mentoring Summary - Mar 25, 2026
+        </h2>
+
+        {/* 💡 자유로운 편집과 마스킹을 모두 지원하는 네이티브 에디터 컨테이너 */}
+        <div 
+          ref={editorRef}
+          contentEditable={!isMenteeView}
+          suppressContentEditableWarning
+          onClick={handleEditorClick}
+          onInput={updateUndoState}
+          onKeyUp={updateUndoState}
+          className={`editor-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight transition-all p-4 -mx-4 rounded-xl
+            ${isMenteeView ? 'mentee-view bg-[#FAFAFA] border border-gray-100 pointer-events-none' : 'focus:ring-2 focus:ring-[#FFCC00]/30 cursor-text'}
+          `}
+        />
+      </div>
+
+      {/* 4. 하단 바 */}
+      <div className="w-full px-5 py-4 bg-white border-t border-gray-100 flex gap-3 shrink-0 pb-safe z-20">
+        <button className="flex flex-col items-center justify-center w-20 bg-white text-gray-600 hover:bg-gray-50 rounded-2xl border border-gray-200 active:scale-95 transition-transform">
+          <Save className="w-5 h-5 mb-1" />
+          <span className="text-[11px] font-bold">임시 저장</span>
+        </button>
+        <button onClick={() => setIsPublishPopupOpen(true)} className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-extrabold text-[16px] py-4 rounded-2xl hover:bg-[#E6B800] transition-colors flex items-center justify-center gap-2 active:scale-[0.98] shadow-sm">
+          <Send className="w-5 h-5" /> 발행하기
+        </button>
+      </div>
+
+      {/* 5. 발행 모달 */}
+      {isPublishPopupOpen && (
+        <div className="absolute inset-0 bg-black/60 z-[100] flex items-center justify-center p-6 backdrop-blur-sm animate-in fade-in duration-200">
+          <div className="bg-white w-full max-w-[320px] rounded-[32px] p-8 shadow-2xl animate-in zoom-in-95 flex flex-col items-center">
+            <div className="bg-[#FFCC00] w-16 h-16 rounded-full flex items-center justify-center mb-5 shadow-inner">
+              <Bell className="w-8 h-8 text-[#1A1A1A]" fill="currentColor" />
+            </div>
+            <h3 className="text-[19px] font-extrabold text-center mb-3">정말 발행하시겠습니까?</h3>
+            <p className="text-gray-500 text-[13px] text-center mb-8 leading-relaxed">
+              발행 시 멘티에게 알림이 전송됩니다. 마스킹 처리가 완벽한지 다시 한 번 확인해 주세요.
+            </p>
+            <div className="flex gap-3 w-full">
+              <button onClick={() => setIsPublishPopupOpen(false)} className="flex-1 bg-[#F2F4F6] text-gray-600 font-bold py-3.5 rounded-xl transition-all hover:bg-gray-200 active:scale-95">취소</button>
+              <button className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-bold py-3.5 rounded-xl shadow-sm transition-all hover:bg-[#E6B800] active:scale-95">발행</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
   );
 }

--- a/apps/demo-web/app/mentor/script/page.tsx
+++ b/apps/demo-web/app/mentor/script/page.tsx
@@ -140,11 +140,23 @@ export default function ScriptEditPage() {
         
         <div className="flex items-center gap-2">
           {/* 💡 onMouseDown 이벤트에 e.preventDefault()를 넣어 버튼 클릭 시 에디터 포커스가 풀리지 않도록 합니다. */}
-          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-[#1A1A1A] text-white p-2 rounded-lg transition-colors hover:bg-black shadow-sm" title="선택된 영역 마스킹">
+          {/* 마스킹: 짙은 회색 아이콘 */}
+          <button 
+            onMouseDown={(e) => e.preventDefault()} 
+            onClick={() => handleAction('mask')} 
+            className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" 
+            title="선택된 영역 마스킹"
+          >
             <EyeOff className="w-4 h-4" />
           </button>
-          
-          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('erase')} className="bg-red-50 text-red-500 hover:bg-red-100 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹 해제">
+
+          {/* 지우기: 빨간색 아이콘으로 포인트 */}
+          <button 
+            onMouseDown={(e) => e.preventDefault()} 
+            onClick={() => handleAction('erase')} 
+            className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" 
+            title="선택된 영역 마스킹 해제"
+          >
             <Eraser className="w-4 h-4" />
           </button>
 
@@ -196,7 +208,8 @@ export default function ScriptEditPage() {
             </div>
             <h3 className="text-[19px] font-extrabold text-center mb-3">정말 발행하시겠습니까?</h3>
             <p className="text-gray-500 text-[13px] text-center mb-8 leading-relaxed">
-              발행 시 멘티에게 알림이 전송됩니다. 마스킹 처리가 완벽한지 다시 한 번 확인해 주세요.
+              발행 시 멘티에게 알림이 전송됩니다.<br />
+              마스킹 처리가 완벽한지 다시 한 번 확인해 주세요.
             </p>
             <div className="flex gap-3 w-full">
               <button onClick={() => setIsPublishPopupOpen(false)} className="flex-1 bg-[#F2F4F6] text-gray-600 font-bold py-3.5 rounded-xl transition-all hover:bg-gray-200 active:scale-95">취소</button>


### PR DESCRIPTION
## 연관된 이슈

#16 

## 작업 내용

https://github.com/user-attachments/assets/bdcb1f19-6ea9-4f06-83f2-f25640198cac

>- 멘토링 스크립트 편집 UI 구현
>- 텍스트 편집이 가능하고, 상단의 버튼을 통해 마스킹 혹은 마스킹 해제가 가능함.
>- 드래그 모드에서는 드래그 된 텍스트들을 마스킹/마스킹해제 할 수 있음.
>- 원클릭 모드에서는 편집할 텍스트 영역의 처음과 끝을 클릭하면 영역이 설정되고, 해당 텍스트들을 마스킹/마스킹해제 할 수 있음.
>- 마스킹 된 텍스트는 멘토 편집 뷰에서는 눈에 보이지만, "멘티 뷰 보기"를 켜면 가려진 것을 확인할 수 있음.
>- 발행하기 버튼을 누르면 발행 전 확인 팝업이 뜸.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

- 텍스트 작성, 삭제 등 편집이 가능한지 확인.
- 드래그 모드에서 드래그 된 텍스트들의 마스킹/마스킹 해제가 잘 이루어지는지 확인.
- 원클릭 모드에서 설정된 영역의 텍스트들의 마스킹/마스킹 해제가 잘 이루어지는지 확인.
- "멘티 뷰 보기"에서 마스킹 된 부분이 잘 가려졌는지 확인.
- 발행 버튼 클릭 시 확인 팝업이 정상적으로 뜨는지 확인.

**실행 방법**
1. feat/16-script-ui 브랜치로 체크아웃
2. /apps/demo-web 폴더에서 터미널 실행 후 "npm run dev" 명령어 실행
3. http://localhost:3000/ 에서 "스크립트 수정 UI" 버튼을 눌러 확인.