### PR TITLE
[User] 마이페이지 및 사용자/설문 데이터 연동

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -12,13 +12,12 @@ import {
   Star, 
   ScrollText, 
   HelpCircle, 
-  MessageSquare 
+  MessageSquare,
+  LogOut // 💡 1. 로그아웃 아이콘 추가 임포트
 } from "lucide-react";
 
-// 💡 API 통신을 위한 apiClient 임포트 (경로는 실제 위치에 맞게 수정하세요)
 import apiClient from "@/lib/apiClient"; 
 
-// 서버에서 받아올 사용자 데이터 타입 정의
 interface UserProfile {
   nickname: string;
   remainingTickets: number; 
@@ -27,36 +26,26 @@ interface UserProfile {
 
 export default function MyPage() {
   const router = useRouter();
-  
-  // 💡 상태 관리 추가
   const [user, setUser] = useState<UserProfile | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 💡 데이터 연동 및 접근 제어 로직
   useEffect(() => {
-    // 1. 미로그인 접근 차단 (Private Route)
     const userId = localStorage.getItem("userId");
     if (!userId) {
       alert("로그인이 필요한 서비스입니다.");
-      router.push("/login"); // 로그인 페이지로 리다이렉트
+      router.push("/login"); 
       return;
     }
 
-    // 💡 2. 데이터 통신 함수 수정
     const fetchUserData = async () => {
       try {
-        // 배포된 Core API(포트 4000)로 내 정보(/users/me)를 요청합니다.
-        // 인터셉터가 알아서 IP 주소와 신분증(x-user-id)을 붙여서 날려줍니다!
         const userRes = await apiClient.get("/users/me");
-        
-        // 서버에서 받아온 응답(userRes.data)을 상태에 예쁘게 담아줍니다.
         setUser({
           nickname: userRes.data.nickname || "사용자",
           remainingTickets: userRes.data.tickets ?? 0,
           surveyType: userRes.data.surveyType ?? "유형 없음",
         });
       } catch (error) {
-        // 401, 403 에러는 apiClient의 응답 인터셉터가 알아서 잡아서 로그인 페이지로 튕겨냅니다.
         console.error("마이페이지 데이터 호출 실패:", error);
       } finally {
         setIsLoading(false);
@@ -66,7 +55,18 @@ export default function MyPage() {
     fetchUserData();
   }, [router]);
 
-  // 로딩 중일 때 보여줄 UI (기존 디자인 무너짐 방지)
+  // 💡 2. 로그아웃 처리 함수 추가
+  const handleLogout = () => {
+    if (window.confirm("로그아웃 하시겠습니까?")) {
+      // 로컬 스토리지에 있는 인증 정보(신분증) 모두 삭제
+      localStorage.removeItem("userId");
+      localStorage.removeItem("accessToken"); // 토큰이 있다면 함께 삭제
+      
+      // 로그인 페이지로 이동
+      router.push("/login");
+    }
+  };
+
   if (isLoading || !user) {
     return (
       <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] pb-[80px] items-center justify-center">
@@ -88,17 +88,14 @@ export default function MyPage() {
 
       {/* 2. 멘티 프로필 영역 */}
       <div className="flex items-center gap-4 px-5 py-6">
-        {/* 멘티 로고 아이콘 */}
         <div className="w-[72px] h-[72px] bg-[#111116] rounded-2xl flex flex-col items-center justify-center text-white shrink-0 shadow-sm">
           <span className="text-[15px] font-extrabold mb-1">멘티</span>
           <span className="text-[10px] font-bold tracking-widest">—O—O—</span>
         </div>
         
         <div className="flex items-center gap-2">
-          {/* 💡 하드코딩 제거: 서버에서 받아온 닉네임 렌더링 */}
           <h2 className="text-[20px] font-semibold tracking-tight">{user.nickname}</h2>
           
-          {/* 💡 하드코딩 제거: 서버에서 받아온 유형 뱃지 렌더링 */}
           {user.surveyType !== "유형 없음" && (
             <span className="inline-block bg-[#FFCC00] text-black text-[12px] font-semibold px-2.5 py-1 rounded-md w-fit">
               {user.surveyType}
@@ -111,7 +108,6 @@ export default function MyPage() {
       <div className="mx-5 mb-8 bg-[#F8F9FA] rounded-2xl p-4 flex items-center justify-between border border-gray-100 shadow-sm">
         <span className="text-[15px] font-bold text-gray-700 ml-1">사전 질문권 개수</span>
         <div className="flex items-center gap-3">
-          {/* 💡 하드코딩 제거: 서버에서 받아온 티켓 수 렌더링 */}
           <span className="text-[18px] font-extrabold">
             {user.remainingTickets} <span className="text-[14px] font-medium text-gray-500">개</span>
           </span>
@@ -184,6 +180,18 @@ export default function MyPage() {
           </div>
           <ChevronRight className="w-5 h-5 text-gray-300" />
         </Link>
+
+        {/* 💡 3. 로그아웃 버튼 (서브 메뉴 하단에 추가) */}
+        <button 
+          onClick={handleLogout} 
+          className="flex items-center justify-between py-4 group w-full text-left"
+        >
+          <div className="flex items-center gap-3">
+            <LogOut className="w-[22px] h-[22px] text-red-500 group-hover:text-red-600 transition-colors" strokeWidth={2} />
+            <span className="text-[16px] font-medium text-red-500 group-hover:text-red-600 transition-all">로그아웃</span>
+          </div>
+          <ChevronRight className="w-5 h-5 text-gray-300" />
+        </button>
       </div>
 
     </main>

--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { 
   Settings, 
@@ -13,7 +15,57 @@ import {
   MessageSquare 
 } from "lucide-react";
 
+// 💡 API 통신을 위한 apiClient 임포트 (경로는 실제 위치에 맞게 수정하세요)
+import apiClient from "@/lib/apiClient"; 
+
+// 서버에서 받아올 사용자 데이터 타입 정의
+interface UserProfile {
+  nickname: string;
+  remainingTickets: number; 
+  surveyType: string;       
+}
+
 export default function MyPage() {
+  const router = useRouter();
+  
+  // 💡 상태 관리 추가
+  const [user, setUser] = useState<UserProfile | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 💡 데이터 연동 및 접근 제어 로직
+  useEffect(() => {
+    
+
+    // 2. 서버 데이터 호출
+    const fetchUserData = async () => {
+      try {
+        const response = await apiClient.get("/users/me");
+        
+        // 백엔드 응답 데이터를 상태에 저장
+        setUser({
+          nickname: response.data.nickname || "사용자",
+          remainingTickets: response.data.tickets ?? 0,
+          surveyType: response.data.surveyType ?? "유형 없음",
+        });
+      } catch (error) {
+        console.error("사용자 정보를 불러오는 데 실패했습니다.", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchUserData();
+  }, [router]);
+
+  // 로딩 중일 때 보여줄 UI (기존 디자인 무너짐 방지)
+  if (isLoading || !user) {
+    return (
+      <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] pb-[80px] items-center justify-center">
+        <p className="text-gray-500 font-medium">데이터를 불러오는 중입니다... ⏳</p>
+      </main>
+    );
+  }
+
   return (
     <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] pb-[80px]">
       
@@ -33,12 +85,16 @@ export default function MyPage() {
           <span className="text-[10px] font-bold tracking-widest">—O—O—</span>
         </div>
         
-        {/* 💡 수정됨: flex-col 대신 flex items-center를 사용하여 닉네임과 뱃지를 가로로 배치합니다. */}
         <div className="flex items-center gap-2">
-          <h2 className="text-[20px] font-semibold tracking-tight">김세종</h2>
-          <span className="inline-block bg-[#FFCC00] text-black text-[12px] font-semibold px-2.5 py-1 rounded-md w-fit">
-            창의적인 모험가
-          </span>
+          {/* 💡 하드코딩 제거: 서버에서 받아온 닉네임 렌더링 */}
+          <h2 className="text-[20px] font-semibold tracking-tight">{user.nickname}</h2>
+          
+          {/* 💡 하드코딩 제거: 서버에서 받아온 유형 뱃지 렌더링 */}
+          {user.surveyType !== "유형 없음" && (
+            <span className="inline-block bg-[#FFCC00] text-black text-[12px] font-semibold px-2.5 py-1 rounded-md w-fit">
+              {user.surveyType}
+            </span>
+          )}
         </div>
       </div>
 
@@ -46,7 +102,10 @@ export default function MyPage() {
       <div className="mx-5 mb-8 bg-[#F8F9FA] rounded-2xl p-4 flex items-center justify-between border border-gray-100 shadow-sm">
         <span className="text-[15px] font-bold text-gray-700 ml-1">사전 질문권 개수</span>
         <div className="flex items-center gap-3">
-          <span className="text-[18px] font-extrabold">5 <span className="text-[14px] font-medium text-gray-500">개</span></span>
+          {/* 💡 하드코딩 제거: 서버에서 받아온 티켓 수 렌더링 */}
+          <span className="text-[18px] font-extrabold">
+            {user.remainingTickets} <span className="text-[14px] font-medium text-gray-500">개</span>
+          </span>
           <button className="bg-[#333333] hover:bg-black text-white text-[13px] font-bold px-4 py-2 rounded-lg transition-colors active:scale-95">
             충전
           </button>

--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -34,21 +34,30 @@ export default function MyPage() {
 
   // 💡 데이터 연동 및 접근 제어 로직
   useEffect(() => {
-    
+    // 1. 미로그인 접근 차단 (Private Route)
+    const userId = localStorage.getItem("userId");
+    if (!userId) {
+      alert("로그인이 필요한 서비스입니다.");
+      router.push("/login"); // 로그인 페이지로 리다이렉트
+      return;
+    }
 
-    // 2. 서버 데이터 호출
+    // 💡 2. 데이터 통신 함수 수정
     const fetchUserData = async () => {
       try {
-        const response = await apiClient.get("/users/me");
+        // 배포된 Core API(포트 4000)로 내 정보(/users/me)를 요청합니다.
+        // 인터셉터가 알아서 IP 주소와 신분증(x-user-id)을 붙여서 날려줍니다!
+        const userRes = await apiClient.get("/users/me");
         
-        // 백엔드 응답 데이터를 상태에 저장
+        // 서버에서 받아온 응답(userRes.data)을 상태에 예쁘게 담아줍니다.
         setUser({
-          nickname: response.data.nickname || "사용자",
-          remainingTickets: response.data.tickets ?? 0,
-          surveyType: response.data.surveyType ?? "유형 없음",
+          nickname: userRes.data.nickname || "사용자",
+          remainingTickets: userRes.data.tickets ?? 0,
+          surveyType: userRes.data.surveyType ?? "유형 없음",
         });
       } catch (error) {
-        console.error("사용자 정보를 불러오는 데 실패했습니다.", error);
+        // 401, 403 에러는 apiClient의 응답 인터셉터가 알아서 잡아서 로그인 페이지로 튕겨냅니다.
+        console.error("마이페이지 데이터 호출 실패:", error);
       } finally {
         setIsLoading(false);
       }

--- a/apps/demo-web/app/login/page.tsx
+++ b/apps/demo-web/app/login/page.tsx
@@ -3,6 +3,8 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { User, ArrowRight } from "lucide-react";
+// 💡 실제 통신을 위해 apiClient를 불러옵니다.
+import apiClient from "@/lib/apiClient"; 
 
 export default function LoginPage() {
   const [userId, setUserId] = useState("");
@@ -10,7 +12,8 @@ export default function LoginPage() {
   const [errorMsg, setErrorMsg] = useState("");
   const router = useRouter();
 
-  const handleLogin = (e: React.FormEvent) => {
+  // 💡 async 함수로 변경하여 API 통신을 기다릴 수 있게 합니다.
+  const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setErrorMsg("");
 
@@ -21,22 +24,36 @@ export default function LoginPage() {
 
     setIsLoading(true);
 
-    // 💡 [Mock Data] 백엔드 API 연동 전 테스트를 위한 가상 분기 처리 로직
-    setTimeout(() => {
-      // 1. 사전설문 데이터가 없는 멘티인 경우 -> 사전설문 페이지로 이동
-      if (userId === "mentee_new") {
-        router.push("/survey");
-      } 
-      // 2. 그 외 (멘토이거나 사전설문 데이터가 있는 멘티) -> 홈(멘토 목록) 화면으로 이동
-      else if (userId === "mentor1" || userId === "mentee_old") {
+    try {
+      // 💡 [임시 우회 적용] POST /login 대신 GET /users/exists 엔드포인트를 찌릅니다.
+      // 백엔드 미들웨어(getUserIdFromRequest)가 헤더에서 값을 찾으므로 headers에 담아줍니다.
+      const response = await apiClient.get("/users/exists", {
+        headers: {
+          "x-user-id": userId,
+        },
+      });
+
+      // 1. DB에 해당 유저가 존재하는 경우 (exists === true)
+      if (response.data.exists) {
+        // 로컬 스토리지에 백엔드에서 확인된 실제 userId를 저장하여 "로그인 상태"로 만듭니다.
+        localStorage.setItem("userId", response.data.user.userId.toString());
+
+        // 💡 참고: 현재 /users/exists API는 설문(surveyType) 데이터를 반환하지 않습니다.
+        // 따라서 임시 우회 상태에서는 세부 분기 처리를 생략하고, 
+        // 일단 모두 홈("/")으로 통과시키도록 처리했습니다.
         router.push("/");
-      } 
-      // 3. 등록되지 않은 테스트 아이디
-      else {
-        setErrorMsg("존재하지 않는 아이디입니다. (테스트: mentee_new, mentee_old, mentor1)");
-        setIsLoading(false);
+      } else {
+        // 2. DB에 유저가 없는 경우 (exists === false)
+        setErrorMsg("존재하지 않는 아이디입니다.");
       }
-    }, 600); // 실제 API 통신처럼 살짝 딜레이를 줍니다.
+
+    } catch (error: any) {
+      console.error("로그인 실패:", error);
+      // 서버가 죽었거나 네트워크 통신 자체가 실패했을 때의 에러 처리
+      setErrorMsg("서버 통신 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   return (
@@ -95,19 +112,6 @@ export default function LoginPage() {
           </button>
         </form>
 
-      </div>
-
-      {/* 테스트용 안내 뱃지 (나중에 백엔드 붙일 때 삭제하시면 됩니다) */}
-      <div className="mt-8 flex gap-2">
-        <button onClick={() => setUserId('mentee_new')} className="text-[11px] font-bold bg-white border border-gray-200 text-gray-500 px-3 py-1.5 rounded-full hover:bg-gray-50 transition-colors">
-          테스트: 신규 멘티
-        </button>
-        <button onClick={() => setUserId('mentee_old')} className="text-[11px] font-bold bg-white border border-gray-200 text-gray-500 px-3 py-1.5 rounded-full hover:bg-gray-50 transition-colors">
-          테스트: 기존 멘티
-        </button>
-        <button onClick={() => setUserId('mentor1')} className="text-[11px] font-bold bg-white border border-gray-200 text-gray-500 px-3 py-1.5 rounded-full hover:bg-gray-50 transition-colors">
-          테스트: 멘토
-        </button>
       </div>
 
     </main>

--- a/apps/demo-web/app/login/page.tsx
+++ b/apps/demo-web/app/login/page.tsx
@@ -12,7 +12,7 @@ export default function LoginPage() {
   const [errorMsg, setErrorMsg] = useState("");
   const router = useRouter();
 
-  // 💡 async 함수로 변경하여 API 통신을 기다릴 수 있게 합니다.
+// 💡 async 함수로 변경하여 API 통신을 기다릴 수 있게 합니다.
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     setErrorMsg("");
@@ -25,31 +25,44 @@ export default function LoginPage() {
     setIsLoading(true);
 
     try {
-      // 💡 [임시 우회 적용] POST /login 대신 GET /users/exists 엔드포인트를 찌릅니다.
-      // 백엔드 미들웨어(getUserIdFromRequest)가 헤더에서 값을 찾으므로 headers에 담아줍니다.
+      // 💡 1. [임시 우회 적용] POST /login 대신 GET /users/exists 엔드포인트를 찌릅니다.
       const response = await apiClient.get("/users/exists", {
         headers: {
           "x-user-id": userId,
         },
       });
 
-      // 1. DB에 해당 유저가 존재하는 경우 (exists === true)
+      // DB에 해당 유저가 존재하는 경우 (exists === true)
       if (response.data.exists) {
-        // 로컬 스토리지에 백엔드에서 확인된 실제 userId를 저장하여 "로그인 상태"로 만듭니다.
+        // 로컬 스토리지에 백엔드에서 확인된 실제 userId를 저장
         localStorage.setItem("userId", response.data.user.userId.toString());
 
-        // 💡 참고: 현재 /users/exists API는 설문(surveyType) 데이터를 반환하지 않습니다.
-        // 따라서 임시 우회 상태에서는 세부 분기 처리를 생략하고, 
-        // 일단 모두 홈("/")으로 통과시키도록 처리했습니다.
-        router.push("/");
+        // 💡 2. 설문조사 여부 확인 로직 추가
+        try {
+          // 방금 로컬 스토리지에 저장한 userId를 기반으로 내 상세 정보(/users/me)를 불러옵니다.
+          const meResponse = await apiClient.get("/users/me");
+          const userData = meResponse.data;
+
+          // 유저가 멘티(MENTEE)이면서, 설문결과(surveyResult)가 없는 경우 /survey로 튕겨냅니다.
+          if (userData.role === "MENTEE" && !userData.menteeProfile?.surveyResult) {
+            router.push("/survey");
+          } else {
+            // 멘토이거나 이미 설문을 완료한 멘티인 경우 홈으로 이동
+            router.push("/");
+          }
+        } catch (meError) {
+          console.error("유저 상세 정보 호출 실패:", meError);
+          // 만약 상세 정보 호출에 실패하더라도 일단 로그인은 된 상태이므로 홈으로 보냅니다.
+          router.push("/");
+        }
+
       } else {
-        // 2. DB에 유저가 없는 경우 (exists === false)
+        // DB에 유저가 없는 경우 (exists === false)
         setErrorMsg("존재하지 않는 아이디입니다.");
       }
 
     } catch (error: any) {
       console.error("로그인 실패:", error);
-      // 서버가 죽었거나 네트워크 통신 자체가 실패했을 때의 에러 처리
       setErrorMsg("서버 통신 중 오류가 발생했습니다.");
     } finally {
       setIsLoading(false);

--- a/apps/demo-web/lib/apiClient.ts
+++ b/apps/demo-web/lib/apiClient.ts
@@ -6,15 +6,18 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true,
+  //withCredentials: true,
 });
 
 // 2. 요청 인터셉터 (Request Interceptor): API를 쏠 때마다 헤더에 userId를 챙겨 넣음
+// apiClient.ts 내부의 요청 인터셉터 부분
 apiClient.interceptors.request.use((config) => {
   const userId = localStorage.getItem('userId');
-  if (userId) {
+  
+  if (userId && !config.headers['x-user-id']) {
     config.headers['x-user-id'] = userId;
   }
+  
   return config;
 });
 

--- a/apps/demo-web/lib/apiClient.ts
+++ b/apps/demo-web/lib/apiClient.ts
@@ -1,38 +1,24 @@
-// src/lib/apiClient.ts
 import axios from 'axios';
 
-// 1. 전역 Axios 인스턴스 생성
+// 1. Core API 클라이언트 생성 (환경 변수 적용)
 const apiClient = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: process.env.NEXT_PUBLIC_CORE_API_URL || 'http://localhost:3001',
   headers: {
     'Content-Type': 'application/json',
   },
-  timeout: 5000,
+  withCredentials: true,
 });
 
-// 2. 요청 인터셉터 (Request Interceptor)
-// apps/demo-web/src/lib/apiClient.ts 의 요청 인터셉터 부분
-apiClient.interceptors.request.use(
-  (config) => {
-    if (typeof window !== 'undefined') {
-      const userId = localStorage.getItem('userId') || '101'; 
-      
-      // 💡 수정된 부분: 배열 대괄호 방식 대신 .set() 메서드 사용
-      config.headers.set('x-user-id', userId);
-      
-      const token = localStorage.getItem('accessToken');
-      if (token) {
-        config.headers.set('Authorization', `Bearer ${token}`);
-      }
-    }
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
+// 2. 요청 인터셉터 (Request Interceptor): API를 쏠 때마다 헤더에 userId를 챙겨 넣음
+apiClient.interceptors.request.use((config) => {
+  const userId = localStorage.getItem('userId');
+  if (userId) {
+    config.headers['x-user-id'] = userId;
   }
-);
+  return config;
+});
 
-// 3. 응답 인터셉터 (Response Interceptor)
+// 3. 응답 인터셉터 (Response Interceptor): 지우면 안 되는 부분! 백엔드에서 쫓겨나면 로그인 창으로 보냄
 apiClient.interceptors.response.use(
   (response) => {
     return response;
@@ -42,9 +28,9 @@ apiClient.interceptors.response.use(
     if (error.response && (error.response.status === 401 || error.response.status === 403)) {
       if (typeof window !== 'undefined') {
         console.warn('인증이 만료되었거나 권한이 없습니다. 다시 로그인해 주세요.');
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('userId');
-        window.location.href = '/login'; 
+        localStorage.removeItem('accessToken'); // 토큰 지우기
+        localStorage.removeItem('userId');      // ID 지우기
+        window.location.href = '/login';        // 로그인 페이지로 강제 이동
       }
     }
     return Promise.reject(error);

--- a/package-lock.json
+++ b/package-lock.json
@@ -776,7 +776,6 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -790,7 +789,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -800,7 +798,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -1646,7 +1643,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -1847,13 +1843,6 @@
       "version": "0.0.1",
       "license": "MIT"
     },
-    "node_modules/cluster-key-slot": {
-      "version": "1.1.2",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "dev": true,
@@ -1958,7 +1947,6 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2375,7 +2363,6 @@
     },
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2937,6 +2924,16 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/events-alias": {
+      "name": "events",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2958,16 +2955,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/events-alias": {
-      "name": "events",
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
       }
     },
     "node_modules/express": {
@@ -3059,7 +3046,6 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3101,7 +3087,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -3432,7 +3417,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -3552,7 +3536,6 @@
     },
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3830,7 +3813,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -3872,7 +3854,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -3907,7 +3888,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -4080,7 +4060,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4415,7 +4394,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -4425,7 +4403,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -5060,7 +5037,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5160,7 +5136,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -5321,7 +5296,6 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5496,7 +5470,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -5521,7 +5494,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5773,7 +5745,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5786,7 +5757,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6291,7 +6261,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -6612,7 +6581,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6774,7 +6742,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "devOptional": true,
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -6871,6 +6838,7 @@
       "name": "@carpoolink/stt-service",
       "version": "0.1.0",
       "dependencies": {
+        "@carpoolink/database": "*",
         "express": "^5.2.1",
         "fluent-ffmpeg": "^2.1.3",
         "multer": "^2.1.1",


### PR DESCRIPTION
## 연관된 이슈

#46 

## 작업 내용

- 로컬 환경이 아닌 배포 환경에서 동작하도록 설정
- 임시 목업 데이터 삭제 및 API 연결
- 마이페이지에 미로그인 접근 차단 기능 및 로그아웃 기능 추가
- 미설문 멘티는 로그인 시 사전설문 페이지로 이동하도록 라우팅 처리

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

**리뷰 방법**
1. /apps/demo-web 폴더에 `.env.local` 파일 생성 후 아래 코드 저장.
```
# 로컬에서 백엔드 켜서 작업할 때 (필요시 주석 해제해서 사용)
# NEXT_PUBLIC_CORE_API_URL=http://localhost:4000

# 배포 개발 서버 IP
NEXT_PUBLIC_CORE_API_URL=http://15.165.13.11:4000
NEXT_PUBLIC_CHAT_API_URL=http://15.165.13.11:4001
NEXT_PUBLIC_MEDIA_API_URL=http://15.165.13.11:4002
NEXT_PUBLIC_QUESTION_API_URL=http://15.165.13.11:4003
NEXT_PUBLIC_STT_API_URL=http://15.165.13.11:4004
```
2. /apps/demo-web 폴더에서 터미널 실행 후 `npm run dev` 명령어 실행
3. http://localhost:3000/mypage 링크로 바로 접속 시 "로그인이 필요한 서비스입니다" 문구 출력 확인
4. 3번에서 확인 버튼 클릭 후, 로그인 페이지로의 자동 이동 여부 확인
5. 로그인 페이지에서 "1"로 로그인 시 마이페이지의 사용자 닉네임이 "테스트멘토"인지 확인
6. 4번에서 로그아웃 버튼 클릭 후, 로그인 페이지로의 자동 이동 여부 확인
7. 로그인 페이지에서 "2"로 로그인 시 사전설문 페이지로 이동하는지 확인
8. 7번에서 나가기 클릭 후, 마이페이지로 이동하여 사용자 닉네임이 "테스트멘티"인지 확인
9. 로그인 페이지에서 "1", "2"를 제외한 무작위 아이디로 로그인 시도 시 "존재하지 않는 아이디입니다." 출력 및 로그인 제한 여부 확인