### PR TITLE
자동 배포 파이프라인 구축

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+**
+!package.json
+!package-lock.json
+!services/**
+!packages/**

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,7 +90,7 @@ jobs:
           context: .
           file: ./services/${{ matrix.service }}/Dockerfile
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.service }}:buildcache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy Carpoolink Services
 on:
   push:
     branches:
-      - release/**
+      - main
     paths:
       - ".github/workflows/deploy.yml"
       - "services/**"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,227 @@
+name: Deploy Carpoolink Services
+
+on:
+  push:
+    branches:
+      - release/**
+    paths:
+      - ".github/workflows/deploy.yml"
+      - "services/**"
+      - "packages/**"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  REPO_OWNER: ${{ github.repository_owner }}
+
+jobs:
+  detectChanges:
+    name: Detect Changed Services
+    runs-on: ubuntu-latest
+    outputs:
+      changed_services: ${{ steps.changes.outputs.changes }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: dorny/paths-filter@v2
+        id: changes
+        with:
+          filters: |
+            core-api:
+              - 'services/core-api/**'
+              - 'packages/**'
+            chat-service:
+              - 'services/chat-service/**'
+              - 'packages/**'
+            media-server:
+              - 'services/media-server/**'
+              - 'packages/**'
+            question-service:
+              - 'services/question-service/**'
+              - 'packages/**'
+            stt-service:
+              - 'services/stt-service/**'
+              - 'packages/**'
+
+  buildAndPush:
+    name: Build and Push ${{ matrix.service }}
+    needs: detectChanges
+    runs-on: ubuntu-latest
+    if: needs.detectChanges.outputs.changed_services != '[]'
+    strategy:
+      matrix:
+        service: ${{ fromJSON(needs.detectChanges.outputs.changed_services) }}
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+
+      # 1. QEMU 설치 (멀티 아키텍처 빌드용)
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.service }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: ./services/${{ matrix.service }}
+          file: ./services/${{ matrix.service }}/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.service }}:buildcache
+          cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.REPO_OWNER }}/${{ matrix.service }}:buildcache,mode=max
+
+  getInstanceId:
+    name: Get EC2 Instance ID
+    runs-on: ubuntu-latest
+    outputs:
+      instance_id: ${{ steps.get_instance_id.outputs.instance_id }}
+    steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Get EC2 Instance ID
+        id: get_instance_id
+        run: |
+          INSTANCE_ID=$(aws ec2 describe-instances \
+            --filters "Name=tag:Name,Values=carpoolink-server" \
+                      "Name=instance-state-name,Values=running" \
+            --query "Reservations[].Instances[].InstanceId" \
+            --output text)
+          echo "instance_id=$INSTANCE_ID" >> $GITHUB_OUTPUT
+
+  deploy:
+    name: Deploy to EC2
+    needs: [buildAndPush, getInstanceId]
+    runs-on: ubuntu-latest
+    if: always() && needs.getInstanceId.outputs.instance_id != ''
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Deploy Services to EC2
+        uses: peterkimzz/aws-ssm-send-command@master
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          instance-ids: ${{ needs.getInstanceId.outputs.instance_id }}
+          working-directory: /app
+          comment: Deploy Carpoolink Services
+          command: |
+            set -e
+            export HOME=/root
+            
+            # GitHub Container Registry 로그인
+            echo "${{ secrets.TK_GITHUB_ACCESS_TOKEN }}" \
+              | docker login ghcr.io \
+                -u ${{ secrets.TK_GITHUB_ACCESS_TOKEN_OWNER }} \
+                --password-stdin
+            
+            # 환경 변수 설정
+            echo "${{ secrets.ENV_FILE_B64 }}" | base64 -d > /app/.env
+            
+            # 네트워크 생성
+            docker network create carpoolink-network 2>/dev/null || true
+            
+            # 기존 컨테이너 정리
+            docker stop carpoolink-core-api 2>/dev/null || true && \
+            docker rm carpoolink-core-api 2>/dev/null || true
+            
+            docker stop carpoolink-chat-service 2>/dev/null || true && \
+            docker rm carpoolink-chat-service 2>/dev/null || true
+            
+            docker stop carpoolink-media-server 2>/dev/null || true && \
+            docker rm carpoolink-media-server 2>/dev/null || true
+            
+            docker stop carpoolink-question-service 2>/dev/null || true && \
+            docker rm carpoolink-question-service 2>/dev/null || true
+            
+            docker stop carpoolink-stt-service 2>/dev/null || true && \
+            docker rm carpoolink-stt-service 2>/dev/null || true
+            
+            # Core API 배포
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/core-api:main && \
+            docker run --restart always \
+              -d --name carpoolink-core-api \
+              -p 4000:4000 \
+              --network carpoolink-network \
+              --env-file /app/.env \
+              ghcr.io/${{ env.REPO_OWNER }}/core-api:main
+            
+            # Chat Service 배포
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/chat-service:main && \
+            docker run --restart always \
+              -d --name carpoolink-chat-service \
+              -p 4001:4001 \
+              --network carpoolink-network \
+              --env-file /app/.env \
+              ghcr.io/${{ env.REPO_OWNER }}/chat-service:main
+            
+            # Media Server 배포
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/media-server:main && \
+            docker run --restart always \
+              -d --name carpoolink-media-server \
+              -p 4002:4002 \
+              --network carpoolink-network \
+              --env-file /app/.env \
+              ghcr.io/${{ env.REPO_OWNER }}/media-server:main
+            
+            # Question Service 배포
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/question-service:main && \
+            docker run --restart always \
+              -d --name carpoolink-question-service \
+              -p 4003:4003 \
+              --network carpoolink-network \
+              --env-file /app/.env \
+              ghcr.io/${{ env.REPO_OWNER }}/question-service:main
+            
+            # STT Service 배포
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/stt-service:main && \
+            docker run --restart always \
+              -d --name carpoolink-stt-service \
+              -p 4004:4004 \
+              --network carpoolink-network \
+              --env-file /app/.env \
+              ghcr.io/${{ env.REPO_OWNER }}/stt-service:main
+            
+            # 미사용 이미지 정리
+            docker image prune -af --filter "until=24h" || true
+            
+            # 배포 완료 메시지
+            echo "✅ Carpoolink Services deployed successfully!"
+            docker ps --filter "network=carpoolink-network" --format "table {{.Names}}\t{{.Ports}}\t{{.Status}}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix={{branch}}-
+            type=raw,value=${{ github.sha }}
             type=raw,value=latest
 
       - name: Build and push
@@ -175,49 +176,49 @@ jobs:
             docker rm carpoolink-stt-service 2>/dev/null || true
             
             # Core API 배포
-            docker pull ghcr.io/${{ env.REPO_OWNER }}/core-api:main && \
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/core-api:${{ github.sha }} && \
             docker run --restart always \
               -d --name carpoolink-core-api \
               -p 4000:4000 \
               --network carpoolink-network \
               --env-file /app/.env \
-              ghcr.io/${{ env.REPO_OWNER }}/core-api:main
+              ghcr.io/${{ env.REPO_OWNER }}/core-api:${{ github.sha }}
             
             # Chat Service 배포
-            docker pull ghcr.io/${{ env.REPO_OWNER }}/chat-service:main && \
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/chat-service:${{ github.sha }} && \
             docker run --restart always \
               -d --name carpoolink-chat-service \
               -p 4001:4001 \
               --network carpoolink-network \
               --env-file /app/.env \
-              ghcr.io/${{ env.REPO_OWNER }}/chat-service:main
+              ghcr.io/${{ env.REPO_OWNER }}/chat-service:${{ github.sha }}
             
             # Media Server 배포
-            docker pull ghcr.io/${{ env.REPO_OWNER }}/media-server:main && \
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/media-server:${{ github.sha }} && \
             docker run --restart always \
               -d --name carpoolink-media-server \
               -p 4002:4002 \
               --network carpoolink-network \
               --env-file /app/.env \
-              ghcr.io/${{ env.REPO_OWNER }}/media-server:main
+              ghcr.io/${{ env.REPO_OWNER }}/media-server:${{ github.sha }}
             
             # Question Service 배포
-            docker pull ghcr.io/${{ env.REPO_OWNER }}/question-service:main && \
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/question-service:${{ github.sha }} && \
             docker run --restart always \
               -d --name carpoolink-question-service \
               -p 4003:4003 \
               --network carpoolink-network \
               --env-file /app/.env \
-              ghcr.io/${{ env.REPO_OWNER }}/question-service:main
+              ghcr.io/${{ env.REPO_OWNER }}/question-service:${{ github.sha }}
             
             # STT Service 배포
-            docker pull ghcr.io/${{ env.REPO_OWNER }}/stt-service:main && \
+            docker pull ghcr.io/${{ env.REPO_OWNER }}/stt-service:${{ github.sha }} && \
             docker run --restart always \
               -d --name carpoolink-stt-service \
               -p 4004:4004 \
               --network carpoolink-network \
               --env-file /app/.env \
-              ghcr.io/${{ env.REPO_OWNER }}/stt-service:main
+              ghcr.io/${{ env.REPO_OWNER }}/stt-service:${{ github.sha }}
             
             # 미사용 이미지 정리
             docker image prune -af --filter "until=24h" || true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
-          context: ./services/${{ matrix.service }}
+          context: .
           file: ./services/${{ matrix.service }}/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -29,26 +29,49 @@ tests/
 	load/
 ```
 
-## 실행
+## 빠른 시작
 
-1. 루트에서 의존성 설치
+### 1. 환경 설정
 
-    ```bash
-    npm install
-    ```
+```bash
+# 프로젝트 루트에서
+npm install
+cp .env.example .env
+```
 
-2. 기본 백엔드(mentoring-session) 실행
+### 2. Docker Compose로 모든 서비스 실행
 
-    ```bash
-    npm run dev
-    ```
+```bash
+cd infra/compose
+docker-compose up -d
 
-3. 개별 서비스 실행 예시
+# 상태 확인
+docker-compose ps
+```
 
-    루트에 위치한 `package.json` scripts 목록 참고
+### 3. 웹 애플리케이션 실행
 
-    ```bash
-    npm run dev:sfu
-    npm run dev:live-chat
-    npm run dev:question-queue
-    ```
+```bash
+cd apps/demo-web
+npm run dev
+```
+
+### 4. 개별 서비스 개발
+
+```bash
+# Core API
+cd services/core-api && npm run dev
+
+# Chat Service
+cd services/chat-service && npm run dev
+
+# 다른 서비스도 동일하게
+```
+
+## 배포
+
+자동 배포는 main 브랜치로 push 시 GitHub Actions를 통해 자동 실행됩니다.
+
+- **배포 가이드**: [infra/compose/DEPLOYMENT_GUIDE.md](./infra/compose/DEPLOYMENT_GUIDE.md)
+- **시크릿 설정**: [.github/SECRETS_SETUP.md](./.github/SECRETS_SETUP.md)
+- **로컬 개발**: [infra/compose/README.md](./infra/compose/README.md)

--- a/infra/compose/README.md
+++ b/infra/compose/README.md
@@ -1,17 +1,237 @@
-# Compose
+# Compose - 로컬 개발 환경 설정
 
-로컬 통합 실행용 docker compose 파일을 관리합니다.
+Carpoolink의 모든 마이크로서비스와 데이터베이스를 Docker Compose로 로컬 환경에서 실행합니다.
 
-## PostgreSQL 실행
+## 빠른 시작
 
-프로젝트 루트에서 아래 명령으로 실행합니다.
-
-```bash
-docker compose --env-file .env -f infra/compose/docker-compose.yml up -d
-```
-
-중지 명령:
+### 1. 환경 변수 설정
 
 ```bash
-docker compose -f infra/compose/docker-compose.yml down
+cd infra/compose
+
+# .env 파일 생성
+
+### 2. 서비스 시작
+
+```bash
+# 모든 서비스 시작
+docker-compose up -d
+
+# 상태 확인
+docker-compose ps
+
+# 특정 서비스 로그 보기
+docker-compose logs -f core-api
 ```
+
+### 3. 서비스 중지
+
+```bash
+# 모든 서비스 중지
+docker-compose down
+
+# 데이터를 포함하여 완전히 제거
+docker-compose down -v
+```
+
+## 서비스 포트 매핑
+
+| 서비스 | 포트 | URL |
+|--------|------|-----|
+| PostgreSQL | 5432 | `postgresql://localhost:5432/carpoolink` |
+| Core API | 4000 | `http://localhost:4000` |
+| Chat Service | 4001 | `ws://localhost:4001` |
+| Media Server | 4002 | `ws://localhost:4002` |
+| Question Service | 4003 | `http://localhost:4003` |
+| STT Service | 4004 | `http://localhost:4004` |
+
+## 개별 서비스 관리
+
+### 특정 서비스만 시작
+
+```bash
+# Core API만 시작
+docker-compose up -d core-api
+
+# 여러 서비스 시작
+docker-compose up -d core-api chat-service
+```
+
+### 특정 서비스 로그 보기
+
+```bash
+# 실시간 로그
+docker-compose logs -f chat-service
+
+# 마지막 100줄
+docker-compose logs --tail=100 core-api
+
+# 모든 서비스 로그
+docker-compose logs
+```
+
+### 특정 서비스 재시작
+
+```bash
+# 서비스 재시작
+docker-compose restart media-server
+
+# 컨테이너 재빌드 및 시작
+docker-compose up -d --build stt-service
+```
+
+## 데이터베이스 관리
+
+### PostgreSQL 접속
+
+```bash
+# psql CLI 사용
+docker-compose exec postgres psql -U carpoolink -d carpoolink
+
+# 또는 로컬 클라이언트 사용
+psql postgresql://carpoolink:password@localhost:5432/carpoolink
+```
+
+### 데이터베이스 초기화
+
+```bash
+# 데이터 유지하고 서비스만 재시작
+docker-compose restart postgres
+
+# 모든 데이터 삭제하고 새로 시작
+docker-compose down -v
+docker-compose up -d postgres
+```
+
+## 환경 변수 관리
+
+
+### 환경 변수 변경 후
+
+```bash
+# 변경사항 적용
+docker-compose down
+docker-compose up -d --build
+```
+
+## 문제 해결
+
+### 포트 충돌 오류
+
+```
+Error: driver failed programming external connectivity
+```
+
+**해결 방법**:
+```bash
+# 충돌하는 프로세스 확인
+sudo lsof -i :5432  # PostgreSQL
+sudo lsof -i :4000  # Core API
+
+# 프로세스 종료
+sudo kill -9 <PID>
+```
+
+### 컨테이너 시작 실패
+
+```bash
+# 로그 확인
+docker-compose logs
+
+# 컨테이너 정리
+docker-compose down -v
+docker system prune -a
+
+# 다시 시작
+docker-compose up -d
+```
+
+### 데이터베이스 연결 오류
+
+```bash
+# 데이터베이스 상태 확인
+docker-compose exec postgres pg_isready -U carpoolink
+
+# 서비스에서 재시도
+docker-compose restart core-api
+```
+
+### 메모리 부족
+
+```bash
+# Docker 리소스 정리
+docker system prune -a --volumes
+
+# 또는 불필요한 이미지 삭제
+docker rmi <image-id>
+```
+
+## 디버깅
+
+### 특정 서비스 쉘 접속
+
+```bash
+# Core API 컨테이너 쉘 접속
+docker-compose exec core-api sh
+
+# 또는 bash
+docker-compose exec core-api bash
+```
+
+### 네트워크 확인
+
+```bash
+# 네트워크 상태 확인
+docker network inspect carpoolink-network
+
+# 컨테이너 간 통신 테스트
+docker-compose exec core-api ping chat-service
+```
+
+### 볼륨 확인
+
+```bash
+# 데이터베이스 볼륨 확인
+docker volume inspect carpoolink-postgres_data
+
+# 또는 직접 데이터 확인
+docker-compose exec postgres ls -la /var/lib/postgresql/data
+```
+
+## 성능 최적화
+
+### 리소스 제한 설정
+
+docker-compose.yml에서 `resources` 설정:
+
+```yaml
+services:
+  core-api:
+    # ... 기타 설정
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+```
+
+### 자동 정리
+
+```bash
+# 정기적으로 미사용 리소스 정리
+docker system prune -a --volumes --force
+```
+
+## 프로덕션 배포
+
+프로덕션 배포는 GitHub Actions 자동 파이프라인 사용
+
+## 참고 자료
+
+- [Docker Documentation](https://docs.docker.com)
+- [Docker Compose Documentation](https://docs.docker.com/compose/)
+- [PostgreSQL Documentation](https://www.postgresql.org/docs/)
+- [Node.js Documentation](https://nodejs.org/en/docs/)

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -1,27 +1,136 @@
-name: capstone-ap
+version: '3.8'
 
 services:
+  # 데이터베이스
   postgres:
     image: postgres:16-alpine
     container_name: carpoolink-postgres
-    restart: unless-stopped
-    env_file:
-      - ../../.env
-    ports:
-      - "${DB_PORT-5432}:5432"
     environment:
-      POSTGRES_USER: ${DB_USER}
-      POSTGRES_PASSWORD: ${DB_PASSWORD}
-      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USERNAME:-carpoolink}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-password}
+      POSTGRES_DB: ${DB_NAME:-carpoolink}
+      TZ: Asia/Seoul
+    ports:
+      - "${DB_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-root} -d ${DB_NAME}"]
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USERNAME:-carpoolink}"]
       interval: 10s
       timeout: 5s
       retries: 5
     networks:
       - carpoolink-network
+
+  # Core API (Port 4000)
+  core-api:
+    build:
+      context: ./services/core-api
+      dockerfile: Dockerfile
+    container_name: carpoolink-core-api
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      PORT: 4000
+      DATABASE_URL: postgresql://${DB_USERNAME:-carpoolink}:${DB_PASSWORD:-password}@postgres:5432/${DB_NAME:-carpoolink}
+      TZ: Asia/Seoul
+    ports:
+      - "4000:4000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ../../services/core-api:/app
+      - /app/node_modules
+    networks:
+      - carpoolink-network
+    command: npm run dev
+
+  # Chat Service (Port 4001)
+  chat-service:
+    build:
+      context: ./services/chat-service
+      dockerfile: Dockerfile
+    container_name: carpoolink-chat-service
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      CHAT_SERVICE_PORT: 4001
+      DATABASE_URL: postgresql://${DB_USERNAME:-carpoolink}:${DB_PASSWORD:-password}@postgres:5432/${DB_NAME:-carpoolink}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+      TZ: Asia/Seoul
+    ports:
+      - "4001:4001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ../../services/chat-service:/app
+      - /app/node_modules
+    networks:
+      - carpoolink-network
+    command: npm run dev
+
+  # Media Server (Port 4002)
+  media-server:
+    build:
+      context: ./services/media-server
+      dockerfile: Dockerfile
+    container_name: carpoolink-media-server
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      MEDIA_SERVER_PORT: 4002
+      DATABASE_URL: postgresql://${DB_USERNAME:-carpoolink}:${DB_PASSWORD:-password}@postgres:5432/${DB_NAME:-carpoolink}
+      CORS_ORIGIN: ${CORS_ORIGIN:-http://localhost:3000}
+      TZ: Asia/Seoul
+    ports:
+      - "4002:4002"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - ../../services/media-server:/app
+      - /app/node_modules
+    networks:
+      - carpoolink-network
+    command: npm run dev
+
+  # Question Service (Port 4003)
+  question-service:
+    build:
+      context: ./services/question-service
+      dockerfile: Dockerfile
+    container_name: carpoolink-question-service
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      QUESTION_SERVICE_PORT: 4003
+      TZ: Asia/Seoul
+    ports:
+      - "4003:4003"
+    volumes:
+      - ../../services/question-service:/app
+      - /app/node_modules
+    networks:
+      - carpoolink-network
+    command: npm run dev
+
+  # STT Service (Port 4004)
+  stt-service:
+    build:
+      context: ./services/stt-service
+      dockerfile: Dockerfile
+    container_name: carpoolink-stt-service
+    environment:
+      NODE_ENV: ${NODE_ENV:-development}
+      STT_SERVICE_PORT: 4004
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      TZ: Asia/Seoul
+    ports:
+      - "4004:4004"
+    volumes:
+      - ../../services/stt-service:/app
+      - /app/node_modules
+    networks:
+      - carpoolink-network
+    command: npm run dev
 
 networks:
   carpoolink-network:

--- a/infra/redis/README.md
+++ b/infra/redis/README.md
@@ -1,3 +1,0 @@
-# Redis
-
-질문 큐/채팅 pub-sub용 redis 설정 파일을 관리합니다.

--- a/package-lock.json
+++ b/package-lock.json
@@ -622,6 +622,8 @@
     },
     "node_modules/@lukeed/csprng": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lukeed/csprng/-/csprng-1.1.0.tgz",
+      "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA==",
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -629,6 +631,8 @@
     },
     "node_modules/@lukeed/uuid": {
       "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@lukeed/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
       "license": "MIT",
       "dependencies": {
         "@lukeed/csprng": "^1.1.0"
@@ -770,6 +774,9 @@
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -781,6 +788,9 @@
     },
     "node_modules/@nodelib/fs.stat": {
       "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -788,6 +798,9 @@
     },
     "node_modules/@nodelib/fs.walk": {
       "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -859,64 +872,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@prisma/debug": "5.22.0"
-      }
-    },
-    "node_modules/@redis/bloom": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/client": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "cluster-key-slot": "1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@node-rs/xxhash": "^1.1.0"
-      },
-      "peerDependenciesMeta": {
-        "@node-rs/xxhash": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@redis/json": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/search": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
-      }
-    },
-    "node_modules/@redis/time-series": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "@redis/client": "^5.11.0"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -1007,6 +962,8 @@
     },
     "node_modules/@types/debug": {
       "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
       "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
@@ -1020,6 +977,8 @@
     "node_modules/@types/events-alias": {
       "name": "@types/events",
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.3.tgz",
+      "integrity": "sha512-trOc4AAUThEz9hapPtSd7wf5tiQKvTtu5b371UxXdTuqzIh0ArcRspRP0i0Viu+LXstIQ1z96t1nsPxT9ol01g==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -1034,6 +993,8 @@
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1571,6 +1532,8 @@
     },
     "node_modules/awaitqueue": {
       "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-3.3.0.tgz",
+      "integrity": "sha512-zLxDhzQbzHmOyvxi7g3OlfR7jLrcmElStPxfLPpJkrFSDm71RSrY/MvsDA8Btlx8X1nOHUzGhQvc6bdUjL2f2w==",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.3"
@@ -1681,6 +1644,9 @@
     },
     "node_modules/braces": {
       "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1990,6 +1956,9 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2222,6 +2191,8 @@
     },
     "node_modules/engine.io-client": {
       "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.4.tgz",
+      "integrity": "sha512-+kjUJnZGwzewFDw951CDWcwj35vMNf2fcj7xQWOctq1F2i1jkDdVvdFG9kM/BEChymCH36KgjnW0NsL58JYRxw==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -2404,6 +2375,7 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2994,6 +2966,14 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
+    "node_modules/events-alias": {
+      "name": "events",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -3039,6 +3019,8 @@
     },
     "node_modules/fake-mediastreamtrack": {
       "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/fake-mediastreamtrack/-/fake-mediastreamtrack-2.2.1.tgz",
+      "integrity": "sha512-SITLc7UTDirSdgLGORrlmqjWLJtbtfIz/xO7DwVbJH3f0ds+NQok4ccl/WEzz49NSgiUlXf2wDW0+y5C+TO6EA==",
       "license": "ISC",
       "dependencies": {
         "@lukeed/uuid": "^2.0.1"
@@ -3053,6 +3035,9 @@
       "license": "MIT"
     },
     "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
       "version": "3.3.1",
       "dev": true,
       "license": "MIT",
@@ -3061,7 +3046,7 @@
         "@nodelib/fs.walk": "^1.2.3",
         "glob-parent": "^5.1.2",
         "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
+        "micromatch": "^4.0.8"
       },
       "engines": {
         "node": ">=8.6.0"
@@ -3079,6 +3064,9 @@
     },
     "node_modules/fastq": {
       "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3118,6 +3106,9 @@
     },
     "node_modules/fill-range": {
       "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3308,6 +3299,20 @@
       "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==",
       "license": "ISC"
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -3432,6 +3437,9 @@
     },
     "node_modules/glob-parent": {
       "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3551,6 +3559,7 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3826,6 +3835,9 @@
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3865,6 +3877,9 @@
     },
     "node_modules/is-glob": {
       "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3897,6 +3912,9 @@
     },
     "node_modules/is-number": {
       "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4067,6 +4085,9 @@
     },
     "node_modules/isexe": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4337,6 +4358,8 @@
     },
     "node_modules/mediasoup-client": {
       "version": "3.18.7",
+      "resolved": "https://registry.npmjs.org/mediasoup-client/-/mediasoup-client-3.18.7.tgz",
+      "integrity": "sha512-110f+zYEvSllYoF6didbIznIvSrTwMY9CqDhdWpq1M0goX1HWLoBdguiYB/MqcA858R2dOKDarP1R4vv5RAg1w==",
       "license": "ISC",
       "dependencies": {
         "@types/debug": "^4.1.12",
@@ -4359,6 +4382,8 @@
     },
     "node_modules/mediasoup-client/node_modules/supports-color": {
       "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -4395,6 +4420,9 @@
     },
     "node_modules/merge2": {
       "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4402,6 +4430,9 @@
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5034,6 +5065,9 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5131,6 +5165,9 @@
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5289,6 +5326,9 @@
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5381,20 +5421,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/redis": {
-      "version": "5.11.0",
-      "license": "MIT",
-      "dependencies": {
-        "@redis/bloom": "5.11.0",
-        "@redis/client": "5.11.0",
-        "@redis/json": "5.11.0",
-        "@redis/search": "5.11.0",
-        "@redis/time-series": "5.11.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "dev": true,
@@ -5475,6 +5501,9 @@
     },
     "node_modules/reusify": {
       "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5497,6 +5526,9 @@
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5595,6 +5627,8 @@
     },
     "node_modules/sdp-transform": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-3.0.0.tgz",
+      "integrity": "sha512-gfYVRGxjHkGF2NPeUWHw5u6T/KGFtS5/drPms73gaSuMaVHKCY3lpLnGDfswVQO0kddeePoti09AwhYP4zA8dQ==",
       "license": "MIT",
       "bin": {
         "sdp-verify": "checker.js"
@@ -5744,6 +5778,9 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5754,6 +5791,9 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5895,6 +5935,8 @@
     },
     "node_modules/socket.io-client": {
       "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
@@ -6254,6 +6296,9 @@
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6572,6 +6617,9 @@
     },
     "node_modules/which": {
       "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6697,6 +6745,8 @@
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6728,7 +6778,10 @@
     },
     "node_modules/zod": {
       "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6815,8 +6868,7 @@
       "name": "@carpoolink/question-service",
       "version": "0.1.0",
       "dependencies": {
-        "express": "^5.2.1",
-        "redis": "^5.8.2"
+        "express": "^5.2.1"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"

--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -7,7 +7,9 @@ datasource db {
 
 generator client {
   provider = "prisma-client-js"
+  binaryTargets = ["native", "debian-openssl-3.0.x"]
 }
+
 
 // Enums
 

--- a/services/chat-service/Dockerfile
+++ b/services/chat-service/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package-lock.json ./
 COPY services ./services
 COPY packages ./packages
 RUN npm ci --workspace services/chat-service --include-workspace-root
+RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || true
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/chat-service

--- a/services/chat-service/Dockerfile
+++ b/services/chat-service/Dockerfile
@@ -1,0 +1,25 @@
+# 1단계: 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# 의존성 설치
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사
+COPY . .
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 빌드 결과물 복사
+COPY --from=build /app /app
+
+EXPOSE 4001
+
+CMD ["npm", "start"]

--- a/services/chat-service/Dockerfile
+++ b/services/chat-service/Dockerfile
@@ -1,7 +1,13 @@
 # 1단계: 빌드
-FROM node:20-alpine AS build
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
+
+# 빌드 의존성
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip build-essential pkg-config openssl ca-certificates \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 # 의존성 설치
 COPY package.json package-lock.json ./
@@ -14,8 +20,10 @@ RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || tru
 WORKDIR /app/services/chat-service
 
 # 2단계: 실행
-FROM node:20-alpine
+FROM node:22-bookworm-slim
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/chat-service/Dockerfile
+++ b/services/chat-service/Dockerfile
@@ -4,11 +4,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 # 의존성 설치
-COPY package*.json ./
-RUN npm ci
+COPY package.json package-lock.json ./
+COPY services ./services
+COPY packages ./packages
+RUN npm ci --workspace services/chat-service --include-workspace-root
 
-# 소스 코드 복사
-COPY . .
+# 실행 워크스페이스로 이동
+WORKDIR /app/services/chat-service
 
 # 2단계: 실행
 FROM node:20-alpine
@@ -19,6 +21,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 빌드 결과물 복사
 COPY --from=build /app /app
+
+WORKDIR /app/services/chat-service
 
 EXPOSE 4001
 

--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package-lock.json ./
 COPY services ./services
 COPY packages ./packages
 RUN npm ci --workspace services/core-api --include-workspace-root
+RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/core-api

--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -1,0 +1,25 @@
+# 1단계: 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# 의존성 설치
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사
+COPY . .
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 빌드 결과물 복사
+COPY --from=build /app /app
+
+EXPOSE 4000
+
+CMD ["npm", "start"]

--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -4,11 +4,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 # 의존성 설치
-COPY package*.json ./
-RUN npm ci
+COPY package.json package-lock.json ./
+COPY services ./services
+COPY packages ./packages
+RUN npm ci --workspace services/core-api --include-workspace-root
 
-# 소스 코드 복사
-COPY . .
+# 실행 워크스페이스로 이동
+WORKDIR /app/services/core-api
 
 # 2단계: 실행
 FROM node:20-alpine
@@ -19,6 +21,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 빌드 결과물 복사
 COPY --from=build /app /app
+
+WORKDIR /app/services/core-api
 
 EXPOSE 4000
 

--- a/services/core-api/Dockerfile
+++ b/services/core-api/Dockerfile
@@ -1,7 +1,13 @@
 # 1단계: 빌드
-FROM node:20-alpine AS build
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
+
+# 빌드 의존성 (Prisma, 빌드 도구 등)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip build-essential pkg-config openssl ca-certificates \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 # 의존성 설치
 COPY package.json package-lock.json ./
@@ -14,8 +20,10 @@ RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma
 WORKDIR /app/services/core-api
 
 # 2단계: 실행
-FROM node:20-alpine
+FROM node:22-bookworm-slim
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -15,6 +15,7 @@ COPY services/media-server/package.json ./services/media-server/
 COPY packages ./packages
 
 RUN npm ci --workspace services/media-server --include-workspace-root
+RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || true
 
 # 코드 복사
 COPY services/media-server/ ./services/media-server/

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -1,0 +1,25 @@
+# 1단계: 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# 의존성 설치
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사
+COPY . .
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 빌드 결과물 복사
+COPY --from=build /app /app
+
+EXPOSE 4002
+
+CMD ["npm", "start"]

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -1,22 +1,29 @@
 # 1단계: 빌드
-FROM node:22-alpine AS build
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
 
 # mediasoup prebuilt 실패 시 로컬 빌드를 위한 의존성
-RUN apk add --no-cache python3 py3-pip make g++ linux-headers && ln -sf python3 /usr/bin/python
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip make g++ pkg-config \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 # 의존성 설치
 COPY package.json package-lock.json ./
-COPY services ./services
+COPY services/media-server/package.json ./services/media-server/
 COPY packages ./packages
+
 RUN npm ci --workspace services/media-server --include-workspace-root
+
+# 코드 복사
+COPY services/media-server/ ./services/media-server/
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/media-server
 
 # 2단계: 실행
-FROM node:22-alpine
+FROM node:22-bookworm-slim
 WORKDIR /app
 
 ENV TZ=Asia/Seoul

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -1,7 +1,10 @@
 # 1단계: 빌드
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 
 WORKDIR /app
+
+# mediasoup prebuilt 실패 시 로컬 빌드를 위한 의존성
+RUN apk add --no-cache python3 py3-pip make g++ linux-headers && ln -sf python3 /usr/bin/python
 
 # 의존성 설치
 COPY package.json package-lock.json ./
@@ -13,7 +16,7 @@ RUN npm ci --workspace services/media-server --include-workspace-root
 WORKDIR /app/services/media-server
 
 # 2단계: 실행
-FROM node:20-alpine
+FROM node:22-alpine
 WORKDIR /app
 
 ENV TZ=Asia/Seoul

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # mediasoup prebuilt 실패 시 로컬 빌드를 위한 의존성
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip make g++ pkg-config \
+    && apt-get install -y --no-install-recommends python3 python3-pip make g++ pkg-config openssl ca-certificates \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
@@ -26,6 +26,8 @@ WORKDIR /app/services/media-server
 # 2단계: 실행
 FROM node:22-bookworm-slim
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -4,11 +4,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 # 의존성 설치
-COPY package*.json ./
-RUN npm ci
+COPY package.json package-lock.json ./
+COPY services ./services
+COPY packages ./packages
+RUN npm ci --workspace services/media-server --include-workspace-root
 
-# 소스 코드 복사
-COPY . .
+# 실행 워크스페이스로 이동
+WORKDIR /app/services/media-server
 
 # 2단계: 실행
 FROM node:20-alpine
@@ -19,6 +21,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 빌드 결과물 복사
 COPY --from=build /app /app
+
+WORKDIR /app/services/media-server
 
 EXPOSE 4002
 

--- a/services/question-service/Dockerfile
+++ b/services/question-service/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package-lock.json ./
 COPY services ./services
 COPY packages ./packages
 RUN npm ci --workspace services/question-service --include-workspace-root
+RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || true
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/question-service

--- a/services/question-service/Dockerfile
+++ b/services/question-service/Dockerfile
@@ -1,0 +1,25 @@
+# 1단계: 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# 의존성 설치
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사
+COPY . .
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 빌드 결과물 복사
+COPY --from=build /app /app
+
+EXPOSE 4003
+
+CMD ["npm", "start"]

--- a/services/question-service/Dockerfile
+++ b/services/question-service/Dockerfile
@@ -1,7 +1,13 @@
 # 1단계: 빌드
-FROM node:20-alpine AS build
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
+
+# 빌드 의존성
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip build-essential pkg-config openssl ca-certificates \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 # 의존성 설치
 COPY package.json package-lock.json ./
@@ -14,8 +20,10 @@ RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || tru
 WORKDIR /app/services/question-service
 
 # 2단계: 실행
-FROM node:20-alpine
+FROM node:22-bookworm-slim
 WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/question-service/Dockerfile
+++ b/services/question-service/Dockerfile
@@ -4,11 +4,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 # 의존성 설치
-COPY package*.json ./
-RUN npm ci
+COPY package.json package-lock.json ./
+COPY services ./services
+COPY packages ./packages
+RUN npm ci --workspace services/question-service --include-workspace-root
 
-# 소스 코드 복사
-COPY . .
+# 실행 워크스페이스로 이동
+WORKDIR /app/services/question-service
 
 # 2단계: 실행
 FROM node:20-alpine
@@ -19,6 +21,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 빌드 결과물 복사
 COPY --from=build /app /app
+
+WORKDIR /app/services/question-service
 
 EXPOSE 4003
 

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -9,8 +9,7 @@
         "dev": "nodemon src/server.js"
     },
     "dependencies": {
-        "express": "^5.2.1",
-        "redis": "^5.8.2"
+        "express": "^5.2.1"
     },
     "devDependencies": {
         "nodemon": "^3.1.14"

--- a/services/stt-service/Dockerfile
+++ b/services/stt-service/Dockerfile
@@ -1,0 +1,28 @@
+# 1단계: 빌드
+FROM node:20-alpine AS build
+
+WORKDIR /app
+
+# 의존성 설치
+COPY package*.json ./
+RUN npm ci
+
+# 소스 코드 복사
+COPY . .
+
+# 2단계: 실행
+FROM node:20-alpine
+WORKDIR /app
+
+# FFmpeg 설치 (fluent-ffmpeg 필요)
+RUN apk add --no-cache ffmpeg
+
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 빌드 결과물 복사
+COPY --from=build /app /app
+
+EXPOSE 4004
+
+CMD ["npm", "start"]

--- a/services/stt-service/Dockerfile
+++ b/services/stt-service/Dockerfile
@@ -8,6 +8,7 @@ COPY package.json package-lock.json ./
 COPY services ./services
 COPY packages ./packages
 RUN npm ci --workspace services/stt-service --include-workspace-root
+RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || true
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/stt-service

--- a/services/stt-service/Dockerfile
+++ b/services/stt-service/Dockerfile
@@ -1,24 +1,37 @@
 # 1단계: 빌드
-FROM node:20-alpine AS build
+# 1단계: 빌드
+FROM node:22-bookworm-slim AS build
 
 WORKDIR /app
+
+# 빌드 의존성 (FFmpeg, Prisma 등)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip build-essential pkg-config ffmpeg openssl ca-certificates \
+    && ln -sf /usr/bin/python3 /usr/bin/python \
+    && rm -rf /var/lib/apt/lists/*
 
 # 의존성 설치
 COPY package.json package-lock.json ./
 COPY services ./services
 COPY packages ./packages
+#COPY services/stt-service/package.json ./services/stt-service/
+#COPY packages/database/package.json ./packages/database/
+
 RUN npm ci --workspace services/stt-service --include-workspace-root
+
+#COPY packages/database ./packages/database
+#COPY services/stt-service ./services/stt-service
+
 RUN npx prisma generate --schema=./packages/database/prisma/schema.prisma || true
 
 # 실행 워크스페이스로 이동
 WORKDIR /app/services/stt-service
 
 # 2단계: 실행
-FROM node:20-alpine
+FROM node:22-bookworm-slim
 WORKDIR /app
 
-# FFmpeg 설치 (fluent-ffmpeg 필요)
-RUN apk add --no-cache ffmpeg
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/stt-service/Dockerfile
+++ b/services/stt-service/Dockerfile
@@ -4,11 +4,13 @@ FROM node:20-alpine AS build
 WORKDIR /app
 
 # 의존성 설치
-COPY package*.json ./
-RUN npm ci
+COPY package.json package-lock.json ./
+COPY services ./services
+COPY packages ./packages
+RUN npm ci --workspace services/stt-service --include-workspace-root
 
-# 소스 코드 복사
-COPY . .
+# 실행 워크스페이스로 이동
+WORKDIR /app/services/stt-service
 
 # 2단계: 실행
 FROM node:20-alpine
@@ -22,6 +24,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # 빌드 결과물 복사
 COPY --from=build /app /app
+
+WORKDIR /app/services/stt-service
 
 EXPOSE 4004
 

--- a/services/stt-service/package.json
+++ b/services/stt-service/package.json
@@ -9,6 +9,7 @@
         "dev": "nodemon src/server.js"
     },
     "dependencies": {
+        "@carpoolink/database": "*",
         "express": "^5.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "multer": "^2.1.1",


### PR DESCRIPTION
## 연관된 이슈

#13 

## 작업 내용

CI/CD 자동 배포 파이프라인을 구축했습니다.

해당 pr 머지시 앞으로 main에 백엔드 변경사항이 푸시될 때마다 배포됩니다.
즉, 백엔드 pr을 main에 머지하면 2-3분 간은 배포 환경 백엔드에 접근 불가합니다.

배포가 완료되면 ec2 인스턴스에서 core-api, chat-service, media-server, question-service, stt-service 총 5개 docker 컨테이너가 실행되고, http ://15.165.13.11:{각 서비스 포트 번호}로 접근이 가능합니다. (ex. http://15.165.13.11:4000/health ) 현재도 4000-4003 범위는 접근 가능합니다. 포트 번호나 기타 환경 변수는 노션(문서-환경변수) 참고해주세요.

## 체크 리스트
- [x] 코드가 정상적으로 컴파일되나요?
- [x] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [x] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

@o0Orangee 빌드에 필요한 의존성이 빠져있어서 stt-service의 package.json에 한 줄 추가했습니다. 확인 부탁드려요!