### PR TITLE
스크립트 발행

### DIFF
--- a/packages/database/prisma/schema.prisma
+++ b/packages/database/prisma/schema.prisma
@@ -122,13 +122,14 @@ model Field {
 
 // 온라인 멘토링 세션
 model Mentoring {
-  mentoringId BigInt          @id @default(autoincrement()) @map("mentoring_id")
-  title       String          @db.VarChar(200)
-  isGroup     Boolean         @map("is_group")
-  status      MentoringStatus @default(READY) @map("status")
-  startedAt   DateTime?       @map("started_at")
-  endedAt     DateTime?       @map("ended_at")
-  userId      BigInt          @map("user_id") // 주관 멘토
+  mentoringId       BigInt          @id @default(autoincrement()) @map("mentoring_id")
+  title             String          @db.VarChar(200)
+  isGroup           Boolean         @map("is_group")
+  status            MentoringStatus @default(READY) @map("status")
+  isScriptPublished Boolean         @map("is_script_published") @default(false)
+  startedAt         DateTime?       @map("started_at")
+  endedAt           DateTime?       @map("ended_at")
+  userId            BigInt          @map("user_id") // 주관 멘토
 
   // 관계 설정
   hostMentor         User               @relation("HostedMentorings", fields: [userId], references: [userId])

--- a/packages/database/prisma/seed.js
+++ b/packages/database/prisma/seed.js
@@ -156,6 +156,7 @@ async function main() {
             data: {
                 isGroup: false,
                 status: "READY",
+                isScriptPublished: true,
                 userId: mentor.userId,
             },
         });
@@ -165,6 +166,7 @@ async function main() {
                 title: "테스트 멘토링",
                 isGroup: false,
                 status: "READY",
+                isScriptPublished: true,
                 userId: mentor.userId,
             },
         });

--- a/services/core-api/README.md
+++ b/services/core-api/README.md
@@ -57,3 +57,52 @@ npm run dev -w services/core-api
 - `GET /scripts`: 접근 가능한 스크립트 멘토링 목록을 조회합니다. `x-user-id`와 `type`(`all`/`group`/`one-on-one`) 쿼리를 사용합니다.
 - `GET /scripts/{mentoringId}`: 특정 멘토링의 스크립트 전문을 조회합니다. `x-user-id`가 필요합니다.
 - `PATCH /scripts/{mentoringId}/publish`: 특정 멘토링의 스크립트를 수정 후 발행합니다. `x-user-id`가 필요합니다.
+    
+    ```json
+    // request body 예시:
+    {
+        "scripts": [
+            {
+                "scriptId": "7",
+                "content": {
+                    "pieces": [
+                        {
+                            "text": "멘토님, 신입 개발자로서 가장 중요하게 생각하시는 역량이 무엇인가요?",
+                            "isMasked": false
+                        }
+                    ]
+                }
+            },
+            {
+                "scriptId": "8",
+                "content": {
+                    "pieces": [
+                        {
+                            "text": "네, 관련 자료는 제 개인 이메일인 ",
+                            "isMasked": false
+                        },
+                        {
+                            "text": "매우매우 민감한 정보!!",
+                            "isMasked": true
+                        },
+                        {
+                            "text": "으로 메일 주시면 보내드릴게요.",
+                            "isMasked": false
+                        }
+                    ]
+                }
+            },
+            {
+                "scriptId": "9",
+                "content": {
+                    "pieces": [
+                        {
+                            "text": "매우매우 민감한 정보!!",
+                            "isMasked": true
+                        }
+                    ]
+                }
+            }
+        ]
+    }
+    ```

--- a/services/core-api/README.md
+++ b/services/core-api/README.md
@@ -56,3 +56,4 @@ npm run dev -w services/core-api
 
 - `GET /scripts`: 접근 가능한 스크립트 멘토링 목록을 조회합니다. `x-user-id`와 `type`(`all`/`group`/`one-on-one`) 쿼리를 사용합니다.
 - `GET /scripts/{mentoringId}`: 특정 멘토링의 스크립트 전문을 조회합니다. `x-user-id`가 필요합니다.
+- `PATCH /scripts/{mentoringId}/publish`: 특정 멘토링의 스크립트를 수정 후 발행합니다. `x-user-id`가 필요합니다.

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -19,6 +19,7 @@ function parseType(type) {
 // 클라이언트가 참여한 멘토링 중 스크립트가 존재하는 멘토링을 찾는 함수
 function buildParticipatedMentoringWhere(userId, type) {
     const where = {
+        status: 'COMPLETED',
         OR: [
             { userId },
             {
@@ -176,6 +177,8 @@ router.get('/:mentoringId', requireUser, async (req, res, next) => {
         // 멘토링과 스크립트 조회 (접근 권한 및 스크립트 존재 여부 검증 포함)
         const mentoring = await prisma.mentoring.findFirst({
             where: {
+                status: 'COMPLETED',
+                isScriptPublished: req.user.role === 'MENTOR' ? undefined : true, // 멘토는 발행 여부 상관없이 조회 가능, 멘티는 발행된 스크립트인 경우만 조회 가능
                 mentoringId,
                 ...buildParticipatedMentoringWhere(req.user.userId),
                 scripts: {

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -41,12 +41,18 @@ function buildParticipatedMentoringWhere(userId, type) {
     return where;
 }
 
-// 스크립트에 마스킹 플래그가 있는지 확인하는 함수
+// 스크립트 단락에 마스킹된 부분이 있는지 확인하는 함수
 function hasMaskedFlag(content) {
     if (!content || typeof content !== 'object') {
         return false;
     }
 
+    // pieces 배열 내부 검사
+    if (Array.isArray(content.pieces)) {
+        return content.pieces.some(piece => piece.isMasked === true);
+    }
+
+    // 전체 단락이 마스킹된 경우 검사
     return content.isMasked === true;
 }
 
@@ -68,8 +74,30 @@ function getVisibleContent(script, viewerUserId) {
             masked: false,
             content: {
                 isPrivate: true,
-                message: '비공개 질문입니다.',
+                text: '비공개 질문입니다.',
             },
+        };
+    }
+
+    const content = script.content;
+
+    if (content && Array.isArray(content.pieces)) {
+        const isMaskedParagraph = content.pieces.some(p => p.isMasked);
+
+        return {
+            visible: true,
+            masked: isMaskedParagraph,
+            content: {
+                pieces: content.pieces.map(piece => {
+                    if (piece.isMasked) {
+                        return {
+                            ...piece,
+                            text: '마스킹된 부분입니다.',
+                        };
+                    }
+                    return piece;
+                })
+            }
         };
     }
 
@@ -80,7 +108,7 @@ function getVisibleContent(script, viewerUserId) {
             masked: true,
             content: {
                 isMasked: true,
-                message: '마스킹된 단락입니다.',
+                text: '마스킹된 단락입니다.',
             },
         };
     }
@@ -99,7 +127,6 @@ function mapScriptParagraph(script, viewerUserId) {
     return {
         scriptId: script.scriptId,
         isPrivate: script.isPrivate,
-        isMasked: Boolean(visibility.masked),
         createdAt: script.createdAt,
         content: visibility.content,
         speaker: {
@@ -306,7 +333,7 @@ router.patch('/:mentoringId/publish', requireUser, async (req, res, next) => {
             });
         });
 
-        res.json(serialize({ message: '스크립트가 성공적으로 수정되고 발행되었습니다.' }));
+        res.json(serialize({ message: '스크립트가 발행되었습니다.' }));
     } catch (error) {
         next(error);
     }

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -235,4 +235,81 @@ router.get('/:mentoringId', requireUser, async (req, res, next) => {
     }
 });
 
+// [PATCH] /scripts/:mentoringId/publish - 스크립트 단락 수정 및 멘토링 스크립트 발행
+router.patch('/:mentoringId/publish', requireUser, async (req, res, next) => {
+    try {
+        let mentoringId;
+        try {
+            mentoringId = BigInt(req.params.mentoringId);
+        } catch {
+            return res.status(400).json({ message: '유효하지 않은 mentoringId입니다.' });
+        }
+
+        const { scripts } = req.body;
+
+        if (!Array.isArray(scripts) || scripts.length === 0) {
+            return res.status(400).json({ message: '업데이트할 스크립트 단락 배열(scripts)이 필요합니다.' });
+        }
+
+        // 1. 멘토링 정보 및 권한 확인
+        const mentoring = await prisma.mentoring.findUnique({
+            where: { mentoringId },
+            select: {
+                userId: true,
+                status: true,
+                isScriptPublished: true
+            },
+        });
+
+        if (!mentoring) {
+            return res.status(404).json({ message: '멘토링을 찾을 수 없습니다.' });
+        }
+
+        // 주관 멘토인지 확인
+        if (mentoring.userId !== req.user.userId) {
+            return res.status(403).json({ message: '스크립트를 발행할 권한이 없습니다.' });
+        }
+
+        if (mentoring.status !== 'COMPLETED') {
+            return res.status(400).json({ message: '완료된 멘토링의 스크립트만 발행할 수 있습니다.' });
+        }
+
+        if (mentoring.isScriptPublished) {
+            return res.status(400).json({ message: '이미 발행된 스크립트입니다. 더 이상 수정하거나 발행할 수 없습니다.' });
+        }
+
+        // 2. 트랜잭션으로 단락별 내용 업데이트 및 발행 상태 변경 수행
+        await prisma.$transaction(async (tx) => {
+            // 전달받은 스크립트 단락들 업데이트
+            for (const script of scripts) {
+                let scriptId;
+                try {
+                    scriptId = BigInt(script.scriptId);
+                } catch {
+                    continue; // 유효하지 않은 scriptId는 무시
+                }
+
+                await tx.script.update({
+                    where: { scriptId },
+                    data: {
+                        content: script.content,
+                    },
+                });
+            }
+
+            // 멘토링 스크립트 발행 상태를 true로 변경
+            await tx.mentoring.update({
+                where: { mentoringId },
+                data: {
+                    isScriptPublished: true,
+                },
+            });
+        });
+
+        res.json(serialize({ message: '스크립트가 성공적으로 수정되고 발행되었습니다.' }));
+    } catch (error) {
+        next(error);
+    }
+});
+
 export default router;

--- a/services/media-server/src/server.js
+++ b/services/media-server/src/server.js
@@ -97,7 +97,8 @@ app.post('/mentorings/start', async (req, res) => {
             title,
             userId,
             isGroup,
-            status: 'ON_AIR'
+            status: 'ON_AIR',
+            isScriptPublished: false,
         });
 
         await mediaOrchestrator.ensureRoom(mentoring.mentoringId, {


### PR DESCRIPTION
## 연관된 이슈

#72 

## 작업 내용

멘토링 종료 후 멘토의 스크립트 수정 및 발행이 가능합니다.
스크립트는 전문 조회 후 수정된 전체 스크립트를 request body에 담아 발행 요청하면 그대로 업데이트됩니다.
자세한 내용은 리드미 참고해주세요.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

로컬 db 사용하고 계시면 머지 후 루트에서 `npm run db:setup` 하셔야 합니다.
리드미 참고하셔서 멘토 계정으로 스크립트 조회 및 발행 테스트 해보셔도 되고 그냥 승인하셔도 됩니다.