### PR TITLE
S3 dvc remote 서울 지역으로 변경

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -1,4 +1,5 @@
 [core]
     remote = carpoolink
 ['remote "carpoolink"']
-    url = s3://capstone2026-carpoolink-dvc
+    url = s3://capstone2026-carpoolink-dvc-kro
+    region = ap-northeast-2


### PR DESCRIPTION
## 연관된 이슈

#69 

## 작업 내용

DVC remote S3 버킷을 시드니 리전에서 서울 리전 버킷으로 변경

## 체크 리스트

- [ ]  .dvc/config의 DVC remote가 서울 S3 버킷을 바라보도록 변경
- [ ]  DVC remote region을 ap-northeast-2로 설정

## 리뷰 요구사항

확인 방법
1. 프로젝트 폴더에서 `.dvc/config` 파일을 엽니다.
2. 아래 내용이 있는지 확인합니다.
```
['remote "carpoolink"']
    url = s3://capstone2026-carpoolink-dvc-kro
    region = ap-northeast-2
```
3. 터미널 사용이 가능하면 아래 명령어를 실행합니다.
`dvc remote list`
4. 결과에 아래처럼 새 버킷 이름이 보이면 정상입니다.
`carpoolink    s3://capstone2026-carpoolink-dvc-kro    (default)`