### PR TITLE
발화자 분리 및 임시 엔드포인트 삭제

### DIFF
--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -134,40 +134,5 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
   }
 });
 
-//mentoringId로 전체 스크립트 조회
-router.get("/script/:mentoringId", async (req, res) => {
-  try {
-    const { mentoringId } = req.params;
-
-    const scripts = await prisma.script.findMany({
-      where: { mentoringId: BigInt(mentoringId) },
-      orderBy: { createdAt: "asc" },
-    });
-
-    if (scripts.length === 0) {
-      return res.status(404).json({ error: "해당 멘토링의 스크립트가 없습니다." });
-    }
-
-    // chunkIndex 순으로 정렬 후 텍스트 이어붙이기
-    const sorted = scripts.sort((a, b) => a.content.chunkIndex - b.content.chunkIndex);
-    const fullText = sorted.map((s) => s.content.text).join(" ");
-
-    res.json({
-      mentoringId,
-      totalChunks: scripts.length,
-      fullText,
-      chunks: sorted.map((s) => ({
-        scriptId: s.scriptId.toString(),
-        chunkIndex: s.content.chunkIndex,
-        startTime: s.content.startTime,
-        endTime: s.content.endTime,
-        text: s.content.text,
-      })),
-    });
-  } catch (err) {
-    console.error("[STT SCRIPT ERROR]", err);
-    res.status(500).json({ error: err.message });
-  }
-});
 
 export default router;

--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -71,6 +71,21 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
       return res.status(400).json({ error: "audio, userId, mentoringId는 필수입니다." });
     }
 
+    // 멘토링 정보 조회
+    const mentoring = await prisma.mentoring.findUnique({
+      where: { mentoringId: BigInt(mentoringId) },
+    });
+
+    if (!mentoring) {
+      return res.status(404).json({ error: "멘토링을 찾을 수 없습니다." });
+    }
+
+    // 발화자 userId 결정(1:N인 경우 멘토로 고정)
+    const speakerUserId = mentoring.isGroup ? mentoring.userId.toString() : userId;
+
+    // 현재 비공개 질문/답변 여부는 false로 기본값 설정. 질문 관리 상태를 먼저 알아야 함
+    const isPrivate = false;
+
     // 1. 청크 분할
     const chunks = await splitAudioIntoChunks(req.file.buffer, req.file.mimetype);
 
@@ -86,8 +101,14 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
       const text = await transcribeAudio(audioFile);
 
       const saved = await saveScript(
-        { text, chunkIndex: chunk.index, startTime: chunk.startTime, endTime: chunk.endTime },
-        { userId, mentoringId }
+        {
+          text,
+          chunkIndex: chunk.index,
+          startTime: chunk.startTime,
+          endTime: chunk.endTime,
+          isPrivate,
+        },
+        { userId: speakerUserId, mentoringId }
       );
 
       results.push({
@@ -95,11 +116,18 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
         chunkIndex: chunk.index,
         startTime: chunk.startTime,
         endTime: chunk.endTime,
+        speakerUserId,
         text,
       });
     }
 
-    res.json({ mentoringId, totalChunks: chunks.length, scripts: results });
+    res.json({
+      mentoringId,
+      isGroup: mentoring.isGroup,
+      speakerUserId,
+      totalChunks: chunks.length,
+      scripts: results
+    });
   } catch (err) {
     console.error("[STT UPLOAD ERROR]", err);
     res.status(500).json({ error: err.message });

--- a/services/stt-service/src/services/scriptSave.js
+++ b/services/stt-service/src/services/scriptSave.js
@@ -6,7 +6,10 @@ import { prisma } from "@carpoolink/database"
  * @param {{ text: string, chunkIndex: number, startTime?: number, endTime?: number }} chunk
  * @param {{ userId: bigint, mentoringId: bigint }} meta
  */
-export async function saveScript({ text, chunkIndex, startTime, endTime }, { userId, mentoringId }) {
+export async function saveScript(
+  { text, chunkIndex, startTime, endTime, isPrivate = false },
+  { userId, mentoringId }
+) {
   return await prisma.script.create({
     data: {
       content: {
@@ -15,7 +18,7 @@ export async function saveScript({ text, chunkIndex, startTime, endTime }, { use
         startTime: startTime ?? null,
         endTime: endTime ?? null,
       },
-      isPrivate: false,
+      isPrivate,
       userId: BigInt(userId),
       mentoringId: BigInt(mentoringId),
     },


### PR DESCRIPTION
## 연관된 이슈

> #37 

## 작업 내용

멘토링 유형(isGroup)으로 발화자 분리
1:N 멘토링의 경우 발화자(userId)를 멘토로 고정했습니다. (1:1 멘토링의 경우 실시간 스트림 연결 시에 수정 필요)

임시로 사용하던 엔드포인트를 삭제했습니다.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

참고사항
> isPrivate은 false로 고정해놓은 상태입니다(질문 관리에 따라 다름)

<img width="1393" height="825" alt="image" src="https://github.com/user-attachments/assets/9ce07316-9cec-49c5-892d-d6e418857562" />

> isGroup이 true인 3번 멘토링(user 1은 테스트용 멘토 유저)


<img width="1403" height="830" alt="image" src="https://github.com/user-attachments/assets/b8d670b3-9394-4f86-8ec2-56b2ea9f5915" />

> userId=2로 요청(테스트용 멘티 유저), 멘토의 userId로 저장되어있음.(기존엔 요청한 userId로 저장됨)