### PR TITLE
마이페이지 UI 그리기

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import Link from "next/link";
+import { 
+  Settings, 
+  ChevronRight, 
+  UserPen, 
+  BadgeCheck, 
+  ClipboardList, 
+  Star, 
+  ScrollText, 
+  HelpCircle, 
+  MessageSquare 
+} from "lucide-react";
+
+export default function MyPage() {
+  return (
+    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] pb-[80px]">
+      
+      {/* 1. 상단 헤더 */}
+      <header className="flex items-center justify-between px-5 py-4 sticky top-0 bg-white z-20">
+        <h1 className="text-[22px] font-bold tracking-tight">마이페이지</h1>
+        <button className="p-1 hover:bg-gray-100 rounded-full transition-colors">
+          <Settings className="w-6 h-6" strokeWidth={2} />
+        </button>
+      </header>
+
+      {/* 2. 멘티 프로필 영역 */}
+      <div className="flex items-center gap-4 px-5 py-6">
+        {/* 멘티 로고 아이콘 (스크린샷 스타일 반영) */}
+        <div className="w-[72px] h-[72px] bg-[#111116] rounded-2xl flex flex-col items-center justify-center text-white shrink-0 shadow-sm">
+          <span className="text-[15px] font-extrabold mb-1">멘티</span>
+          <span className="text-[10px] font-bold tracking-widest">—O—O—</span>
+        </div>
+        
+        <div className="flex flex-col gap-1.5">
+          <h2 className="text-[20px] font-semibold tracking-tight">김세종</h2>
+          {/* 💡 추가됨: 사전 설문 결과 (유형 이름) */}
+          <span className="inline-block bg-[#FFCC00] text-black-600 text-[12px] font-semibold px-2.5 py-1.5 rounded-md w-fit">
+            탐구하는 개발자
+          </span>
+        </div>
+      </div>
+
+      {/* 3. 사전 질문권 개수 영역 (스크린샷의 메시지 전송가능 건수 변형) */}
+      <div className="mx-5 mb-8 bg-[#F8F9FA] rounded-2xl p-4 flex items-center justify-between border border-gray-100 shadow-sm">
+        <span className="text-[15px] font-bold text-gray-700 ml-1">사전 질문권 개수</span>
+        <div className="flex items-center gap-3">
+          <span className="text-[18px] font-extrabold">5 <span className="text-[14px] font-medium text-gray-500">개</span></span>
+          <button className="bg-[#333333] hover:bg-black text-white text-[13px] font-bold px-4 py-2 rounded-lg transition-colors active:scale-95">
+            충전
+          </button>
+        </div>
+      </div>
+
+      {/* 4. 메인 메뉴 리스트 */}
+      <div className="flex flex-col px-5 mb-6">
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <UserPen className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">멘티프로필 수정</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <BadgeCheck className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">멘토 등록</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <ClipboardList className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">멘토링 진행내역</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <Star className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">리뷰 관리</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+
+        {/* 💡 추가됨: 스크립트 목록 버튼 */}
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <ScrollText className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">스크립트 목록</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+      </div>
+
+      {/* 구분선 (스크린샷 스타일 반영) */}
+      <div className="w-full h-[8px] bg-[#F8F9FA]" />
+
+      {/* 5. 서브 메뉴 리스트 (고객센터 등) */}
+      <div className="flex flex-col px-5 mt-4">
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <HelpCircle className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">서비스 이용 안내</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+
+        <Link href="#" className="flex items-center justify-between py-4 group">
+          <div className="flex items-center gap-3">
+            <MessageSquare className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium group-hover:font-bold transition-all">1:1 문의</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </Link>
+      </div>
+
+    </main>
+  );
+}

--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -27,22 +27,22 @@ export default function MyPage() {
 
       {/* 2. 멘티 프로필 영역 */}
       <div className="flex items-center gap-4 px-5 py-6">
-        {/* 멘티 로고 아이콘 (스크린샷 스타일 반영) */}
+        {/* 멘티 로고 아이콘 */}
         <div className="w-[72px] h-[72px] bg-[#111116] rounded-2xl flex flex-col items-center justify-center text-white shrink-0 shadow-sm">
           <span className="text-[15px] font-extrabold mb-1">멘티</span>
           <span className="text-[10px] font-bold tracking-widest">—O—O—</span>
         </div>
         
-        <div className="flex flex-col gap-1.5">
+        {/* 💡 수정됨: flex-col 대신 flex items-center를 사용하여 닉네임과 뱃지를 가로로 배치합니다. */}
+        <div className="flex items-center gap-2">
           <h2 className="text-[20px] font-semibold tracking-tight">김세종</h2>
-          {/* 💡 추가됨: 사전 설문 결과 (유형 이름) */}
-          <span className="inline-block bg-[#FFCC00] text-black-600 text-[12px] font-semibold px-2.5 py-1.5 rounded-md w-fit">
-            탐구하는 개발자
+          <span className="inline-block bg-[#FFCC00] text-black text-[12px] font-semibold px-2.5 py-1 rounded-md w-fit">
+            창의적인 모험가
           </span>
         </div>
       </div>
 
-      {/* 3. 사전 질문권 개수 영역 (스크린샷의 메시지 전송가능 건수 변형) */}
+      {/* 3. 사전 질문권 개수 영역 */}
       <div className="mx-5 mb-8 bg-[#F8F9FA] rounded-2xl p-4 flex items-center justify-between border border-gray-100 shadow-sm">
         <span className="text-[15px] font-bold text-gray-700 ml-1">사전 질문권 개수</span>
         <div className="flex items-center gap-3">
@@ -87,7 +87,6 @@ export default function MyPage() {
           <ChevronRight className="w-5 h-5 text-gray-300" />
         </Link>
 
-        {/* 💡 추가됨: 스크립트 목록 버튼 */}
         <Link href="/mypage/scripts" className="flex items-center justify-between py-4 group">
           <div className="flex items-center gap-3">
             <ScrollText className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
@@ -97,10 +96,10 @@ export default function MyPage() {
         </Link>
       </div>
 
-      {/* 구분선 (스크린샷 스타일 반영) */}
+      {/* 구분선 */}
       <div className="w-full h-[8px] bg-[#F8F9FA]" />
 
-      {/* 5. 서브 메뉴 리스트 (고객센터 등) */}
+      {/* 5. 서브 메뉴 리스트 */}
       <div className="flex flex-col px-5 mt-4">
         <Link href="#" className="flex items-center justify-between py-4 group">
           <div className="flex items-center gap-3">

--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -88,7 +88,7 @@ export default function MyPage() {
         </Link>
 
         {/* 💡 추가됨: 스크립트 목록 버튼 */}
-        <Link href="#" className="flex items-center justify-between py-4 group">
+        <Link href="/mypage/scripts" className="flex items-center justify-between py-4 group">
           <div className="flex items-center gap-3">
             <ScrollText className="w-[22px] h-[22px] text-gray-500 group-hover:text-[#1A1A1A] transition-colors" strokeWidth={2} />
             <span className="text-[16px] font-medium group-hover:font-bold transition-all">스크립트 목록</span>

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -1,0 +1,8 @@
+export default function ScriptListPage() {
+  return (
+    <main className="p-5">
+      <h1 className="text-2xl font-bold">스크립트 목록 페이지</h1>
+      <p className="mt-4 text-gray-500">여기에 스크립트 리스트가 들어올 예정입니다.</p>
+    </main>
+  );
+}


### PR DESCRIPTION
## 연관된 이슈

#39 

## 작업 내용
<img width="287" height="510" alt="image" src="https://github.com/user-attachments/assets/123ffef1-ae69-4173-854e-d17ff85346c9" />

* 마이페이지 UI 제작
* 닉네임 옆에 사전설문 결과 라벨이 붙도록 함.
* 스크립트 목록 버튼 추가 및 해당 페이지 연결: 현재 테스트 페이지가 출력됨

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항
* http://localhost:3000/mypage 에서 확인 가능
* 기존 마이페이지와 거의 흡사한 UI라 캡처본만 확인하고 승인하셔도 됩니다.
