### PR TITLE
멘토링 목록 UI 그리기

### DIFF
--- a/apps/demo-web/app/(with-nav)/layout.tsx
+++ b/apps/demo-web/app/(with-nav)/layout.tsx
@@ -1,8 +1,20 @@
+"use client"; // 💡 usePathname을 사용하기 위해 최상단에 추가합니다.
+
 import Link from "next/link";
-// 💡 새로운 항목에 어울리는 아이콘들로 변경했습니다.
+import { usePathname } from "next/navigation"; // 💡 현재 경로를 가져오는 훅
 import { Home, Users, UserCircle, User } from "lucide-react";
 
 export default function WithNavLayout({ children }: { children: React.ReactNode }) {
+  // 현재 접속 중인 URL 주소를 가져옵니다. (예: "/mentoring_list/1on1_list")
+  const pathname = usePathname();
+
+  // 💡 특정 경로가 현재 URL에 포함되어 있는지 확인하는 도우미 함수
+  // 홈("/")은 정확히 일치할 때만 활성화하고, 나머지는 하위 페이지에 들어가도 활성화되도록 startsWith를 사용합니다.
+  const isActive = (path: string) => {
+    if (path === "/") return pathname === "/";
+    return pathname?.startsWith(path);
+  };
+
   return (
     <div className="flex flex-col w-full h-[100dvh] bg-white overflow-hidden relative font-sans">
       
@@ -12,29 +24,51 @@ export default function WithNavLayout({ children }: { children: React.ReactNode 
       </div>
 
       {/* 하단 네비게이션 바 */}
-      {/* 항목이 5개에서 4개로 줄었기 때문에, 각 버튼이 차지하는 너비가 자연스럽게 넓어졌습니다. */}
-      <nav className="w-full shrink-0 bg-white border-t border-gray-100 flex justify-between px-2 pt-2 pb-safe text-gray-400 z-50">
+      {/* 💡 nav 태그 자체의 텍스트 색상을 지우고, 각 버튼에서 개별적으로 제어하도록 변경했습니다. */}
+      <nav className="w-full shrink-0 bg-white border-t border-gray-100 flex justify-between px-2 pt-2 pb-safe z-50">
         
-        <Link href="/" className="flex flex-col items-center justify-center p-2 flex-1 text-[#1A1A1A]">
-          <Home className="w-6 h-6 mb-1" strokeWidth={2.5} />
+        {/* 홈 */}
+        <Link 
+          href="/" 
+          className={`flex flex-col items-center justify-center p-2 flex-1 transition-colors 
+            ${isActive("/") ? "text-[#1A1A1A]" : "text-gray-400 hover:text-gray-900"}
+          `}
+        >
+          {/* 활성화되면 선 굵기(strokeWidth)도 2에서 2.5로 진하게 만듭니다. */}
+          <Home className="w-6 h-6 mb-1" strokeWidth={isActive("/") ? 2.5 : 2} />
           <span className="text-[11px] font-bold tracking-tight">홈</span>
         </Link>
 
-        {/* 1:N 멘토링 (다수 인원 느낌의 Users 아이콘 사용) */}
-        <Link href="/mentoring_list/live_list" className="flex flex-col items-center justify-center p-2 flex-1 hover:text-gray-900 transition-colors">
-          <Users className="w-6 h-6 mb-1" strokeWidth={2} />
+        {/* 1:N 멘토링 */}
+        <Link 
+          href="/mentoring_list/live_list" 
+          className={`flex flex-col items-center justify-center p-2 flex-1 transition-colors 
+            ${isActive("/mentoring_list/live_list") ? "text-[#1A1A1A]" : "text-gray-400 hover:text-gray-900"}
+          `}
+        >
+          <Users className="w-6 h-6 mb-1" strokeWidth={isActive("/mentoring_list/live_list") ? 2.5 : 2} />
           <span className="text-[11px] font-bold tracking-tight whitespace-nowrap">1:N 멘토링</span>
         </Link>
 
-        {/* 1:1 멘토링 (개인 대 개인 느낌의 UserCircle 아이콘 사용) */}
-        <Link href="/mentoring_list/1on1_list" className="flex flex-col items-center justify-center p-2 flex-1 hover:text-gray-900 transition-colors">
-          <UserCircle className="w-6 h-6 mb-1" strokeWidth={2} />
+        {/* 1:1 멘토링 */}
+        <Link 
+          href="/mentoring_list/1on1_list" 
+          className={`flex flex-col items-center justify-center p-2 flex-1 transition-colors 
+            ${isActive("/mentoring_list/1on1_list") ? "text-[#1A1A1A]" : "text-gray-400 hover:text-gray-900"}
+          `}
+        >
+          <UserCircle className="w-6 h-6 mb-1" strokeWidth={isActive("/mentoring_list/1on1_list") ? 2.5 : 2} />
           <span className="text-[11px] font-bold tracking-tight whitespace-nowrap">1:1 멘토링</span>
         </Link>
 
         {/* 마이페이지 */}
-        <Link href="/mypage" className="flex flex-col items-center justify-center p-2 flex-1 hover:text-gray-900 transition-colors">
-          <User className="w-6 h-6 mb-1" strokeWidth={2} />
+        <Link 
+          href="/mypage" 
+          className={`flex flex-col items-center justify-center p-2 flex-1 transition-colors 
+            ${isActive("/mypage") ? "text-[#1A1A1A]" : "text-gray-400 hover:text-gray-900"}
+          `}
+        >
+          <User className="w-6 h-6 mb-1" strokeWidth={isActive("/mypage") ? 2.5 : 2} />
           <span className="text-[11px] font-bold tracking-tight">마이페이지</span>
         </Link>
 

--- a/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useMemo, useRef, useEffect } from "react";
-import { Search, MessageSquare, Calendar as CalendarIcon, X, Send, ChevronLeft, ChevronRight } from "lucide-react";
+import { Search, MessageSquare, Calendar as CalendarIcon, X, Send, ChevronLeft, ChevronRight, AlertCircle, Clock } from "lucide-react";
 
-// 💡 1. 메시지 타입을 정의하고 MentoringPerson에 추가합니다.
 type Message = {
   id: number;
   sender: "me" | "other";
@@ -19,9 +18,11 @@ type MentoringPerson = {
   status: string;
   profileColor: string;
   tags: string[];
-  availableDates?: number[];
+  // 💡 시간 선택을 위해 구조 변경: { 날짜: [시간들] }
+  availableSlots?: Record<number, string[]>;
   bookedDate?: number | null;
-  messages: Message[]; // 모든 사람에게 메시지 배열 추가
+  bookedTime?: string | null;
+  messages: Message[];
 };
 
 const INITIAL_MENTORS: MentoringPerson[] = [
@@ -33,7 +34,12 @@ const INITIAL_MENTORS: MentoringPerson[] = [
     status: "진행 완료",
     profileColor: "bg-blue-500",
     tags: ["포트폴리오", "기술면접"],
-    availableDates: [12, 15, 18, 25],
+    availableSlots: {
+      12: ["10:00", "14:00", "16:00"],
+      15: ["11:00", "15:00"],
+      18: ["14:00", "19:00"],
+      25: ["10:00", "13:00", "17:00"],
+    },
     messages: [
       { id: 1, sender: "me", text: "안녕하세요! 멘토링 관련해서 궁금한 점이 있습니다.", time: "오후 2:30" },
       { id: 2, sender: "other", text: "네, 편하게 말씀해 주세요! 😊", time: "오후 2:32" }
@@ -47,7 +53,13 @@ const INITIAL_MENTORS: MentoringPerson[] = [
     status: "예약됨",
     profileColor: "bg-emerald-500",
     tags: ["React", "성능최적화"],
-    availableDates: [10, 11, 20, 22],
+    bookedDate: 30,
+    bookedTime: "15:00",
+    availableSlots: {
+      10: ["10:00"],
+      20: ["14:00", "16:00"],
+      30: ["15:00"],
+    },
     messages: [],
   }
 ];
@@ -65,17 +77,6 @@ const INITIAL_MENTEES: MentoringPerson[] = [
     messages: [],
   },
   {
-    id: 102,
-    name: "코딩하는토끼",
-    role: "주니어 개발자 · 1년차",
-    lastMentoring: "2026. 04. 18",
-    status: "진행 완료",
-    profileColor: "bg-purple-400",
-    tags: ["코드 리뷰", "아키텍처"],
-    bookedDate: null,
-    messages: [],
-  },
-  {
     id: 103,
     name: "방황하는감자",
     role: "전공생 · 3학년",
@@ -84,6 +85,7 @@ const INITIAL_MENTEES: MentoringPerson[] = [
     profileColor: "bg-pink-400",
     tags: ["진로 상담"],
     bookedDate: 15,
+    bookedTime: "14:00",
     messages: [],
   }
 ];
@@ -99,10 +101,10 @@ export default function OneOnOneListPage() {
   const [activeMessage, setActiveMessage] = useState<MentoringPerson | null>(null);
   const [activeCalendar, setActiveCalendar] = useState<MentoringPerson | null>(null);
   const [selectedDate, setSelectedDate] = useState<number | null>(null);
+  const [selectedTime, setSelectedTime] = useState<string | null>(null);
 
-  // 💡 2. 채팅 입력창 상태 추가
   const [inputText, setInputText] = useState("");
-  const messagesEndRef = useRef<HTMLDivElement>(null); // 자동 스크롤을 위한 참조
+  const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const displayList = useMemo(() => {
     let list = userRole === "MENTEE" ? mentors : mentees;
@@ -119,8 +121,9 @@ export default function OneOnOneListPage() {
   const emptyDays = Array.from({ length: 5 });
   const daysInMonth = Array.from({ length: 31 }, (_, i) => i + 1);
 
+  // 💡 예약 확정 핸들러
   const handleConfirmReservation = () => {
-    if (!selectedDate || !activeCalendar) return;
+    if (!selectedDate || !selectedTime || !activeCalendar) return;
 
     if (userRole === "MENTEE") {
       setMentors(prev => prev.map(mentor => {
@@ -128,164 +131,243 @@ export default function OneOnOneListPage() {
           return {
             ...mentor,
             status: "예약됨",
-            lastMentoring: `2026. 05. ${String(selectedDate).padStart(2, '0')}`
+            bookedDate: selectedDate,
+            bookedTime: selectedTime,
+            lastMentoring: `2026. 05. ${String(selectedDate).padStart(2, '0')} (${selectedTime})`
           };
         }
         return mentor;
       }));
     }
-
-    alert(`${selectedDate}일로 예약이 완료되었습니다!`);
-    setActiveCalendar(null); 
+    setActiveCalendar(null);
   };
 
-  // 💡 3. 메시지 전송 로직
+  // 💡 예약 취소 핸들러
+  const handleCancelReservation = () => {
+    if (!activeCalendar) return;
+    if (!confirm("정말 예약을 취소하시겠습니까?")) return;
+
+    if (userRole === "MENTEE") {
+      setMentors(prev => prev.map(mentor => {
+        if (mentor.id === activeCalendar.id) {
+          return {
+            ...mentor,
+            status: "진행 완료",
+            bookedDate: null,
+            bookedTime: null,
+            lastMentoring: "2026. 04. 25" // 임시 과거 날짜 복구
+          };
+        }
+        return mentor;
+      }));
+    }
+    setActiveCalendar(null);
+  };
+
   const handleSendMessage = () => {
     if (!inputText.trim() || !activeMessage) return;
-
     const newMessage: Message = {
-      id: Date.now(),
-      sender: "me",
-      text: inputText,
-      time: new Date().toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit' }) // 예: 오후 3:45
+      id: Date.now(), sender: "me", text: inputText,
+      time: new Date().toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit' })
     };
-
-    // 현재 열려있는 모달창의 데이터 즉시 업데이트
-    const updatedPerson = { 
-      ...activeMessage, 
-      messages: [...activeMessage.messages, newMessage] 
-    };
+    const updatedPerson = { ...activeMessage, messages: [...activeMessage.messages, newMessage] };
     setActiveMessage(updatedPerson);
-
-    // 전체 리스트(배열) 상태도 업데이트하여 껐다 켜도 유지되게 함
-    if (userRole === "MENTEE") {
-      setMentors(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
-    } else {
-      setMentees(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
-    }
-
-    setInputText(""); // 입력창 초기화
+    if (userRole === "MENTEE") setMentors(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
+    else setMentees(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
+    setInputText("");
   };
 
-  // 새로운 메시지가 추가될 때마다 스크롤을 맨 아래로 내리기
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [activeMessage?.messages]);
+  useEffect(() => { messagesEndRef.current?.scrollIntoView({ behavior: "smooth" }); }, [activeMessage?.messages]);
 
   return (
     <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] relative pb-[70px]">
       
-      <header className="sticky top-0 bg-white z-20">
-        <div className="flex items-center justify-between px-5 py-4">
-          {!isSearchOpen ? (
-            <>
-              <h1 className="text-[20px] font-extrabold tracking-tight">1:1 멘토링</h1>
-              <button onClick={() => setIsSearchOpen(true)} className="p-1 hover:bg-gray-100 rounded-full transition-colors">
-                <Search className="w-6 h-6" strokeWidth={2.5} />
-              </button>
-            </>
-          ) : (
-            <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth={2.5} />
-                <input 
-                  autoFocus
-                  type="text"
-                  placeholder="이름 또는 태그 검색"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none"
-                />
-              </div>
-              <button 
-                onClick={() => { setIsSearchOpen(false); setSearchQuery(""); }} 
-                className="text-[14px] font-bold text-gray-500 px-1"
-              >
-                취소
-              </button>
-            </div>
-          )}
-        </div>
+      <header className="sticky top-0 bg-white z-20 px-5 py-4 flex items-center justify-between">
+        {!isSearchOpen ? (
+          <>
+            <h1 className="text-[20px] font-extrabold tracking-tight">1:1 멘토링</h1>
+            <button onClick={() => setIsSearchOpen(true)} className="p-1 hover:bg-gray-100 rounded-full"><Search className="w-6 h-6" /></button>
+          </>
+        ) : (
+          <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
+            <input autoFocus type="text" placeholder="검색어 입력" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="flex-1 bg-gray-100 py-2.5 px-4 rounded-xl text-[14px] outline-none" />
+            <button onClick={() => { setIsSearchOpen(false); setSearchQuery(""); }} className="text-[14px] font-bold text-gray-500">취소</button>
+          </div>
+        )}
       </header>
 
-      <div className="px-5 mb-2">
-        <div className="flex bg-gray-100 p-1 rounded-xl">
-          <button 
-            onClick={() => { setUserRole("MENTEE"); setSearchQuery(""); }}
-            className={`flex-1 py-2 text-[14px] font-bold rounded-lg transition-all ${userRole === "MENTEE" ? "bg-white text-[#1A1A1A] shadow-sm" : "text-gray-500"}`}
-          >
-            나의 멘토
-          </button>
-          <button 
-            onClick={() => { setUserRole("MENTOR"); setSearchQuery(""); }}
-            className={`flex-1 py-2 text-[14px] font-bold rounded-lg transition-all ${userRole === "MENTOR" ? "bg-white text-[#1A1A1A] shadow-sm" : "text-gray-500"}`}
-          >
-            나의 멘티
-          </button>
-        </div>
+      <div className="px-5 mb-2 flex bg-gray-100 p-1 rounded-xl mx-5">
+        <button onClick={() => setUserRole("MENTEE")} className={`flex-1 py-2 text-[14px] font-bold rounded-lg ${userRole === "MENTEE" ? "bg-white shadow-sm" : "text-gray-500"}`}>나의 멘토</button>
+        <button onClick={() => setUserRole("MENTOR")} className={`flex-1 py-2 text-[14px] font-bold rounded-lg ${userRole === "MENTOR" ? "bg-white shadow-sm" : "text-gray-500"}`}>나의 멘티</button>
       </div>
 
       <div className="flex flex-col px-5 py-4 gap-4">
-        {displayList.length > 0 ? (
-          displayList.map((person) => (
-            <div key={person.id} className="flex flex-col bg-white border border-gray-100 rounded-2xl p-4 shadow-sm">
-              <div className="flex items-center justify-between mb-4">
-                <div className="flex items-center gap-3">
-                  <div className={`w-12 h-12 rounded-full ${person.profileColor} border border-gray-100 shrink-0`} />
-                  <div>
-                    <h3 className="text-[16px] font-bold text-[#1A1A1A]">{person.name}</h3>
-                    <p className="text-[13px] text-gray-500 font-medium">{person.role}</p>
-                  </div>
-                </div>
-                <span className={`text-[12px] font-bold px-2.5 py-1 rounded-full ${person.status === "예약됨" ? "bg-[#FFCC00]/20 text-yellow-700" : "bg-gray-100 text-gray-600"}`}>
-                  {person.status}
-                </span>
-              </div>
-
-              <div className="flex flex-col gap-2 mb-4 bg-gray-50 p-3 rounded-xl">
-                <div className="flex items-center gap-2">
-                  <span className="text-[12px] font-bold text-gray-500 w-14 shrink-0">멘토링 주제</span>
-                  <div className="flex gap-1.5 flex-wrap">
-                    {person.tags.map((tag, idx) => (
-                      <span key={idx} className="text-[12px] font-bold text-[#1A1A1A] bg-white px-1.5 py-0.5 rounded border border-gray-200">{tag}</span>
-                    ))}
-                  </div>
-                </div>
-                <div className="flex items-center gap-2">
-                  <span className="text-[12px] font-bold text-gray-500 w-14 shrink-0">
-                    {person.status === "예약됨" ? "예약 일정" : "최근 진행"}
-                  </span>
-                  <span className="text-[13px] font-medium text-[#1A1A1A]">{person.lastMentoring}</span>
+        {displayList.map((person) => (
+          <div key={person.id} className="bg-white border border-gray-100 rounded-2xl p-4 shadow-sm">
+            <div className="flex items-center justify-between mb-4">
+              <div className="flex items-center gap-3">
+                <div className={`w-12 h-12 rounded-full ${person.profileColor}`} />
+                <div>
+                  <h3 className="text-[16px] font-bold">{person.name}</h3>
+                  <p className="text-[13px] text-gray-500">{person.role}</p>
                 </div>
               </div>
-
-              <div className="flex items-center gap-2">
-                <button 
-                  onClick={() => setActiveMessage(person)}
-                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-gray-100 hover:bg-gray-200 rounded-xl text-[#1A1A1A] text-[14px] font-bold transition-colors"
-                >
-                  <MessageSquare className="w-4 h-4" /> 메시지
-                </button>
-                <button 
-                  onClick={() => {
-                    setActiveCalendar(person);
-                    setSelectedDate(null);
-                  }}
-                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-[#1A1A1A] hover:bg-black rounded-xl text-white text-[14px] font-bold transition-colors"
-                >
-                  <CalendarIcon className="w-4 h-4" /> {userRole === "MENTEE" ? "다시 예약" : "일정 관리"}
-                </button>
-              </div>
+              <span className={`text-[12px] font-bold px-2.5 py-1 rounded-full ${person.status === "예약됨" ? "bg-[#FFCC00]/20 text-yellow-700" : "bg-gray-100 text-gray-600"}`}>{person.status}</span>
             </div>
-          ))
-        ) : (
-          <div className="flex-1 flex flex-col items-center justify-center py-20">
-            <p className="text-gray-400 font-bold text-[15px]">검색 결과가 없습니다.</p>
+            <div className="bg-gray-50 p-3 rounded-xl mb-4 text-[13px]">
+              <div className="flex gap-2 mb-1"><span className="font-bold text-gray-500 w-14">주제</span><span>{person.tags.join(", ")}</span></div>
+              <div className="flex gap-2"><span className="font-bold text-gray-500 w-14">일정</span><span className="font-bold">{person.lastMentoring}</span></div>
+            </div>
+            <div className="flex gap-2">
+              <button onClick={() => setActiveMessage(person)} className="flex-1 py-2.5 bg-gray-100 rounded-xl font-bold text-[14px]">메시지</button>
+              <button onClick={() => { setActiveCalendar(person); setSelectedDate(person.bookedDate || null); setSelectedTime(person.bookedTime || null); }} className="flex-1 py-2.5 bg-[#1A1A1A] text-white rounded-xl font-bold text-[14px]">{userRole === "MENTEE" ? "다시 예약" : "일정 관리"}</button>
+            </div>
           </div>
-        )}
+        ))}
       </div>
 
-      {/* 💡 업데이트된 메시지 모달창 */}
+      {/* 💡 수정된 달력 및 시간 선택 모달창 */}
+      {activeCalendar && (
+        <div 
+          className="fixed inset-0 z-[999] bg-black/60 flex items-end justify-center sm:items-center max-w-md mx-auto animate-in fade-in duration-200"
+          onClick={() => setActiveCalendar(null)} // 💡 1. 어두운 배경을 클릭해도 모달이 닫히도록 추가
+        >
+          <div 
+            className="bg-white w-full sm:w-[90%] sm:rounded-3xl rounded-t-3xl p-6 pb-safe animate-in slide-in-from-bottom-10 duration-300 relative"
+            onClick={(e) => e.stopPropagation()} // 💡 2. 모달 하얀색 '내부'를 클릭했을 땐 창이 닫히지 않고 정상 작동하도록 이벤트 보호
+          >
+            
+            <div className="flex justify-between items-center mb-6">
+              <div>
+                <h2 className="text-[18px] font-extrabold">
+                  {userRole === "MENTEE" ? "멘토링 예약하기" : "멘티 일정 확인"}
+                </h2>
+                <p className="text-[13px] text-gray-500 font-medium mt-1">대상: {activeCalendar.name}</p>
+              </div>
+              {/* 💡 3. type="button"을 명시하여 브라우저 기본 동작 충돌 방지 */}
+              <button 
+                type="button" 
+                onClick={() => setActiveCalendar(null)} 
+                className="p-2 bg-gray-50 rounded-full hover:bg-gray-200 transition-colors z-10 relative"
+              >
+                <X className="w-5 h-5" />
+              </button>
+            </div>
+
+            <div className="flex items-center justify-between mb-4 px-2">
+              <button type="button" className="p-1"><ChevronLeft className="w-5 h-5 text-gray-400" /></button>
+              <span className="font-bold text-[16px]">2026년 5월</span>
+              <button type="button" className="p-1"><ChevronRight className="w-5 h-5 text-gray-400" /></button>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 mb-2 text-center text-[12px] font-bold text-gray-400">
+              <div className="text-red-400">일</div><div>월</div><div>화</div><div>수</div><div>목</div><div>금</div><div className="text-blue-400">토</div>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 text-center">
+              {emptyDays.map((_, i) => <div key={`empty-${i}`} className="p-2" />)}
+              
+              {daysInMonth.map(day => {
+                const isMentee = userRole === "MENTEE";
+                const isAvailable = isMentee && activeCalendar.availableSlots?.[day];
+                const isBooked = !isMentee && activeCalendar.bookedDate === day;
+                const isSelected = selectedDate === day;
+
+                // 💡 CSS 충돌(노란 바탕 + 노란 글씨) 방지를 위해 조건별로 클래스를 명확히 분리합니다.
+                let buttonClass = "relative p-2.5 text-[14px] font-medium rounded-full transition-all ";
+                
+                if (isSelected || isBooked) {
+                  // 예약된 날짜이거나 현재 선택된 날짜 (노란 바탕 + 진한 검정 글씨)
+                  buttonClass += "bg-[#FFCC00] text-[#1A1A1A] font-extrabold shadow-md transform scale-110";
+                } else if (isAvailable) {
+                  // 예약 가능한 빈 날짜
+                  buttonClass += "bg-gray-50 text-[#1A1A1A] border border-gray-200 hover:border-[#FFCC00]";
+                } else {
+                  // 선택 불가능한 날짜 (회색 글씨)
+                  buttonClass += "text-gray-300";
+                }
+
+                return (
+                  <button 
+                    key={day}
+                    type="button"
+                    disabled={isMentee && !isAvailable}
+                    onClick={() => isMentee && isAvailable && setSelectedDate(day)}
+                    className={buttonClass}
+                  >
+                    {day}
+                  </button>
+                );
+              })}
+            </div>
+
+            {/* 시간 선택 영역 */}
+            {selectedDate && (activeCalendar.availableSlots?.[selectedDate] || activeCalendar.bookedDate === selectedDate) && (
+              <div className="mb-8 animate-in fade-in slide-in-from-top-2 mt-4">
+                <div className="flex items-center gap-1.5 mb-3 text-gray-500">
+                  <Clock className="w-4 h-4" />
+                  <span className="text-[13px] font-bold">시간 선택</span>
+                </div>
+                <div className="flex flex-wrap gap-2">
+                  {(activeCalendar.availableSlots?.[selectedDate] || (activeCalendar.bookedTime ? [activeCalendar.bookedTime] : [])).map(time => (
+                    <button 
+                      key={time}
+                      type="button"
+                      onClick={() => userRole === "MENTEE" && setSelectedTime(time as string)}
+                      className={`px-4 py-2 rounded-lg text-[13px] font-bold border transition-all 
+                        ${selectedTime === time ? "bg-[#FFCC00] border-[#FFCC00]" : "bg-white border-gray-200 text-gray-500 hover:bg-gray-50"}`}
+                    >
+                      {time}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {/* 하단 액션 버튼 */}
+            <div className="flex flex-col gap-2 mt-6">
+              {userRole === "MENTEE" && activeCalendar.status === "예약됨" && (
+                <button 
+                  type="button"
+                  onClick={handleCancelReservation} 
+                  className="w-full py-3 text-red-500 font-bold text-[14px] border border-red-100 rounded-xl mb-2 hover:bg-red-50 transition-colors"
+                >
+                  예약 취소하기
+                </button>
+              )}
+              {userRole === "MENTEE" ? (
+                <button 
+                  type="button"
+                  disabled={!selectedTime}
+                  className={`w-full py-4 rounded-xl font-bold text-[16px] transition-colors ${selectedTime ? 'bg-[#1A1A1A] text-white active:bg-black' : 'bg-gray-100 text-gray-400'}`}
+                  onClick={handleConfirmReservation}
+                >
+                  {selectedTime ? `${selectedDate}일 ${selectedTime} 예약 확정` : '날짜와 시간을 선택해주세요'}
+                </button>
+              ) : (
+                <button 
+                  type="button"
+                  onClick={() => setActiveCalendar(null)} 
+                  className="w-full py-4 bg-[#1A1A1A] text-white rounded-xl font-bold hover:bg-black transition-colors"
+                >
+                  확인
+                </button>
+              )}
+            </div>
+
+          </div>
+        </div>
+      )}
+      
+      {/* 🟢 달력 모달창 (이 부분은 파일에 있는 그대로 두시면 됩니다!) */}
+      {activeCalendar && (
+        <div className="fixed inset-0 z-[100] ...">
+          {/* ... 달력 내용들 ... */}
+        </div>
+      )}
+      
+      {/* 🟢 여기서부터 아래 코드를 </main> 바로 위에 추가해 주세요! */}
+      {/* 메시지 모달창 */}
       {activeMessage && (
         <div className="fixed inset-0 z-[100] flex flex-col bg-gray-100 max-w-md mx-auto animate-in slide-in-from-bottom-full duration-300">
           <div className="bg-white px-4 py-3 flex items-center justify-between border-b shadow-sm">
@@ -301,7 +383,6 @@ export default function OneOnOneListPage() {
           <div className="flex-1 p-5 overflow-y-auto flex flex-col gap-4">
             <div className="text-center text-xs text-gray-400 my-2">2026년 4월 20일</div>
             
-            {/* 메시지 리스트 렌더링 */}
             {activeMessage.messages.length > 0 ? (
               activeMessage.messages.map((msg) => (
                 <div key={msg.id} className={`flex flex-col w-3/4 ${msg.sender === "me" ? "self-end items-end" : "self-start items-start"}`}>
@@ -320,7 +401,6 @@ export default function OneOnOneListPage() {
                 아직 나눈 대화가 없습니다. <br/>인사를 건네보세요!
               </div>
             )}
-            {/* 스크롤 하단 자동 이동을 위한 투명 요소 */}
             <div ref={messagesEndRef} />
           </div>
 
@@ -330,7 +410,7 @@ export default function OneOnOneListPage() {
               placeholder="메시지 보내기..." 
               value={inputText}
               onChange={(e) => setInputText(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()} // 엔터키로도 전송
+              onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()}
               className="flex-1 bg-gray-100 rounded-full px-4 py-2.5 text-[14px] focus:outline-none focus:ring-2 focus:ring-[#FFCC00]/50" 
             />
             <button 
@@ -339,87 +419,6 @@ export default function OneOnOneListPage() {
             >
               <Send className="w-4 h-4 ml-0.5" />
             </button>
-          </div>
-        </div>
-      )}
-
-      {/* 달력 모달창 (기존과 동일) */}
-      {activeCalendar && (
-        <div className="fixed inset-0 z-[100] bg-black/60 flex items-end justify-center sm:items-center max-w-md mx-auto animate-in fade-in duration-200">
-          <div className="bg-white w-full sm:w-[90%] sm:rounded-3xl rounded-t-3xl p-6 pb-safe animate-in slide-in-from-bottom-10 duration-300">
-            
-            <div className="flex justify-between items-center mb-6">
-              <div>
-                <h2 className="text-[18px] font-extrabold">
-                  {userRole === "MENTEE" ? "멘토링 예약하기" : "멘티 일정 확인"}
-                </h2>
-                <p className="text-[13px] text-gray-500 font-medium mt-1">대상: {activeCalendar.name}</p>
-              </div>
-              <button onClick={() => setActiveCalendar(null)} className="p-2 bg-gray-50 rounded-full"><X className="w-5 h-5" /></button>
-            </div>
-
-            <div className="flex items-center justify-between mb-4 px-2">
-              <button className="p-1"><ChevronLeft className="w-5 h-5 text-gray-400" /></button>
-              <span className="font-bold text-[16px]">2026년 5월</span>
-              <button className="p-1"><ChevronRight className="w-5 h-5 text-gray-400" /></button>
-            </div>
-
-            <div className="grid grid-cols-7 gap-1 mb-2 text-center text-[12px] font-bold text-gray-400">
-              <div className="text-red-400">일</div><div>월</div><div>화</div><div>수</div><div>목</div><div>금</div><div className="text-blue-400">토</div>
-            </div>
-
-            <div className="grid grid-cols-7 gap-1 text-center">
-              {emptyDays.map((_, i) => <div key={`empty-${i}`} className="p-2" />)}
-              
-              {daysInMonth.map(day => {
-                const isMentee = userRole === "MENTEE";
-                const isAvailable = isMentee && activeCalendar.availableDates?.includes(day);
-                const isBooked = !isMentee && activeCalendar.bookedDate === day;
-                const isSelected = selectedDate === day;
-
-                return (
-                  <button 
-                    key={day}
-                    disabled={isMentee && !isAvailable}
-                    onClick={() => isMentee && isAvailable && setSelectedDate(day)}
-                    className={`
-                      relative p-2.5 text-[14px] font-medium rounded-full transition-all
-                      ${isBooked ? 'bg-[#1A1A1A] text-[#FFCC00] font-extrabold shadow-md' : ''} 
-                      ${isSelected ? 'bg-[#FFCC00] text-[#1A1A1A] font-extrabold shadow-md transform scale-110' : ''}
-                      ${isAvailable && !isSelected ? 'bg-gray-50 text-[#1A1A1A] border border-gray-200 hover:border-[#FFCC00]' : ''}
-                      ${!isAvailable && !isBooked && !isSelected ? 'text-gray-300' : ''}
-                    `}
-                  >
-                    {day}
-                  </button>
-                );
-              })}
-            </div>
-
-            <div className="mt-6">
-              {userRole === "MENTEE" ? (
-                <>
-                  <div className="flex items-center gap-2 text-[12px] font-medium text-gray-500 mb-4 justify-center">
-                    <div className="w-3 h-3 bg-gray-50 border border-gray-200 rounded-full" /> 예약 가능
-                    <div className="w-3 h-3 bg-[#FFCC00] rounded-full ml-2" /> 선택됨
-                  </div>
-                  <button 
-                    disabled={!selectedDate}
-                    className={`w-full py-4 rounded-xl font-bold text-[16px] transition-colors ${selectedDate ? 'bg-[#1A1A1A] text-white active:bg-black' : 'bg-gray-100 text-gray-400'}`}
-                    onClick={handleConfirmReservation}
-                  >
-                    {selectedDate ? `${selectedDate}일 예약 확정하기` : '날짜를 선택해주세요'}
-                  </button>
-                </>
-              ) : (
-                <>
-                  <div className="flex items-center gap-2 text-[12px] font-medium text-gray-500 justify-center">
-                    <div className="w-3 h-3 bg-[#1A1A1A] rounded-full" /> 멘티가 예약한 날짜
-                  </div>
-                </>
-              )}
-            </div>
-
           </div>
         </div>
       )}

--- a/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
@@ -1,0 +1,429 @@
+"use client";
+
+import { useState, useMemo, useRef, useEffect } from "react";
+import { Search, MessageSquare, Calendar as CalendarIcon, X, Send, ChevronLeft, ChevronRight } from "lucide-react";
+
+// 💡 1. 메시지 타입을 정의하고 MentoringPerson에 추가합니다.
+type Message = {
+  id: number;
+  sender: "me" | "other";
+  text: string;
+  time: string;
+};
+
+type MentoringPerson = {
+  id: number;
+  name: string;
+  role: string;
+  lastMentoring: string;
+  status: string;
+  profileColor: string;
+  tags: string[];
+  availableDates?: number[];
+  bookedDate?: number | null;
+  messages: Message[]; // 모든 사람에게 메시지 배열 추가
+};
+
+const INITIAL_MENTORS: MentoringPerson[] = [
+  {
+    id: 1,
+    name: "AI네이티브개발자",
+    role: "백엔드 개발자 · 2년차",
+    lastMentoring: "2026. 04. 25",
+    status: "진행 완료",
+    profileColor: "bg-blue-500",
+    tags: ["포트폴리오", "기술면접"],
+    availableDates: [12, 15, 18, 25],
+    messages: [
+      { id: 1, sender: "me", text: "안녕하세요! 멘토링 관련해서 궁금한 점이 있습니다.", time: "오후 2:30" },
+      { id: 2, sender: "other", text: "네, 편하게 말씀해 주세요! 😊", time: "오후 2:32" }
+    ],
+  },
+  {
+    id: 2,
+    name: "프론트엔드장인",
+    role: "프론트엔드 개발자 · 5년차",
+    lastMentoring: "2026. 04. 30",
+    status: "예약됨",
+    profileColor: "bg-emerald-500",
+    tags: ["React", "성능최적화"],
+    availableDates: [10, 11, 20, 22],
+    messages: [],
+  }
+];
+
+const INITIAL_MENTEES: MentoringPerson[] = [
+  {
+    id: 101,
+    name: "열혈취준생",
+    role: "백엔드 지망생",
+    lastMentoring: "2026. 04. 20",
+    status: "진행 완료",
+    profileColor: "bg-orange-400",
+    tags: ["이력서 첨삭", "CS 기초"],
+    bookedDate: null, 
+    messages: [],
+  },
+  {
+    id: 102,
+    name: "코딩하는토끼",
+    role: "주니어 개발자 · 1년차",
+    lastMentoring: "2026. 04. 18",
+    status: "진행 완료",
+    profileColor: "bg-purple-400",
+    tags: ["코드 리뷰", "아키텍처"],
+    bookedDate: null,
+    messages: [],
+  },
+  {
+    id: 103,
+    name: "방황하는감자",
+    role: "전공생 · 3학년",
+    lastMentoring: "2026. 05. 02",
+    status: "예약됨",
+    profileColor: "bg-pink-400",
+    tags: ["진로 상담"],
+    bookedDate: 15,
+    messages: [],
+  }
+];
+
+export default function OneOnOneListPage() {
+  const [mentors, setMentors] = useState<MentoringPerson[]>(INITIAL_MENTORS);
+  const [mentees, setMentees] = useState<MentoringPerson[]>(INITIAL_MENTEES);
+
+  const [userRole, setUserRole] = useState<"MENTEE" | "MENTOR">("MENTEE");
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  
+  const [activeMessage, setActiveMessage] = useState<MentoringPerson | null>(null);
+  const [activeCalendar, setActiveCalendar] = useState<MentoringPerson | null>(null);
+  const [selectedDate, setSelectedDate] = useState<number | null>(null);
+
+  // 💡 2. 채팅 입력창 상태 추가
+  const [inputText, setInputText] = useState("");
+  const messagesEndRef = useRef<HTMLDivElement>(null); // 자동 스크롤을 위한 참조
+
+  const displayList = useMemo(() => {
+    let list = userRole === "MENTEE" ? mentors : mentees;
+    if (searchQuery.trim() !== "") {
+      const q = searchQuery.toLowerCase();
+      list = list.filter(person => 
+        person.name.toLowerCase().includes(q) || 
+        person.tags.some(tag => tag.toLowerCase().includes(q))
+      );
+    }
+    return list;
+  }, [userRole, searchQuery, mentors, mentees]);
+
+  const emptyDays = Array.from({ length: 5 });
+  const daysInMonth = Array.from({ length: 31 }, (_, i) => i + 1);
+
+  const handleConfirmReservation = () => {
+    if (!selectedDate || !activeCalendar) return;
+
+    if (userRole === "MENTEE") {
+      setMentors(prev => prev.map(mentor => {
+        if (mentor.id === activeCalendar.id) {
+          return {
+            ...mentor,
+            status: "예약됨",
+            lastMentoring: `2026. 05. ${String(selectedDate).padStart(2, '0')}`
+          };
+        }
+        return mentor;
+      }));
+    }
+
+    alert(`${selectedDate}일로 예약이 완료되었습니다!`);
+    setActiveCalendar(null); 
+  };
+
+  // 💡 3. 메시지 전송 로직
+  const handleSendMessage = () => {
+    if (!inputText.trim() || !activeMessage) return;
+
+    const newMessage: Message = {
+      id: Date.now(),
+      sender: "me",
+      text: inputText,
+      time: new Date().toLocaleTimeString('ko-KR', { hour: 'numeric', minute: '2-digit' }) // 예: 오후 3:45
+    };
+
+    // 현재 열려있는 모달창의 데이터 즉시 업데이트
+    const updatedPerson = { 
+      ...activeMessage, 
+      messages: [...activeMessage.messages, newMessage] 
+    };
+    setActiveMessage(updatedPerson);
+
+    // 전체 리스트(배열) 상태도 업데이트하여 껐다 켜도 유지되게 함
+    if (userRole === "MENTEE") {
+      setMentors(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
+    } else {
+      setMentees(prev => prev.map(m => m.id === updatedPerson.id ? updatedPerson : m));
+    }
+
+    setInputText(""); // 입력창 초기화
+  };
+
+  // 새로운 메시지가 추가될 때마다 스크롤을 맨 아래로 내리기
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [activeMessage?.messages]);
+
+  return (
+    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] relative pb-[70px]">
+      
+      <header className="sticky top-0 bg-white z-20">
+        <div className="flex items-center justify-between px-5 py-4">
+          {!isSearchOpen ? (
+            <>
+              <h1 className="text-[20px] font-extrabold tracking-tight">1:1 멘토링</h1>
+              <button onClick={() => setIsSearchOpen(true)} className="p-1 hover:bg-gray-100 rounded-full transition-colors">
+                <Search className="w-6 h-6" strokeWidth={2.5} />
+              </button>
+            </>
+          ) : (
+            <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth={2.5} />
+                <input 
+                  autoFocus
+                  type="text"
+                  placeholder="이름 또는 태그 검색"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none"
+                />
+              </div>
+              <button 
+                onClick={() => { setIsSearchOpen(false); setSearchQuery(""); }} 
+                className="text-[14px] font-bold text-gray-500 px-1"
+              >
+                취소
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className="px-5 mb-2">
+        <div className="flex bg-gray-100 p-1 rounded-xl">
+          <button 
+            onClick={() => { setUserRole("MENTEE"); setSearchQuery(""); }}
+            className={`flex-1 py-2 text-[14px] font-bold rounded-lg transition-all ${userRole === "MENTEE" ? "bg-white text-[#1A1A1A] shadow-sm" : "text-gray-500"}`}
+          >
+            나의 멘토
+          </button>
+          <button 
+            onClick={() => { setUserRole("MENTOR"); setSearchQuery(""); }}
+            className={`flex-1 py-2 text-[14px] font-bold rounded-lg transition-all ${userRole === "MENTOR" ? "bg-white text-[#1A1A1A] shadow-sm" : "text-gray-500"}`}
+          >
+            나의 멘티
+          </button>
+        </div>
+      </div>
+
+      <div className="flex flex-col px-5 py-4 gap-4">
+        {displayList.length > 0 ? (
+          displayList.map((person) => (
+            <div key={person.id} className="flex flex-col bg-white border border-gray-100 rounded-2xl p-4 shadow-sm">
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-3">
+                  <div className={`w-12 h-12 rounded-full ${person.profileColor} border border-gray-100 shrink-0`} />
+                  <div>
+                    <h3 className="text-[16px] font-bold text-[#1A1A1A]">{person.name}</h3>
+                    <p className="text-[13px] text-gray-500 font-medium">{person.role}</p>
+                  </div>
+                </div>
+                <span className={`text-[12px] font-bold px-2.5 py-1 rounded-full ${person.status === "예약됨" ? "bg-[#FFCC00]/20 text-yellow-700" : "bg-gray-100 text-gray-600"}`}>
+                  {person.status}
+                </span>
+              </div>
+
+              <div className="flex flex-col gap-2 mb-4 bg-gray-50 p-3 rounded-xl">
+                <div className="flex items-center gap-2">
+                  <span className="text-[12px] font-bold text-gray-500 w-14 shrink-0">멘토링 주제</span>
+                  <div className="flex gap-1.5 flex-wrap">
+                    {person.tags.map((tag, idx) => (
+                      <span key={idx} className="text-[12px] font-bold text-[#1A1A1A] bg-white px-1.5 py-0.5 rounded border border-gray-200">{tag}</span>
+                    ))}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-[12px] font-bold text-gray-500 w-14 shrink-0">
+                    {person.status === "예약됨" ? "예약 일정" : "최근 진행"}
+                  </span>
+                  <span className="text-[13px] font-medium text-[#1A1A1A]">{person.lastMentoring}</span>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                <button 
+                  onClick={() => setActiveMessage(person)}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-gray-100 hover:bg-gray-200 rounded-xl text-[#1A1A1A] text-[14px] font-bold transition-colors"
+                >
+                  <MessageSquare className="w-4 h-4" /> 메시지
+                </button>
+                <button 
+                  onClick={() => {
+                    setActiveCalendar(person);
+                    setSelectedDate(null);
+                  }}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-2.5 bg-[#1A1A1A] hover:bg-black rounded-xl text-white text-[14px] font-bold transition-colors"
+                >
+                  <CalendarIcon className="w-4 h-4" /> {userRole === "MENTEE" ? "다시 예약" : "일정 관리"}
+                </button>
+              </div>
+            </div>
+          ))
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center py-20">
+            <p className="text-gray-400 font-bold text-[15px]">검색 결과가 없습니다.</p>
+          </div>
+        )}
+      </div>
+
+      {/* 💡 업데이트된 메시지 모달창 */}
+      {activeMessage && (
+        <div className="fixed inset-0 z-[100] flex flex-col bg-gray-100 max-w-md mx-auto animate-in slide-in-from-bottom-full duration-300">
+          <div className="bg-white px-4 py-3 flex items-center justify-between border-b shadow-sm">
+            <div className="flex items-center gap-2">
+              <div className={`w-8 h-8 rounded-full ${activeMessage.profileColor}`} />
+              <span className="font-bold text-[16px]">{activeMessage.name}</span>
+            </div>
+            <button onClick={() => setActiveMessage(null)} className="p-2 bg-gray-50 rounded-full hover:bg-gray-200 transition-colors">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+          
+          <div className="flex-1 p-5 overflow-y-auto flex flex-col gap-4">
+            <div className="text-center text-xs text-gray-400 my-2">2026년 4월 20일</div>
+            
+            {/* 메시지 리스트 렌더링 */}
+            {activeMessage.messages.length > 0 ? (
+              activeMessage.messages.map((msg) => (
+                <div key={msg.id} className={`flex flex-col w-3/4 ${msg.sender === "me" ? "self-end items-end" : "self-start items-start"}`}>
+                  <div className={`p-3 text-[14px] shadow-sm ${
+                    msg.sender === "me" 
+                      ? "bg-[#FFCC00] rounded-2xl rounded-tr-none text-[#1A1A1A]" 
+                      : "bg-white border border-gray-100 rounded-2xl rounded-tl-none text-[#1A1A1A]"
+                  }`}>
+                    {msg.text}
+                  </div>
+                  <span className="text-[10px] text-gray-400 mt-1 px-1">{msg.time}</span>
+                </div>
+              ))
+            ) : (
+              <div className="text-center text-[13px] text-gray-400 mt-10">
+                아직 나눈 대화가 없습니다. <br/>인사를 건네보세요!
+              </div>
+            )}
+            {/* 스크롤 하단 자동 이동을 위한 투명 요소 */}
+            <div ref={messagesEndRef} />
+          </div>
+
+          <div className="bg-white p-3 border-t flex items-center gap-2 pb-safe">
+            <input 
+              type="text" 
+              placeholder="메시지 보내기..." 
+              value={inputText}
+              onChange={(e) => setInputText(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSendMessage()} // 엔터키로도 전송
+              className="flex-1 bg-gray-100 rounded-full px-4 py-2.5 text-[14px] focus:outline-none focus:ring-2 focus:ring-[#FFCC00]/50" 
+            />
+            <button 
+              onClick={handleSendMessage}
+              className="w-10 h-10 bg-[#1A1A1A] rounded-full flex items-center justify-center text-[#FFCC00] shrink-0 hover:bg-black transition-colors"
+            >
+              <Send className="w-4 h-4 ml-0.5" />
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* 달력 모달창 (기존과 동일) */}
+      {activeCalendar && (
+        <div className="fixed inset-0 z-[100] bg-black/60 flex items-end justify-center sm:items-center max-w-md mx-auto animate-in fade-in duration-200">
+          <div className="bg-white w-full sm:w-[90%] sm:rounded-3xl rounded-t-3xl p-6 pb-safe animate-in slide-in-from-bottom-10 duration-300">
+            
+            <div className="flex justify-between items-center mb-6">
+              <div>
+                <h2 className="text-[18px] font-extrabold">
+                  {userRole === "MENTEE" ? "멘토링 예약하기" : "멘티 일정 확인"}
+                </h2>
+                <p className="text-[13px] text-gray-500 font-medium mt-1">대상: {activeCalendar.name}</p>
+              </div>
+              <button onClick={() => setActiveCalendar(null)} className="p-2 bg-gray-50 rounded-full"><X className="w-5 h-5" /></button>
+            </div>
+
+            <div className="flex items-center justify-between mb-4 px-2">
+              <button className="p-1"><ChevronLeft className="w-5 h-5 text-gray-400" /></button>
+              <span className="font-bold text-[16px]">2026년 5월</span>
+              <button className="p-1"><ChevronRight className="w-5 h-5 text-gray-400" /></button>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 mb-2 text-center text-[12px] font-bold text-gray-400">
+              <div className="text-red-400">일</div><div>월</div><div>화</div><div>수</div><div>목</div><div>금</div><div className="text-blue-400">토</div>
+            </div>
+
+            <div className="grid grid-cols-7 gap-1 text-center">
+              {emptyDays.map((_, i) => <div key={`empty-${i}`} className="p-2" />)}
+              
+              {daysInMonth.map(day => {
+                const isMentee = userRole === "MENTEE";
+                const isAvailable = isMentee && activeCalendar.availableDates?.includes(day);
+                const isBooked = !isMentee && activeCalendar.bookedDate === day;
+                const isSelected = selectedDate === day;
+
+                return (
+                  <button 
+                    key={day}
+                    disabled={isMentee && !isAvailable}
+                    onClick={() => isMentee && isAvailable && setSelectedDate(day)}
+                    className={`
+                      relative p-2.5 text-[14px] font-medium rounded-full transition-all
+                      ${isBooked ? 'bg-[#1A1A1A] text-[#FFCC00] font-extrabold shadow-md' : ''} 
+                      ${isSelected ? 'bg-[#FFCC00] text-[#1A1A1A] font-extrabold shadow-md transform scale-110' : ''}
+                      ${isAvailable && !isSelected ? 'bg-gray-50 text-[#1A1A1A] border border-gray-200 hover:border-[#FFCC00]' : ''}
+                      ${!isAvailable && !isBooked && !isSelected ? 'text-gray-300' : ''}
+                    `}
+                  >
+                    {day}
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-6">
+              {userRole === "MENTEE" ? (
+                <>
+                  <div className="flex items-center gap-2 text-[12px] font-medium text-gray-500 mb-4 justify-center">
+                    <div className="w-3 h-3 bg-gray-50 border border-gray-200 rounded-full" /> 예약 가능
+                    <div className="w-3 h-3 bg-[#FFCC00] rounded-full ml-2" /> 선택됨
+                  </div>
+                  <button 
+                    disabled={!selectedDate}
+                    className={`w-full py-4 rounded-xl font-bold text-[16px] transition-colors ${selectedDate ? 'bg-[#1A1A1A] text-white active:bg-black' : 'bg-gray-100 text-gray-400'}`}
+                    onClick={handleConfirmReservation}
+                  >
+                    {selectedDate ? `${selectedDate}일 예약 확정하기` : '날짜를 선택해주세요'}
+                  </button>
+                </>
+              ) : (
+                <>
+                  <div className="flex items-center gap-2 text-[12px] font-medium text-gray-500 justify-center">
+                    <div className="w-3 h-3 bg-[#1A1A1A] rounded-full" /> 멘티가 예약한 날짜
+                  </div>
+                </>
+              )}
+            </div>
+
+          </div>
+        </div>
+      )}
+
+    </main>
+  );
+}

--- a/apps/demo-web/app/(with-nav)/mentoring_list/live_list/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/live_list/[id]/page.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export default function DummyLiveDetailPage({ params }: { params: { id: string } }) {
+  const router = useRouter();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-[100dvh] bg-white">
+      <h1 className="text-2xl font-bold mb-4">{params.id}번 라이브 방송</h1>
+      <p className="text-gray-500 mb-8">현재 상세 페이지 개발 중입니다 🛠️</p>
+      
+      <button 
+        onClick={() => router.back()}
+        className="px-6 py-3 bg-[#FFCC00] text-[#1A1A1A] font-bold rounded-xl"
+      >
+        뒤로 가기 테스트
+      </button>
+    </div>
+  );
+}

--- a/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
@@ -1,56 +1,16 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, Suspense, useEffect } from "react";
 import Link from "next/link";
+import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { Search, ChevronDown, Users, Radio, Check, AlertCircle } from "lucide-react";
 
-// 💡 핵심 수정: Date.now() 같은 동적 함수를 제거하고, 고정된 시간 문자열을 사용하여 
-// Next.js의 Hydration(렌더링 동기화) 에러와 클릭 이벤트 먹통 현상을 완벽하게 방지했습니다.
+// 데이터 부분 (이전과 동일)
 const LIVE_STREAMS = [
-  {
-    id: 101,
-    title: "신입 백엔드 포트폴리오 실시간 리뷰 & QnA",
-    mentor: "AI네이티브개발자",
-    category: "개발",
-    viewers: 128,
-    startTime: "2026-04-28T10:30:00Z", // 고정된 시간
-    tags: ["백엔드", "포트폴리오", "취업"],
-    thumbnailColor: "bg-blue-900",
-    profileColor: "bg-blue-500",
-  },
-  {
-    id: 102,
-    title: "실무에서 쓰이는 React 패턴 (주니어용)",
-    mentor: "프론트엔드장인",
-    category: "개발",
-    viewers: 85,
-    startTime: "2026-04-28T11:50:00Z", 
-    tags: ["프론트엔드", "React", "실무"],
-    thumbnailColor: "bg-emerald-900",
-    profileColor: "bg-emerald-500",
-  },
-  {
-    id: 103,
-    title: "Unreal Engine 5 구조 설계 노하우 방송",
-    mentor: "게임개발자K",
-    category: "개발",
-    viewers: 210,
-    startTime: "2026-04-28T09:00:00Z",
-    tags: ["게임개발", "언리얼"],
-    thumbnailColor: "bg-purple-900",
-    profileColor: "bg-purple-500",
-  },
-  {
-    id: 104,
-    title: "주니어 기획자를 위한 역량 강화 가이드",
-    mentor: "기획왕",
-    category: "기획/PM",
-    viewers: 45,
-    startTime: "2026-04-28T11:15:00Z",
-    tags: ["기획", "PM", "커리어"],
-    thumbnailColor: "bg-orange-900",
-    profileColor: "bg-orange-500",
-  }
+  { id: 101, title: "신입 백엔드 포트폴리오 실시간 리뷰 & QnA", mentor: "AI네이티브개발자", category: "개발", viewers: 128, startTime: "2026-04-28T10:30:00Z", tags: ["백엔드", "포트폴리오", "취업"], thumbnailColor: "bg-blue-900", profileColor: "bg-blue-500" },
+  { id: 102, title: "실무에서 쓰이는 React 패턴 (주니어용)", mentor: "프론트엔드장인", category: "개발", viewers: 85, startTime: "2026-04-28T11:50:00Z", tags: ["프론트엔드", "React", "실무"], thumbnailColor: "bg-emerald-900", profileColor: "bg-emerald-500" },
+  { id: 103, title: "Unreal Engine 5 구조 설계 노하우 방송", mentor: "게임개발자K", category: "개발", viewers: 210, startTime: "2026-04-28T09:00:00Z", tags: ["게임개발", "언리얼"], thumbnailColor: "bg-purple-900", profileColor: "bg-purple-500" },
+  { id: 104, title: "주니어 기획자를 위한 역량 강화 가이드", mentor: "기획왕", category: "기획/PM", viewers: 45, startTime: "2026-04-28T11:15:00Z", tags: ["기획", "PM", "커리어"], thumbnailColor: "bg-orange-900", profileColor: "bg-orange-500" }
 ];
 
 const CATEGORIES = ["전체", "개발", "기획/PM", "디자인", "마케팅"];
@@ -60,38 +20,57 @@ const SORT_OPTIONS = [
   { id: "oldest", label: "오래된 순" },
 ];
 
-export default function LiveListPage() {
-  const [sortBy, setSortBy] = useState("viewers");
-  const [activeCategory, setActiveCategory] = useState("전체");
+function LiveListContent() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  // 💡 [해결책 1] 하이드레이션 체크: 클라이언트 마운트 완료 확인
+  const [isMounted, setIsMounted] = useState(false);
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const activeCategory = searchParams.get("category") || "전체";
+  const sortBy = searchParams.get("sort") || "viewers";
+
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
 
+  const handleCategoryClick = (category: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (category === "전체") params.delete("category");
+    else params.set("category", category);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+  };
+
+  const handleSortClick = (sortId: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (sortId === "viewers") params.delete("sort");
+    else params.set("sort", sortId);
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    setIsSortMenuOpen(false);
+  };
+
   const filteredAndSortedStreams = useMemo(() => {
     let list = [...LIVE_STREAMS];
-
-    if (activeCategory !== "전체") {
-      list = list.filter(stream => stream.category === activeCategory);
-    }
-
+    if (activeCategory !== "전체") list = list.filter(s => s.category === activeCategory);
     if (searchQuery.trim() !== "") {
-      const query = searchQuery.toLowerCase();
-      list = list.filter(stream => 
-        stream.title.toLowerCase().includes(query) || 
-        stream.mentor.toLowerCase().includes(query)
-      );
+      const q = searchQuery.toLowerCase();
+      list = list.filter(s => s.title.toLowerCase().includes(q) || s.mentor.toLowerCase().includes(q));
     }
-
     if (sortBy === "viewers") list.sort((a, b) => b.viewers - a.viewers);
     else if (sortBy === "newest") list.sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
     else if (sortBy === "oldest") list.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
-
     return list;
   }, [activeCategory, searchQuery, sortBy]);
 
+  // 💡 마운트 전에는 레이아웃만 보여주고 클릭 이벤트가 포함된 UI는 마운트 후에 렌더링
+  if (!isMounted) return <div className="w-full h-screen bg-white" />;
+
   return (
-    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] relative">
-      
+    <div className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] relative">
       <header className={`sticky top-0 bg-white z-20 transition-all duration-300 ${isSearchOpen ? 'pb-2' : ''}`}>
         <div className="flex items-center justify-between px-5 py-4">
           {!isSearchOpen ? (
@@ -103,11 +82,7 @@ export default function LiveListPage() {
                   <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
                 </span>
               </h1>
-              <button 
-                type="button"
-                onClick={() => setIsSearchOpen(true)} 
-                className="p-1 hover:bg-gray-100 rounded-full transition-colors"
-              >
+              <button type="button" onClick={() => setIsSearchOpen(true)} className="p-1 hover:bg-gray-100 rounded-full transition-colors">
                 <Search className="w-6 h-6" strokeWidth={2.5} />
               </button>
             </>
@@ -115,25 +90,9 @@ export default function LiveListPage() {
             <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
               <div className="relative flex-1">
                 <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth={2.5} />
-                <input 
-                  autoFocus
-                  type="text"
-                  placeholder="멘토 또는 라이브 제목 검색"
-                  value={searchQuery}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none focus:ring-2 focus:ring-[#FFCC00]/50"
-                />
+                <input autoFocus type="text" placeholder="검색어 입력" value={searchQuery} onChange={(e) => setSearchQuery(e.target.value)} className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none" />
               </div>
-              <button 
-                type="button"
-                onClick={() => {
-                  setIsSearchOpen(false);
-                  setSearchQuery("");
-                }} 
-                className="text-[14px] font-bold text-gray-500 px-1"
-              >
-                취소
-              </button>
+              <button type="button" onClick={() => { setIsSearchOpen(false); setSearchQuery(""); }} className="text-[14px] font-bold text-gray-500 px-1">취소</button>
             </div>
           )}
         </div>
@@ -141,46 +100,22 @@ export default function LiveListPage() {
 
       <div className="flex gap-2 overflow-x-auto px-5 py-2 scrollbar-hide">
         {CATEGORIES.map((category) => (
-          <button
-            key={category}
-            type="button" // 💡 명시적으로 버튼 타입을 지정하여 폼 전송 등 오작동 방지
-            onClick={() => setActiveCategory(category)}
-            className={`shrink-0 px-4 py-2 rounded-full text-[14px] font-bold border transition-all
-              ${activeCategory === category 
-                ? 'bg-[#1A1A1A] text-white border-[#1A1A1A]' 
-                : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'
-              }
-            `}
-          >
+          <button key={category} type="button" onClick={() => handleCategoryClick(category)} className={`shrink-0 px-4 py-2 rounded-full text-[14px] font-bold border transition-all ${activeCategory === category ? 'bg-[#1A1A1A] text-white border-[#1A1A1A]' : 'bg-white text-gray-500 border-gray-200'}`}>
             {category}
           </button>
         ))}
       </div>
 
       <div className="px-5 py-4 flex items-center justify-between relative">
-        <button 
-          type="button"
-          onClick={() => setIsSortMenuOpen(!isSortMenuOpen)}
-          className="flex items-center gap-1 text-[13px] font-bold text-gray-600 bg-gray-50 px-3 py-1.5 rounded-lg active:bg-gray-100 transition-colors"
-        >
+        <button type="button" onClick={() => setIsSortMenuOpen(!isSortMenuOpen)} className="flex items-center gap-1 text-[13px] font-bold text-gray-600 bg-gray-50 px-3 py-1.5 rounded-lg">
           {SORT_OPTIONS.find(opt => opt.id === sortBy)?.label}
           <ChevronDown className={`w-4 h-4 transition-transform ${isSortMenuOpen ? 'rotate-180' : ''}`} />
         </button>
         
         {isSortMenuOpen && (
-          <div className="absolute top-14 left-5 w-[160px] bg-white border border-gray-100 rounded-2xl shadow-xl z-30 p-2 animate-in fade-in zoom-in-95 duration-150">
+          <div className="absolute top-14 left-5 w-[160px] bg-white border border-gray-100 rounded-2xl shadow-xl z-30 p-2">
             {SORT_OPTIONS.map((option) => (
-              <button
-                key={option.id}
-                type="button"
-                onClick={() => {
-                  setSortBy(option.id);
-                  setIsSortMenuOpen(false);
-                }}
-                className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-[13px] font-bold transition-colors
-                  ${sortBy === option.id ? 'bg-[#FFCC00]/10 text-[#1A1A1A]' : 'text-gray-500 hover:bg-gray-50'}
-                `}
-              >
+              <button key={option.id} type="button" onClick={() => handleSortClick(option.id)} className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-[13px] font-bold ${sortBy === option.id ? 'bg-[#FFCC00]/10 text-[#1A1A1A]' : 'text-gray-500 hover:bg-gray-50'}`}>
                 {option.label}
                 {sortBy === option.id && <Check className="w-4 h-4 text-[#FFCC00]" />}
               </button>
@@ -193,72 +128,48 @@ export default function LiveListPage() {
       <div className="flex flex-col px-5 gap-6 pb-10 flex-1">
         {filteredAndSortedStreams.length > 0 ? (
           filteredAndSortedStreams.map((stream) => (
-            <Link 
-              key={stream.id} 
-              href={`/mentoring_list/live_list/${stream.id}`} 
-              className="group flex flex-col gap-3"
-            >
-              <div className={`relative w-full aspect-video rounded-2xl ${stream.thumbnailColor} overflow-hidden shadow-sm`}>
-                <div className="absolute inset-0 flex items-center justify-center opacity-30">
-                  <Radio className="w-16 h-16 text-white" />
-                </div>
-                <div className="absolute top-3 left-3 bg-red-600 text-white text-[11px] font-extrabold px-2 py-1 rounded-[6px] flex items-center gap-1 tracking-wider">
+            <Link key={stream.id} href={`/mentoring_list/live_list/${stream.id}`} className="group flex flex-col gap-3">
+              <div className={`relative w-full aspect-video rounded-2xl ${stream.thumbnailColor} overflow-hidden`}>
+                <div className="absolute top-3 left-3 bg-red-600 text-white text-[11px] font-extrabold px-2 py-1 rounded-[6px] flex items-center gap-1">
                   <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse" /> LIVE
                 </div>
-                <div className="absolute bottom-3 right-3 bg-black/70 backdrop-blur-sm text-white text-[12px] font-bold px-2.5 py-1 rounded-[8px] flex items-center gap-1.5">
+                <div className="absolute bottom-3 right-3 bg-black/70 text-white text-[12px] font-bold px-2.5 py-1 rounded-[8px] flex items-center gap-1.5">
                   <Users className="w-3.5 h-3.5" /> {stream.viewers}명 시청 중
                 </div>
               </div>
-
               <div className="flex gap-3 px-1">
-                <div className={`w-10 h-10 rounded-full shrink-0 ${stream.profileColor} border border-gray-100 shadow-sm`} />
+                <div className={`w-10 h-10 rounded-full shrink-0 ${stream.profileColor}`} />
                 <div className="flex flex-col flex-1 min-w-0 pt-0.5">
-                  <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-tight mb-1 truncate group-hover:text-blue-600 transition-colors">
-                    {stream.title}
-                  </h3>
-                  <p className="text-[13px] font-medium text-gray-500 mb-2">
-                    {stream.mentor} · {stream.category}
-                  </p>
-                  <div className="flex flex-wrap gap-1.5">
-                    {stream.tags.map((tag, idx) => (
-                      <span key={idx} className="bg-[#F2F4F6] text-gray-600 text-[11px] font-bold px-2 py-0.5 rounded-[4px]">
-                        {tag}
-                      </span>
-                    ))}
-                  </div>
+                  <h3 className="text-[16px] font-bold text-[#1A1A1A] truncate">{stream.title}</h3>
+                  <p className="text-[13px] font-medium text-gray-500">{stream.mentor} · {stream.category}</p>
                 </div>
               </div>
             </Link>
           ))
         ) : (
-          <div className="flex-1 flex flex-col items-center justify-center py-20 animate-in fade-in duration-500">
-            <div className="bg-gray-50 p-6 rounded-full mb-4">
-              <AlertCircle className="w-10 h-10 text-gray-300" />
-            </div>
-            <p className="text-gray-400 font-bold text-[15px] mb-1">해당하는 라이브가 없습니다.</p>
-            <p className="text-gray-300 text-[13px]">다른 카테고리나 검색어를 이용해 보세요.</p>
-            {(activeCategory !== "전체" || searchQuery !== "") && (
-              <button 
-                type="button"
-                onClick={() => {
-                  setActiveCategory("전체");
-                  setSearchQuery("");
-                }}
-                className="mt-6 text-[#FFCC00] font-bold text-[14px] border-b border-[#FFCC00] pb-0.5"
-              >
-                필터 초기화
-              </button>
-            )}
+          <div className="flex-1 flex flex-col items-center justify-center py-20">
+            <AlertCircle className="w-10 h-10 text-gray-300 mb-4" />
+            <p className="text-gray-400 font-bold text-[15px]">해당하는 라이브가 없습니다.</p>
           </div>
         )}
       </div>
 
       {isSortMenuOpen && <div className="fixed inset-0 z-20" onClick={() => setIsSortMenuOpen(false)} />}
+    </div>
+  );
+}
 
-      <style dangerouslySetInnerHTML={{__html: `
-        .scrollbar-hide::-webkit-scrollbar { display: none; }
-        .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
-      `}} />
-    </main>
+export default function LiveListPage() {
+  const searchParams = useSearchParams();
+  const pathname = usePathname();
+
+  // 💡 [해결책 2] 고유한 Key 부여: 경로와 검색 파라미터가 바뀔 때마다 리액트가 컴포넌트를 새로 생성하게 함
+  // 뒤로가기 시 캐시된 DOM 대신 리액트가 다시 마운트되면서 이벤트 리스너를 복구합니다.
+  const uniqueKey = `${pathname}-${searchParams.toString()}`;
+
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <LiveListContent key={uniqueKey} />
+    </Suspense>
   );
 }

--- a/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import Link from "next/link";
+import { Search, ChevronDown, Users, Radio, Check, AlertCircle } from "lucide-react";
+
+// 💡 핵심 수정: Date.now() 같은 동적 함수를 제거하고, 고정된 시간 문자열을 사용하여 
+// Next.js의 Hydration(렌더링 동기화) 에러와 클릭 이벤트 먹통 현상을 완벽하게 방지했습니다.
+const LIVE_STREAMS = [
+  {
+    id: 101,
+    title: "신입 백엔드 포트폴리오 실시간 리뷰 & QnA",
+    mentor: "AI네이티브개발자",
+    category: "개발",
+    viewers: 128,
+    startTime: "2026-04-28T10:30:00Z", // 고정된 시간
+    tags: ["백엔드", "포트폴리오", "취업"],
+    thumbnailColor: "bg-blue-900",
+    profileColor: "bg-blue-500",
+  },
+  {
+    id: 102,
+    title: "실무에서 쓰이는 React 패턴 (주니어용)",
+    mentor: "프론트엔드장인",
+    category: "개발",
+    viewers: 85,
+    startTime: "2026-04-28T11:50:00Z", 
+    tags: ["프론트엔드", "React", "실무"],
+    thumbnailColor: "bg-emerald-900",
+    profileColor: "bg-emerald-500",
+  },
+  {
+    id: 103,
+    title: "Unreal Engine 5 구조 설계 노하우 방송",
+    mentor: "게임개발자K",
+    category: "개발",
+    viewers: 210,
+    startTime: "2026-04-28T09:00:00Z",
+    tags: ["게임개발", "언리얼"],
+    thumbnailColor: "bg-purple-900",
+    profileColor: "bg-purple-500",
+  },
+  {
+    id: 104,
+    title: "주니어 기획자를 위한 역량 강화 가이드",
+    mentor: "기획왕",
+    category: "기획/PM",
+    viewers: 45,
+    startTime: "2026-04-28T11:15:00Z",
+    tags: ["기획", "PM", "커리어"],
+    thumbnailColor: "bg-orange-900",
+    profileColor: "bg-orange-500",
+  }
+];
+
+const CATEGORIES = ["전체", "개발", "기획/PM", "디자인", "마케팅"];
+const SORT_OPTIONS = [
+  { id: "viewers", label: "시청자 많은순" },
+  { id: "newest", label: "최신순" },
+  { id: "oldest", label: "오래된 순" },
+];
+
+export default function LiveListPage() {
+  const [sortBy, setSortBy] = useState("viewers");
+  const [activeCategory, setActiveCategory] = useState("전체");
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isSortMenuOpen, setIsSortMenuOpen] = useState(false);
+
+  const filteredAndSortedStreams = useMemo(() => {
+    let list = [...LIVE_STREAMS];
+
+    if (activeCategory !== "전체") {
+      list = list.filter(stream => stream.category === activeCategory);
+    }
+
+    if (searchQuery.trim() !== "") {
+      const query = searchQuery.toLowerCase();
+      list = list.filter(stream => 
+        stream.title.toLowerCase().includes(query) || 
+        stream.mentor.toLowerCase().includes(query)
+      );
+    }
+
+    if (sortBy === "viewers") list.sort((a, b) => b.viewers - a.viewers);
+    else if (sortBy === "newest") list.sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime());
+    else if (sortBy === "oldest") list.sort((a, b) => new Date(a.startTime).getTime() - new Date(b.startTime).getTime());
+
+    return list;
+  }, [activeCategory, searchQuery, sortBy]);
+
+  return (
+    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] relative">
+      
+      <header className={`sticky top-0 bg-white z-20 transition-all duration-300 ${isSearchOpen ? 'pb-2' : ''}`}>
+        <div className="flex items-center justify-between px-5 py-4">
+          {!isSearchOpen ? (
+            <>
+              <h1 className="text-[20px] font-extrabold tracking-tight flex items-center gap-2">
+                1:N 라이브 멘토링
+                <span className="relative flex h-3 w-3">
+                  <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+                  <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
+                </span>
+              </h1>
+              <button 
+                type="button"
+                onClick={() => setIsSearchOpen(true)} 
+                className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+              >
+                <Search className="w-6 h-6" strokeWidth={2.5} />
+              </button>
+            </>
+          ) : (
+            <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
+              <div className="relative flex-1">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth={2.5} />
+                <input 
+                  autoFocus
+                  type="text"
+                  placeholder="멘토 또는 라이브 제목 검색"
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none focus:ring-2 focus:ring-[#FFCC00]/50"
+                />
+              </div>
+              <button 
+                type="button"
+                onClick={() => {
+                  setIsSearchOpen(false);
+                  setSearchQuery("");
+                }} 
+                className="text-[14px] font-bold text-gray-500 px-1"
+              >
+                취소
+              </button>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className="flex gap-2 overflow-x-auto px-5 py-2 scrollbar-hide">
+        {CATEGORIES.map((category) => (
+          <button
+            key={category}
+            type="button" // 💡 명시적으로 버튼 타입을 지정하여 폼 전송 등 오작동 방지
+            onClick={() => setActiveCategory(category)}
+            className={`shrink-0 px-4 py-2 rounded-full text-[14px] font-bold border transition-all
+              ${activeCategory === category 
+                ? 'bg-[#1A1A1A] text-white border-[#1A1A1A]' 
+                : 'bg-white text-gray-500 border-gray-200 hover:bg-gray-50'
+              }
+            `}
+          >
+            {category}
+          </button>
+        ))}
+      </div>
+
+      <div className="px-5 py-4 flex items-center justify-between relative">
+        <button 
+          type="button"
+          onClick={() => setIsSortMenuOpen(!isSortMenuOpen)}
+          className="flex items-center gap-1 text-[13px] font-bold text-gray-600 bg-gray-50 px-3 py-1.5 rounded-lg active:bg-gray-100 transition-colors"
+        >
+          {SORT_OPTIONS.find(opt => opt.id === sortBy)?.label}
+          <ChevronDown className={`w-4 h-4 transition-transform ${isSortMenuOpen ? 'rotate-180' : ''}`} />
+        </button>
+        
+        {isSortMenuOpen && (
+          <div className="absolute top-14 left-5 w-[160px] bg-white border border-gray-100 rounded-2xl shadow-xl z-30 p-2 animate-in fade-in zoom-in-95 duration-150">
+            {SORT_OPTIONS.map((option) => (
+              <button
+                key={option.id}
+                type="button"
+                onClick={() => {
+                  setSortBy(option.id);
+                  setIsSortMenuOpen(false);
+                }}
+                className={`w-full flex items-center justify-between px-3 py-2.5 rounded-xl text-[13px] font-bold transition-colors
+                  ${sortBy === option.id ? 'bg-[#FFCC00]/10 text-[#1A1A1A]' : 'text-gray-500 hover:bg-gray-50'}
+                `}
+              >
+                {option.label}
+                {sortBy === option.id && <Check className="w-4 h-4 text-[#FFCC00]" />}
+              </button>
+            ))}
+          </div>
+        )}
+        <span className="text-[12px] font-bold text-gray-400">결과 {filteredAndSortedStreams.length}개</span>
+      </div>
+
+      <div className="flex flex-col px-5 gap-6 pb-10 flex-1">
+        {filteredAndSortedStreams.length > 0 ? (
+          filteredAndSortedStreams.map((stream) => (
+            <Link 
+              key={stream.id} 
+              href={`/mentoring_list/live_list/${stream.id}`} 
+              className="group flex flex-col gap-3"
+            >
+              <div className={`relative w-full aspect-video rounded-2xl ${stream.thumbnailColor} overflow-hidden shadow-sm`}>
+                <div className="absolute inset-0 flex items-center justify-center opacity-30">
+                  <Radio className="w-16 h-16 text-white" />
+                </div>
+                <div className="absolute top-3 left-3 bg-red-600 text-white text-[11px] font-extrabold px-2 py-1 rounded-[6px] flex items-center gap-1 tracking-wider">
+                  <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse" /> LIVE
+                </div>
+                <div className="absolute bottom-3 right-3 bg-black/70 backdrop-blur-sm text-white text-[12px] font-bold px-2.5 py-1 rounded-[8px] flex items-center gap-1.5">
+                  <Users className="w-3.5 h-3.5" /> {stream.viewers}명 시청 중
+                </div>
+              </div>
+
+              <div className="flex gap-3 px-1">
+                <div className={`w-10 h-10 rounded-full shrink-0 ${stream.profileColor} border border-gray-100 shadow-sm`} />
+                <div className="flex flex-col flex-1 min-w-0 pt-0.5">
+                  <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-tight mb-1 truncate group-hover:text-blue-600 transition-colors">
+                    {stream.title}
+                  </h3>
+                  <p className="text-[13px] font-medium text-gray-500 mb-2">
+                    {stream.mentor} · {stream.category}
+                  </p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {stream.tags.map((tag, idx) => (
+                      <span key={idx} className="bg-[#F2F4F6] text-gray-600 text-[11px] font-bold px-2 py-0.5 rounded-[4px]">
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </Link>
+          ))
+        ) : (
+          <div className="flex-1 flex flex-col items-center justify-center py-20 animate-in fade-in duration-500">
+            <div className="bg-gray-50 p-6 rounded-full mb-4">
+              <AlertCircle className="w-10 h-10 text-gray-300" />
+            </div>
+            <p className="text-gray-400 font-bold text-[15px] mb-1">해당하는 라이브가 없습니다.</p>
+            <p className="text-gray-300 text-[13px]">다른 카테고리나 검색어를 이용해 보세요.</p>
+            {(activeCategory !== "전체" || searchQuery !== "") && (
+              <button 
+                type="button"
+                onClick={() => {
+                  setActiveCategory("전체");
+                  setSearchQuery("");
+                }}
+                className="mt-6 text-[#FFCC00] font-bold text-[14px] border-b border-[#FFCC00] pb-0.5"
+              >
+                필터 초기화
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {isSortMenuOpen && <div className="fixed inset-0 z-20" onClick={() => setIsSortMenuOpen(false)} />}
+
+      <style dangerouslySetInnerHTML={{__html: `
+        .scrollbar-hide::-webkit-scrollbar { display: none; }
+        .scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+      `}} />
+    </main>
+  );
+}


### PR DESCRIPTION
## 연관된 이슈

#31 

## 작업 내용

* **1:N 멘토링 목록 UI 제작**
  * 썸네일 및 제목으로 현재 진행중인 라이브 목록 노출
  * 시청자 많은순, 오래된순, 최신순에 따른 정렬 기능 구현
  * 멘토링 제목에 따른 검색 기능 구현
  * 멘토링 썸네일 및 제목을 클릭하면 해당 멘토링에 접속 가능 -> 현재 임시 더미 페이지로 연결됨
  
* **1:1 멘토링 목록 UI 제작**
  * 이전에 멘토링 진행 이력이 있는 멘토/멘티의 프로필이 노출됨.
  * 멘토/멘티 사용자의 UI 구분 -> 현재 위의 임시 버튼으로 멘토/멘티의 UI를 둘 다 볼 수 있게 해둠
  * 멘토/멘티 이름 검색 기능 구현
  * 멘티 화면
    * 멘토 정보, 멘토링 주제, 멘토링 일정, 예약 상태를 볼 수 있음.
    * "다시 예약" 버튼으로 달력 창에서 가능한 날짜 및 시간에 예약 가능 / 예약 취소 가능
    * 메시지 창에서 멘토에게 메시지를 보낼 수 있음
  * 멘토 화면
    * 멘티 정보, 멘토링 주제, 멘토링 일정, 예약 상태를 볼 수 있음.
    * "일정 관리" 버튼으로 달력 창에서 예약된 멘토링 날짜 및 시간을 볼 수 있음.
    * 메시지 창에서 멘티에게 메시지를 보낼 수 있음.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

* **리뷰 방법 및 요구사항**
  1. feat/31-mentoring-list-ui 브랜치로 체크아웃
  2.  /apps/demo-web 에서 터미널 실행 후 "npm run dev" 명령어 실행
  3. http://localhost:3000/ 접속 후, 화면 하단의 네비게이션 바의 버튼으로 1:N 멘토링, 1:1 멘토링 페이지로 이동 가능
  4. 작업 내용에서 말한 기능들이 제대로 작동하는지 확인