### PR TITLE
[Mentors] 멘토 목록 조회 및 상세페이지 연동

### DIFF
--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -51,9 +51,10 @@ export default function HomePage() {
     fetchMentors();
   }, []);
 
-  // 카테고리 필터 + 검색어 필터 동시 적용
+  // 카테고리 필터 + 검색어 필터 + 고정 정렬 적용
   const filteredMentors = useMemo(() => {
-    let list = mentors;
+    // 원본 배열이 변형되지 않도록 얕은 복사 생성
+    let list = [...mentors];
 
     // 1. 카테고리 필터링
     if (activeCategory !== "전체") {
@@ -70,6 +71,12 @@ export default function HomePage() {
         mentor.nickname.toLowerCase().includes(q)
       );
     }
+
+    // 3. 고정 정렬 (mentorId 오름차순: 오래된 멘토부터 / 내림차순을 원하면 b - a로 변경)
+    // 업데이트 순서에 영향을 받지 않도록 고유 ID 값으로 정렬을 강제 고정합니다.
+    list.sort((a, b) => {
+      return Number(a.mentorId) - Number(b.mentorId);
+    });
 
     return list;
   }, [mentors, activeCategory, searchQuery]);

--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -39,7 +39,7 @@ export default function HomePage() {
   useEffect(() => {
     const fetchMentors = async () => {
       try {
-        const res = await apiClient.get("/mentors");
+        const res = await apiClient.get("/api/mentors");
         setMentors(res.data.mentors || []);
       } catch (error) {
         console.error("멘토 목록 로딩 실패:", error);

--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -81,7 +81,7 @@ export default function HomePage() {
       <header className={`flex items-center justify-between px-5 py-4 sticky top-0 bg-white z-20 transition-all duration-300 ${isSearchOpen ? 'pb-2' : ''}`}>
         {!isSearchOpen ? (
           <>
-            <button className="flex items-center gap-1 text-[20px] font-extrabold tracking-tight">
+            <button className="flex items-center gap-1 text-[20px] font-bold tracking-tight">
               전체 지역 <ChevronDown className="w-5 h-5 mt-0.5" strokeWidth={2.5} />
             </button>
             <button 
@@ -168,7 +168,7 @@ export default function HomePage() {
                   <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-snug mb-1 truncate">
                     {mentor.nickname} 멘토와 함께하는 카풀링
                   </h3>
-                  <p className="text-[15px] font-extrabold text-[#1A1A1A] mb-2.5">
+                  <p className="text-[15px] font-semibold text-[#1A1A1A] mb-2.5">
                     {mentor.price.toLocaleString()}원 <span className="text-sm font-medium text-gray-500">/ 60분</span>
                   </p>
 

--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -1,54 +1,72 @@
 "use client";
 
-import { useState } from "react";
-// 💡 Link 컴포넌트를 불러옵니다.
-import Link from "next/link"; 
-import { Search, ChevronDown, Star } from "lucide-react";
+import { useState, useEffect, useMemo } from "react";
+import Link from "next/link";
+import { Search, ChevronDown, Star, AlertCircle } from "lucide-react";
 
-// 스크린샷 기반 목업 데이터
-const MOCK_MENTORS = [
-  {
-    id: 1,
-    isSuper: true,
-    tags: ["커리어 / 보상", "카풀링 3회"],
-    rating: null,
-    title: "IT 백엔드 개발 및 프로젝트 경험",
-    price: "20,000원 / 60분",
-    career: "백엔드 개발자 2년차",
-    location: "봉천동 · 사당동",
-    bgColor: "bg-gray-200" 
-  },
-  {
-    id: 2,
-    isSuper: true,
-    tags: ["업무 / 커리어", "카풀링 9회"],
-    rating: "5.0점",
-    title: "증권사 빅데이터 직무 / 실무와 취업 이야기",
-    price: "30,000원 / 60분",
-    career: "금융 빅데이터 10년차",
-    location: "신공덕동 · 여의도동 · 군자동",
-    bgColor: "bg-gray-300" 
-  },
-  {
-    id: 3,
-    isSuper: false,
-    tags: ["업계 / 업무"],
-    rating: null,
-    title: "개발자 취업 및 커리어 상담",
-    price: "30,000원 / 60분",
-    career: "백엔드 개발자 9년차",
-    location: "정자동 · 판교동",
-    bgColor: "bg-black" 
-  }
-];
+// 💡 apiClient 임포트 (경로는 프로젝트에 맞게 수정해주세요)
+import apiClient from "@/lib/apiClient";
 
-const CATEGORIES = ["전체", "업무", "일상", "보상", "성장", "커리어", "업계"];
+const CATEGORIES = ["전체", "업무", "일상", "보상", "성장", "커리어", "업계", "멘탈", "실전", "기타"];
+
+// 💡 DB 필드와 UI 카테고리 매핑 테이블
+const FIELD_MAP: Record<string, string> = {
+  WORK: "업무",
+  LIFE: "일상",
+  REWARD: "보상",
+  GROWTH: "성장",
+  CAREER: "커리어",
+  INDUSTRY: "업계",
+  MENTAL: "멘탈",
+  ACTUAL: "실전",
+  ETC: "기타",
+};
+
+// 💡 백엔드 응답에 맞춘 멘토 타입 정의
+interface Mentor {
+  mentorId: string | number;
+  userId: string | number;
+  nickname: string;
+  price: number;
+  fields: string[];
+  updatedAt: string;
+}
 
 export default function HomePage() {
   const [activeCategory, setActiveCategory] = useState("전체");
+  const [mentors, setMentors] = useState<Mentor[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 💡 API를 통해 멘토 목록 불러오기
+  useEffect(() => {
+    const fetchMentors = async () => {
+      try {
+        const res = await apiClient.get("/mentors");
+        setMentors(res.data.mentors || []);
+      } catch (error) {
+        console.error("멘토 목록 로딩 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMentors();
+  }, []);
+
+  // 💡 선택된 카테고리에 맞게 멘토 리스트 필터링
+  const filteredMentors = useMemo(() => {
+    if (activeCategory === "전체") return mentors;
+
+    return mentors.filter((mentor) => {
+      // 멘토가 가진 영문 필드들을 한글로 변환한 배열 생성
+      const koreanFields = mentor.fields.map(f => FIELD_MAP[f] || "기타");
+      // 선택된 카테고리가 변환된 배열에 포함되어 있는지 확인
+      return koreanFields.includes(activeCategory);
+    });
+  }, [mentors, activeCategory]);
 
   return (
-    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans">
+    <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh]">
       
       <header className="flex items-center justify-between px-5 py-4 sticky top-0 bg-white z-20">
         <button className="flex items-center gap-1 text-[20px] font-extrabold tracking-tight">
@@ -82,69 +100,65 @@ export default function HomePage() {
         </button>
       </div>
 
-      {/* 4. 멘토 리스트 */}
-      <div className="flex flex-col">
-        {MOCK_MENTORS.map((mentor) => (
-          // 💡 핵심 변경점: div 태그를 Link 태그로 바꾸고, href 속성으로 멘토의 id를 주소에 넘겨줍니다!
-          // 누를 때 살짝 회색 배경이 되도록 hover:bg-gray-50 도 추가했습니다.
-          <Link 
-            key={mentor.id} 
-            href={`/mentor/${mentor.id}`}
-            className="flex gap-4 px-5 py-6 border-b border-gray-100/60 bg-white hover:bg-gray-50 active:bg-gray-100 transition-colors cursor-pointer"
-          >
-            <div className="relative shrink-0">
-              <div className={`w-[92px] h-[92px] rounded-2xl ${mentor.bgColor} flex items-center justify-center overflow-hidden`}>
-                {mentor.id === 3 && (
-                  <div className="text-[#FFCC00] font-extrabold text-sm flex flex-col items-center">
-                    <span>멘토</span>
-                    <span className="text-white text-[10px] mt-1">—O—O—</span>
+      {/* 💡 멘토 리스트 렌더링 영역 */}
+      <div className="flex flex-col pb-20">
+        {isLoading ? (
+          <div className="flex justify-center py-20">
+            <div className="w-8 h-8 border-4 border-gray-200 border-t-[#FFCC00] rounded-full animate-spin"></div>
+          </div>
+        ) : filteredMentors.length > 0 ? (
+          filteredMentors.map((mentor, index) => {
+            // UI용 가짜 데이터 (백엔드에서 제공하지 않는 데이터들)
+            const colors = ["bg-blue-100", "bg-emerald-100", "bg-orange-100", "bg-pink-100"];
+            const profileColor = colors[index % colors.length];
+            const displayTags = mentor.fields.length > 0 
+              ? mentor.fields.map(f => FIELD_MAP[f] || "기타").join(" / ") 
+              : "분야 미정";
+
+            return (
+              <Link 
+                key={mentor.mentorId} 
+                href={`/mentor/${mentor.mentorId}`}
+                className="flex gap-4 px-5 py-6 border-b border-gray-100/60 bg-white hover:bg-gray-50 active:bg-gray-100 transition-colors cursor-pointer"
+              >
+                <div className="relative shrink-0">
+                  <div className={`w-[92px] h-[92px] rounded-2xl ${profileColor} flex items-center justify-center overflow-hidden`}>
+                    <span className="text-3xl font-bold text-black/20">
+                      {mentor.nickname.charAt(0)}
+                    </span>
                   </div>
-                )}
-              </div>
-              
-              {mentor.isSuper && (
-                <div className="absolute -top-1.5 -left-1.5 bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded shadow-sm z-10 tracking-tight">
-                  슈퍼멘토
                 </div>
-              )}
-            </div>
 
-            <div className="flex flex-col flex-1 min-w-0 pt-0.5">
-              
-              <div className="flex flex-wrap items-center gap-1.5 mb-2">
-                {mentor.tags.map((tag, idx) => (
-                  <span key={idx} className="bg-[#F2F4F6] text-gray-600 text-[11px] font-bold px-2 py-1 rounded-[4px]">
-                    {tag}
-                  </span>
-                ))}
-                {mentor.rating && (
-                  <span className="bg-[#FFF9E6] text-[#1A1A1A] text-[11px] font-extrabold px-2 py-1 rounded-[4px] flex items-center gap-0.5">
-                    <Star className="w-3 h-3 text-[#FFCC00] fill-current" /> {mentor.rating}
-                  </span>
-                )}
-              </div>
+                <div className="flex flex-col flex-1 min-w-0 pt-0.5">
+                  <div className="flex flex-wrap items-center gap-1.5 mb-2">
+                    <span className="bg-[#F2F4F6] text-gray-600 text-[11px] font-bold px-2 py-1 rounded-[4px]">
+                      {displayTags}
+                    </span>
+                  </div>
 
-              <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-snug mb-1 truncate">
-                {mentor.title}
-              </h3>
-              <p className="text-[15px] font-extrabold text-[#1A1A1A] mb-2.5">
-                {mentor.price}
-              </p>
+                  <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-snug mb-1 truncate">
+                    {mentor.nickname} 멘토와 함께하는 커피챗
+                  </h3>
+                  <p className="text-[15px] font-extrabold text-[#1A1A1A] mb-2.5">
+                    {mentor.price.toLocaleString()}원 <span className="text-sm font-medium text-gray-500">/ 60분</span>
+                  </p>
 
-              <div className="flex flex-col gap-0.5 text-[12.5px]">
-                <div className="flex gap-2">
-                  <span className="font-bold text-gray-500">직군 경력</span>
-                  <span className="text-gray-400">{mentor.career}</span>
+                  <div className="flex flex-col gap-0.5 text-[12.5px]">
+                    <div className="flex gap-2">
+                      <span className="font-bold text-gray-500">닉네임</span>
+                      <span className="text-gray-400">{mentor.nickname}</span>
+                    </div>
+                  </div>
                 </div>
-                <div className="flex gap-2">
-                  <span className="font-bold text-gray-500">가능 지역</span>
-                  <span className="text-gray-400">{mentor.location}</span>
-                </div>
-              </div>
-              
-            </div>
-          </Link>
-        ))}
+              </Link>
+            );
+          })
+        ) : (
+          <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+            <AlertCircle className="w-10 h-10 mb-4 text-gray-300" />
+            <p className="font-medium text-[15px]">해당 분야의 멘토가 없습니다.</p>
+          </div>
+        )}
       </div>
 
       <style dangerouslySetInnerHTML={{__html: `

--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
-import { Search, ChevronDown, Star, AlertCircle } from "lucide-react";
+import { Search, ChevronDown, AlertCircle } from "lucide-react";
 
 import apiClient from "@/lib/apiClient";
 
@@ -33,6 +33,8 @@ export default function HomePage() {
   const [activeCategory, setActiveCategory] = useState("전체");
   const [mentors, setMentors] = useState<Mentor[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
 
   useEffect(() => {
     const fetchMentors = async () => {
@@ -49,25 +51,69 @@ export default function HomePage() {
     fetchMentors();
   }, []);
 
+  // 카테고리 필터 + 검색어 필터 동시 적용
   const filteredMentors = useMemo(() => {
-    if (activeCategory === "전체") return mentors;
+    let list = mentors;
 
-    return mentors.filter((mentor) => {
-      const koreanFields = mentor.fields.map(f => FIELD_MAP[f] || "기타");
-      return koreanFields.includes(activeCategory);
-    });
-  }, [mentors, activeCategory]);
+    // 1. 카테고리 필터링
+    if (activeCategory !== "전체") {
+      list = list.filter((mentor) => {
+        const koreanFields = mentor.fields.map(f => FIELD_MAP[f] || "기타");
+        return koreanFields.includes(activeCategory);
+      });
+    }
+
+    // 2. 검색어 필터링 (닉네임 기준)
+    if (searchQuery.trim() !== "") {
+      const q = searchQuery.toLowerCase();
+      list = list.filter((mentor) => 
+        mentor.nickname.toLowerCase().includes(q)
+      );
+    }
+
+    return list;
+  }, [mentors, activeCategory, searchQuery]);
 
   return (
     <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh]">
       
-      <header className="flex items-center justify-between px-5 py-4 sticky top-0 bg-white z-20">
-        <button className="flex items-center gap-1 text-[20px] font-extrabold tracking-tight">
-          전체 지역 <ChevronDown className="w-5 h-5 mt-0.5" strokeWidth={2.5} />
-        </button>
-        <button className="p-1">
-          <Search className="w-6 h-6" strokeWidth={2.5} />
-        </button>
+      {/* 💡 검색 상태에 따라 동적으로 변하는 헤더 */}
+      <header className={`flex items-center justify-between px-5 py-4 sticky top-0 bg-white z-20 transition-all duration-300 ${isSearchOpen ? 'pb-2' : ''}`}>
+        {!isSearchOpen ? (
+          <>
+            <button className="flex items-center gap-1 text-[20px] font-extrabold tracking-tight">
+              전체 지역 <ChevronDown className="w-5 h-5 mt-0.5" strokeWidth={2.5} />
+            </button>
+            <button 
+              type="button" 
+              onClick={() => setIsSearchOpen(true)} 
+              className="p-1 hover:bg-gray-100 rounded-full transition-colors"
+            >
+              <Search className="w-6 h-6" strokeWidth={2.5} />
+            </button>
+          </>
+        ) : (
+          <div className="flex items-center gap-3 w-full animate-in slide-in-from-right-4 duration-300">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" strokeWidth={2.5} />
+              <input 
+                autoFocus 
+                type="text" 
+                placeholder="멘토 닉네임 검색" 
+                value={searchQuery} 
+                onChange={(e) => setSearchQuery(e.target.value)} 
+                className="w-full bg-gray-100 py-2.5 pl-10 pr-4 rounded-xl text-[14px] font-medium focus:outline-none" 
+              />
+            </div>
+            <button 
+              type="button" 
+              onClick={() => { setIsSearchOpen(false); setSearchQuery(""); }} 
+              className="text-[14px] font-bold text-gray-500 px-1"
+            >
+              취소
+            </button>
+          </div>
+        )}
       </header>
 
       <div className="flex gap-2 overflow-x-auto px-5 py-2 scrollbar-hide">
@@ -105,7 +151,6 @@ export default function HomePage() {
                 className="flex gap-4 px-5 py-6 border-b border-gray-100/60 bg-white hover:bg-gray-50 active:bg-gray-100 transition-colors cursor-pointer"
               >
                 <div className="relative shrink-0">
-                  {/* 💡 프로필 이미지를 고정 이미지로 변경 */}
                   <img 
                     src="/images/mentor_profile.jpg" 
                     alt={`${mentor.nickname} 프로필`}
@@ -126,6 +171,7 @@ export default function HomePage() {
                   <p className="text-[15px] font-extrabold text-[#1A1A1A] mb-2.5">
                     {mentor.price.toLocaleString()}원 <span className="text-sm font-medium text-gray-500">/ 60분</span>
                   </p>
+
                 </div>
               </Link>
             );
@@ -133,7 +179,7 @@ export default function HomePage() {
         ) : (
           <div className="flex flex-col items-center justify-center py-20 text-gray-400">
             <AlertCircle className="w-10 h-10 mb-4 text-gray-300" />
-            <p className="font-medium text-[15px]">해당 분야의 멘토가 없습니다.</p>
+            <p className="font-medium text-[15px]">조건에 맞는 멘토가 없습니다.</p>
           </div>
         )}
       </div>

--- a/apps/demo-web/app/(with-nav)/page.tsx
+++ b/apps/demo-web/app/(with-nav)/page.tsx
@@ -4,12 +4,10 @@ import { useState, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { Search, ChevronDown, Star, AlertCircle } from "lucide-react";
 
-// 💡 apiClient 임포트 (경로는 프로젝트에 맞게 수정해주세요)
 import apiClient from "@/lib/apiClient";
 
 const CATEGORIES = ["전체", "업무", "일상", "보상", "성장", "커리어", "업계", "멘탈", "실전", "기타"];
 
-// 💡 DB 필드와 UI 카테고리 매핑 테이블
 const FIELD_MAP: Record<string, string> = {
   WORK: "업무",
   LIFE: "일상",
@@ -22,7 +20,6 @@ const FIELD_MAP: Record<string, string> = {
   ETC: "기타",
 };
 
-// 💡 백엔드 응답에 맞춘 멘토 타입 정의
 interface Mentor {
   mentorId: string | number;
   userId: string | number;
@@ -37,7 +34,6 @@ export default function HomePage() {
   const [mentors, setMentors] = useState<Mentor[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // 💡 API를 통해 멘토 목록 불러오기
   useEffect(() => {
     const fetchMentors = async () => {
       try {
@@ -53,14 +49,11 @@ export default function HomePage() {
     fetchMentors();
   }, []);
 
-  // 💡 선택된 카테고리에 맞게 멘토 리스트 필터링
   const filteredMentors = useMemo(() => {
     if (activeCategory === "전체") return mentors;
 
     return mentors.filter((mentor) => {
-      // 멘토가 가진 영문 필드들을 한글로 변환한 배열 생성
       const koreanFields = mentor.fields.map(f => FIELD_MAP[f] || "기타");
-      // 선택된 카테고리가 변환된 배열에 포함되어 있는지 확인
       return koreanFields.includes(activeCategory);
     });
   }, [mentors, activeCategory]);
@@ -94,23 +87,13 @@ export default function HomePage() {
         ))}
       </div>
 
-      <div className="px-5 py-4 flex">
-        <button className="flex items-center gap-1 text-[13px] font-medium text-gray-500">
-          최신순 <ChevronDown className="w-4 h-4" />
-        </button>
-      </div>
-
-      {/* 💡 멘토 리스트 렌더링 영역 */}
       <div className="flex flex-col pb-20">
         {isLoading ? (
           <div className="flex justify-center py-20">
             <div className="w-8 h-8 border-4 border-gray-200 border-t-[#FFCC00] rounded-full animate-spin"></div>
           </div>
         ) : filteredMentors.length > 0 ? (
-          filteredMentors.map((mentor, index) => {
-            // UI용 가짜 데이터 (백엔드에서 제공하지 않는 데이터들)
-            const colors = ["bg-blue-100", "bg-emerald-100", "bg-orange-100", "bg-pink-100"];
-            const profileColor = colors[index % colors.length];
+          filteredMentors.map((mentor) => {
             const displayTags = mentor.fields.length > 0 
               ? mentor.fields.map(f => FIELD_MAP[f] || "기타").join(" / ") 
               : "분야 미정";
@@ -122,11 +105,12 @@ export default function HomePage() {
                 className="flex gap-4 px-5 py-6 border-b border-gray-100/60 bg-white hover:bg-gray-50 active:bg-gray-100 transition-colors cursor-pointer"
               >
                 <div className="relative shrink-0">
-                  <div className={`w-[92px] h-[92px] rounded-2xl ${profileColor} flex items-center justify-center overflow-hidden`}>
-                    <span className="text-3xl font-bold text-black/20">
-                      {mentor.nickname.charAt(0)}
-                    </span>
-                  </div>
+                  {/* 💡 프로필 이미지를 고정 이미지로 변경 */}
+                  <img 
+                    src="/images/mentor_profile.jpg" 
+                    alt={`${mentor.nickname} 프로필`}
+                    className="w-[92px] h-[92px] rounded-2xl object-cover bg-gray-100 border border-gray-100"
+                  />
                 </div>
 
                 <div className="flex flex-col flex-1 min-w-0 pt-0.5">
@@ -137,18 +121,11 @@ export default function HomePage() {
                   </div>
 
                   <h3 className="text-[16px] font-bold text-[#1A1A1A] leading-snug mb-1 truncate">
-                    {mentor.nickname} 멘토와 함께하는 커피챗
+                    {mentor.nickname} 멘토와 함께하는 카풀링
                   </h3>
                   <p className="text-[15px] font-extrabold text-[#1A1A1A] mb-2.5">
                     {mentor.price.toLocaleString()}원 <span className="text-sm font-medium text-gray-500">/ 60분</span>
                   </p>
-
-                  <div className="flex flex-col gap-0.5 text-[12.5px]">
-                    <div className="flex gap-2">
-                      <span className="font-bold text-gray-500">닉네임</span>
-                      <span className="text-gray-400">{mentor.nickname}</span>
-                    </div>
-                  </div>
                 </div>
               </Link>
             );

--- a/apps/demo-web/app/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentor/[id]/page.tsx
@@ -1,67 +1,146 @@
 "use client";
 
+// 💡 1. React에서 'use'를 추가로 임포트합니다.
+import { useState, useEffect, use } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronLeft, MoreVertical, HelpCircle } from "lucide-react";
+import { MoreVertical, HelpCircle, AlertCircle } from "lucide-react";
+import apiClient from "@/lib/apiClient";
 
-export default function MentorDetailPage({ params }: { params: { id: string } }) {
-  const router = useRouter();
+// 💡 DB 필드와 UI 카테고리 매핑 테이블
+const FIELD_MAP: Record<string, string> = {
+  WORK: "업무",
+  LIFE: "일상",
+  REWARD: "보상",
+  GROWTH: "성장",
+  CAREER: "커리어",
+  INDUSTRY: "업계",
+  MENTAL: "멘탈",
+  ACTUAL: "실전",
+  ETC: "기타",
+};
 
-  // 스크린샷 기반 목업 데이터
-  const mentorData = {
-    title: "IT 백엔드 개발 및 프로젝트 경험",
-    name: "AI네이티브개발자",
-    count: "카풀링 3회",
-    infoTags: ["카풀링", "백엔드 개발자", "2년차", "남성", "직장인"],
-    fieldTags: ["커리어", "보상"],
-    detailTags: ["Javascript", "Typescript", "AWS", "Serverless", "Jira", "Slack", "PM", "IT"],
-    intro: "IT 백엔드 개발자 2년차입니다. 서버 아키텍처 설계, 금융 도메인, AI Native 등 다양한 개발 관련 대한 실무 경험을 쌓고 있습니다.\n\n백엔드 개발 입문자, 신입 개발자 희망자분들께 도움을 드릴 수 있습니다. 기술 면접 준비, 포트폴리오 피드백, 실무 개발 패턴, 커리어 고민 등을 함께 이야기할 수 있습니다.\n\n얼마 전까지 초보였기에 여러분의 어려움을 잘 이해합니다. 어려운 용어보다 쉽고 친절한 설명을 지향하며, 어떤 질문도 환영합니다. 함께 성장하겠습니다!",
-    locationTags: ["봉천동", "사당동"],
-    price: "20,000원 / 1시간"
+interface MentorDetail {
+  mentorId: number;
+  nickname: string;
+  price: number;
+  fields: string[];
+  bio: string;
+  info?: {
+    tags?: string[];
+    details?: string[];
+    locations?: string[];
   };
+  count?: number;
+}
+
+// 💡 2. params의 타입을 Promise 형태로 감싸줍니다.
+export default function MentorDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter();
+  
+  // 💡 3. React.use()를 사용하여 비동기 params를 동기적으로 풀어줍니다!
+  const unwrappedParams = use(params);
+  const mentorId = unwrappedParams.id;
+
+  const [mentor, setMentor] = useState<MentorDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchMentorDetail = async () => {
+      try {
+        // 💡 4. 풀어낸 mentorId를 사용합니다.
+        const res = await apiClient.get(`/mentors/${mentorId}`);
+        setMentor(res.data.mentor || res.data);
+      } catch (err) {
+        console.error("멘토 상세 정보 로딩 실패:", err);
+        setError("멘토 정보를 불러오지 못했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (mentorId) {
+      fetchMentorDetail();
+    }
+  }, [mentorId]); // 💡 5. 의존성 배열(dependency array)에도 mentorId를 넣어줍니다.
+
+  if (isLoading) {
+    return (
+      <main className="w-full max-w-md mx-auto h-[100dvh] bg-white flex items-center justify-center">
+        <div className="w-8 h-8 border-4 border-gray-200 border-t-[#FFCC00] rounded-full animate-spin"></div>
+      </main>
+    );
+  }
+
+  if (error || !mentor) {
+    return (
+      <main className="w-full max-w-md mx-auto h-[100dvh] bg-white flex flex-col items-center justify-center text-gray-400">
+        <AlertCircle className="w-10 h-10 mb-4 text-gray-300" />
+        <p className="font-medium text-[15px]">{error || "멘토를 찾을 수 없습니다."}</p>
+        <button onClick={() => router.back()} className="mt-6 px-4 py-2 bg-gray-100 text-gray-700 rounded-lg font-bold text-sm">
+          뒤로 가기
+        </button>
+      </main>
+    );
+  }
+
+  const title = `${mentor.nickname} 멘토와 함께하는 커피챗`;
+  const countStr = `카풀링 ${mentor.count || 0}회`;
+  const fieldTags = mentor.fields && mentor.fields.length > 0 
+    ? mentor.fields.map(f => FIELD_MAP[f] || "기타") 
+    : ["분야 미정"];
+  
+  // 기본값을 빈 배열([])로 설정합니다.
+  const infoTags = mentor.info?.tags || []; 
+  const detailTags = mentor.info?.details || [];
+  const locationTags = mentor.info?.locations || [];
+  const priceStr = `${mentor.price?.toLocaleString() || 0}원 / 60분`;
 
   return (
-    // PC 화면에서도 모바일 앱처럼 보이도록 max-w-md mx-auto 적용
     <main className="w-full max-w-md mx-auto h-[100dvh] bg-white relative shadow-sm flex flex-col font-sans">
       
-      {/* 1. 상단 고정 헤더 */}
       <header className="flex items-center justify-between px-2 py-3 bg-white sticky top-0 z-20">
         <button onClick={() => router.back()} className="p-2 hover:bg-gray-50 rounded-full transition-colors">
-          <img src="/icons/arrow.svg" className="w-5 h-5 text-[#1A1A1A]" />
+          <img src="/icons/arrow.svg" alt="뒤로가기" className="w-5 h-5 text-[#1A1A1A]" />
         </button>
         <button className="p-2 hover:bg-gray-50 rounded-full transition-colors">
           <MoreVertical className="w-5 h-5 text-[#1A1A1A]" strokeWidth={2.5} />
         </button>
       </header>
 
-      {/* 2. 스크롤 가능한 본문 영역 */}
       <div className="flex-1 overflow-y-auto px-5 pb-[100px] custom-scrollbar">
         
-        {/* 타이틀 */}
         <h1 className="text-[22px] font-bold text-[#1A1A1A] leading-snug mt-2 mb-8 tracking-tight">
-          {mentorData.title}
+          {title}
         </h1>
 
-        {/* 프로필 요약 */}
         <div className="flex items-center gap-4 mb-10">
-          {/* 프로필 이미지 (임시 회색 박스) */}
-          <div className="w-[72px] h-[72px] bg-gray-200 rounded-[20px] shrink-0" />
+          <img 
+            src="/images/mentor_profile.jpg" 
+            alt={`${mentor.nickname} 프로필`}
+            className="w-[72px] h-[72px] object-cover rounded-[20px] shrink-0 border border-gray-100" 
+          />
           <div className="flex flex-col gap-1.5">
-            <h2 className="text-[18px] font-bold text-[#1A1A1A]">{mentorData.name}</h2>
+            <h2 className="text-[18px] font-bold text-[#1A1A1A]">{mentor.nickname}</h2>
             <span className="inline-block bg-[#F2F4F6] text-gray-600 text-[12px] font-medium px-2.5 py-1 rounded-[6px] w-fit">
-              {mentorData.count}
+              {countStr}
             </span>
           </div>
         </div>
 
-        {/* 섹션: 멘토 정보 */}
+        {/* 섹션: 멘토 정보 (데이터 없으면 "정보가 없습니다" 표시) */}
         <section className="mb-10">
           <h3 className="text-[15px] font-bold text-[#1A1A1A] mb-4">멘토 정보</h3>
           <div className="flex flex-wrap gap-2">
-            {mentorData.infoTags.map((tag, idx) => (
-              <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
-                {tag}
-              </span>
-            ))}
+            {infoTags.length > 0 ? (
+              infoTags.map((tag, idx) => (
+                <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
+                  {tag}
+                </span>
+              ))
+            ) : (
+              <p className="text-gray-400 text-[14px] ml-1">정보가 없습니다</p>
+            )}
           </div>
         </section>
 
@@ -72,23 +151,31 @@ export default function MentorDetailPage({ params }: { params: { id: string } })
             <HelpCircle className="w-4 h-4 text-gray-400" strokeWidth={2} />
           </div>
           <div className="flex flex-wrap gap-2">
-            {mentorData.fieldTags.map((tag, idx) => (
-              <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
-                {tag}
-              </span>
-            ))}
+            {fieldTags.length > 0 ? (
+              fieldTags.map((tag, idx) => (
+                <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
+                  {tag}
+                </span>
+              ))
+            ) : (
+              <p className="text-gray-400 text-[14px] ml-1">정보가 없습니다</p>
+            )}
           </div>
         </section>
 
-        {/* 섹션: 멘토링 세부 분야 */}
+        {/* 섹션: 멘토링 세부 분야 (데이터 없으면 "정보가 없습니다" 표시) */}
         <section className="mb-10">
           <h3 className="text-[15px] font-bold text-[#1A1A1A] mb-4">멘토링 세부 분야</h3>
           <div className="flex flex-wrap gap-2">
-            {mentorData.detailTags.map((tag, idx) => (
-              <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
-                {tag}
-              </span>
-            ))}
+            {detailTags.length > 0 ? (
+              detailTags.map((tag, idx) => (
+                <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
+                  {tag}
+                </span>
+              ))
+            ) : (
+              <p className="text-gray-400 text-[14px] ml-1">정보가 없습니다</p>
+            )}
           </div>
         </section>
 
@@ -96,33 +183,35 @@ export default function MentorDetailPage({ params }: { params: { id: string } })
         <section className="mb-10">
           <h3 className="text-[15px] font-bold text-[#1A1A1A] mb-4">멘토링 소개</h3>
           <p className="text-[15px] text-[#333333] leading-[1.7] whitespace-pre-wrap tracking-tight">
-            {mentorData.intro}
+            {mentor.bio || "멘토링 소개가 아직 작성되지 않았습니다."}
           </p>
         </section>
 
-        {/* 섹션: 멘토링 가능 지역 */}
+        {/* 섹션: 멘토링 가능 지역 (데이터 없으면 "정보가 없습니다" 표시) */}
         <section className="mb-10">
           <h3 className="text-[15px] font-bold text-[#1A1A1A] mb-4">멘토링 가능 지역</h3>
           <div className="flex flex-wrap gap-2">
-            {mentorData.locationTags.map((tag, idx) => (
-              <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
-                {tag}
-              </span>
-            ))}
+            {locationTags.length > 0 ? (
+              locationTags.map((tag, idx) => (
+                <span key={idx} className="bg-[#F8F9FA] text-[#333333] text-[14px] px-3.5 py-1.5 rounded-full border border-gray-100">
+                  {tag}
+                </span>
+              ))
+            ) : (
+              <p className="text-gray-400 text-[14px] ml-1">정보가 없습니다</p>
+            )}
           </div>
         </section>
 
-        {/* 섹션: 멘토링 비용 */}
         <section className="mb-4">
           <h3 className="text-[15px] font-bold text-[#1A1A1A] mb-4">멘토링 비용</h3>
           <div className="bg-[#F8F9FA] rounded-2xl p-5 flex items-center">
-            <span className="text-[16px] font-bold text-[#1A1A1A]">{mentorData.price}</span>
+            <span className="text-[16px] font-bold text-[#1A1A1A]">{priceStr}</span>
           </div>
         </section>
 
       </div>
 
-      {/* 3. 하단 고정 버튼 영역 */}
       <div className="absolute bottom-0 left-0 w-full bg-white px-5 py-3 pb-safe z-50">
         <button className="w-full bg-[#111116] text-[white] font-bold text-[16px] py-4 rounded-xl hover:bg-black transition-colors active:scale-[0.98]">
           사전상담하기

--- a/apps/demo-web/app/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentor/[id]/page.tsx
@@ -49,7 +49,7 @@ export default function MentorDetailPage({ params }: { params: Promise<{ id: str
     const fetchMentorDetail = async () => {
       try {
         // 💡 4. 풀어낸 mentorId를 사용합니다.
-        const res = await apiClient.get(`/mentors/${mentorId}`);
+        const res = await apiClient.get(`/api/mentors/${mentorId}`);
         setMentor(res.data.mentor || res.data);
       } catch (err) {
         console.error("멘토 상세 정보 로딩 실패:", err);


### PR DESCRIPTION
## 연관된 이슈

#61 

## 작업 내용

- 홈(멘토 목록 화면)과 상세페이지에 mentors.js API를 사용하여 데이터 연동.
- 홈(멘토 목록 화면)에 멘토 검색 기능 추가.
- 멘토 프로필 사진은 지정 이미지로 통일함.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

**리뷰 방법**
1. 루트의 .env와 /apps/demo-web의 .env.local에 배포용 환경변수 세팅
2. /apps/demo-web 터미널에서 `npm run dev` 실행
3. 전체 탭에서 테스트멘토의 프로필(분야, 닉네임+멘토와함께하는카풀링, 가격/60분)이 잘 렌더링 되는지 확인
4. 해당하는 카테고리(업무, 일상) 탭에서 테스트멘토의 프로필이 잘 렌더링 되는지 확인
5. 테스트멘토를 클릭하여 상세페이지에 접속 후 아래 데이터들이 정상정으로 렌더링 되는지 확인
```
멘토 정보: 정보가 없습니다
멘토링 분야: 업무, 일상
멘토링 세부 분야: 정보가 없습니다
멘토링 소개: 테스트멘토입니다.
멘토링 가능 지역: 정보가 없습니다
멘토링 비용: 20,000원/60분
```