### PR TITLE
[Script] 스크립트 목록 조회 및 편집/발행 연동

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import Link from "next/link";
+import Image from "next/image";
 import { 
   Settings, 
   ChevronRight, 
@@ -14,7 +15,7 @@ import {
   HelpCircle, 
   MessageSquare,
   LogOut,
-  RefreshCw // 💡 1. 재시작 아이콘 추가
+  RefreshCw
 } from "lucide-react";
 
 import apiClient from "@/lib/apiClient"; 
@@ -22,7 +23,8 @@ import apiClient from "@/lib/apiClient";
 interface UserProfile {
   nickname: string;
   remainingTickets: number; 
-  surveyType: string;       
+  surveyType: string;
+  role: string;       
 }
 
 export default function MyPage() {
@@ -45,6 +47,7 @@ export default function MyPage() {
           nickname: userRes.data.nickname || "사용자",
           remainingTickets: userRes.data.menteeProfile?.balance ?? 0,
           surveyType: userRes.data.menteeProfile?.surveyResult ?? "유형 없음",
+          role: userRes.data.role || "MENTEE",
         });
       } catch (error) {
         console.error("마이페이지 데이터 호출 실패:", error);
@@ -56,7 +59,7 @@ export default function MyPage() {
     fetchUserData();
   }, [router]);
 
-  // 💡 2. 설문 데이터 초기화 및 다시하기 로직
+  // 2. 설문 데이터 초기화 및 다시하기 로직
   const handleRetakeSurvey = async () => {
     if (window.confirm("기존 설문 결과가 초기화됩니다. 다시 테스트하시겠습니까?")) {
       try {
@@ -102,12 +105,19 @@ export default function MyPage() {
         </button>
       </header>
 
-      {/* 멘티 프로필 영역 */}
+      {/* 멘티/멘토 프로필 영역 */}
       <div className="flex flex-col px-5 py-6">
         <div className="flex items-center gap-4 mb-4">
-          <div className="w-[72px] h-[72px] bg-[#111116] rounded-2xl flex flex-col items-center justify-center text-white shrink-0 shadow-sm">
-            <span className="text-[15px] font-extrabold mb-1">멘티</span>
-            <span className="text-[10px] font-bold tracking-widest">—O—O—</span>
+
+          {/* 사용자의 role에 따라 프로필 이미지를 분기하여 렌더링 */}
+          <div className="relative w-[72px] h-[72px] shrink-0 shadow-sm rounded-2xl overflow-hidden bg-gray-100 border border-gray-200">
+            <Image 
+              src={user.role === "MENTOR" ? "/images/mentor_profile.jpg" : "/images/mentee_profile.jpg"} 
+              alt="프로필 이미지" 
+              fill
+              className="object-cover"
+              sizes="72px"
+            />
           </div>
 
           <div className="flex flex-col gap-1.5">
@@ -120,7 +130,7 @@ export default function MyPage() {
               )}
             </div>
 
-            {/* 💡 3. 다시하기 버튼 추가 (프로필 옆/아래 배치) */}
+            {/* 3. 다시하기 버튼 */}
             <button
               onClick={handleRetakeSurvey}
               className="flex items-center gap-1.5 text-gray-500 hover:text-[#1A1A1A] transition-colors"
@@ -150,12 +160,12 @@ export default function MyPage() {
         <Link href="#" className="flex items-center justify-between py-4 group">
           <div className="flex items-center gap-3">
             <UserPen className="w-[22px] h-[22px] text-gray-500" strokeWidth={2} />
-            <span className="text-[16px] font-medium">멘티프로필 수정</span>
+            <span className="text-[16px] font-medium">
+              {user.role === "MENTOR" ? "멘토프로필 수정" : "멘티프로필 수정"}
+            </span>
           </div>
           <ChevronRight className="w-5 h-5 text-gray-300" />
         </Link>
-
-        {/* ... (기타 메뉴 생략) ... */}
 
         <Link href="/mypage/scripts" className="flex items-center justify-between py-4 group">
           <div className="flex items-center gap-3">

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -38,6 +38,11 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
             const isMentor = s.speaker?.isHostMentor;
             let text = s.content?.message || "";
 
+            // timestamp 출력
+            const timestamp = s.content?.timestamp 
+              ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none">${s.content.timestamp}</span>` 
+              : "";
+
             // [비공개 처리] 권한이 없는 비공개 질문인 경우
             if (s.content?.isPrivate) {
               return `<div class="mb-4 text-gray-400 italic">🔒 <b>[${speakerName}]</b> ${text}</div>`;
@@ -51,7 +56,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
             // 발화자 구분 가독성을 위해 이름 색상 다르게 지정
             const nameColor = isMentor ? "#D97706" : "#2563EB"; 
 
-            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b> ${text}</div>`;
+            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${text}</span></div>`;
           }).join('');
 
           // 스크립트 데이터가 비어있을 경우 방어 코드

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -2,8 +2,7 @@
 
 import { use, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
-import Link from "next/link";
-import { ChevronLeft, FileText, Loader2, AlertCircle } from "lucide-react";
+import { ChevronLeft, Loader2, AlertCircle } from "lucide-react";
 import apiClient from "@/lib/apiClient";
 
 export default function PublishedScriptPage({ params }: { params: Promise<{ id: string }> }) {
@@ -20,12 +19,14 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
     const fetchScriptData = async () => {
       setIsLoading(true);
       try {
-        const res = await apiClient.get(`/api/scripts/${id}`);
+        const res = await apiClient.get(`/scripts/${id}`);
         const { mentoring, scripts } = res.data;
 
-        // 날짜 포맷 변환
-        const d = new Date(mentoring.startedAt);
-        const dateStr = `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+        // 방어 로직이 적용된 날짜 포맷 변환
+        const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
+        const dateStr = d 
+          ? `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`
+          : "날짜 미상";
 
         setMentoringInfo({
           title: mentoring.title,
@@ -36,27 +37,42 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
           const htmlContent = scripts.map((s: any) => {
             const speakerName = s.speaker?.nickname || "알 수 없음";
             const isMentor = s.speaker?.isHostMentor;
-            let text = s.content?.message || "";
 
-            // timestamp 출력
+            // timestamp 출력 (존재할 경우)
             const timestamp = s.content?.timestamp 
               ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none">${s.content.timestamp}</span>` 
               : "";
 
-            // [비공개 처리] 권한이 없는 비공개 질문인 경우
-            if (s.content?.isPrivate) {
-              return `<div class="mb-4 text-gray-400 italic">🔒 <b>[${speakerName}]</b> ${text}</div>`;
+            let textHTML = "";
+
+            // [1. 비공개 처리] 백엔드에서 내려준 비공개 메시지 출력
+            if (s.content?.isPrivate || s.isPrivate) {
+              textHTML = s.content?.text || "비공개 질문입니다.";
+              return `<div class="mb-4 text-gray-400 italic">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
             }
 
-            // [마스킹 처리] CSS의 투명/노란색 배경 효과를 받기 위해 span 태그로 감싸기
-            if (s.isMasked || s.content?.isMasked) {
-              text = `<span style="background-color: #FFCC00">${text}</span>`;
+            // [2. 부분 마스킹 배열(pieces) 처리]
+            if (s.content?.pieces && Array.isArray(s.content.pieces)) {
+              textHTML = s.content.pieces.map((piece: any) => {
+                // 백엔드에서 치환된 텍스트('마스킹된 부분입니다.')를 노란색 span으로 감싸기
+                if (piece.isMasked) {
+                  return `<span style="background-color: #FFCC00">${piece.text || "마스킹된 부분입니다."}</span>`;
+                }
+                return piece.text || "";
+              }).join('');
+            } 
+            // [3. 통문장 마스킹 또는 구버전 데이터(message) 호환 처리]
+            else {
+              textHTML = s.content?.text || s.content?.message || "";
+              if (s.masked || s.isMasked || s.content?.isMasked) {
+                textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+              }
             }
 
             // 발화자 구분 가독성을 위해 이름 색상 다르게 지정
             const nameColor = isMentor ? "#D97706" : "#2563EB"; 
 
-            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${text}</span></div>`;
+            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
           }).join('');
 
           // 스크립트 데이터가 비어있을 경우 방어 코드
@@ -78,7 +94,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
       
-      {/* 편집기의 '멘티 뷰' CSS 로직을 그대로 가져왔습니다. */}
+      {/* 멘티 뷰 CSS 로직 (마스킹된 텍스트 글자색 투명화 및 블라인드 처리) */}
       <style>{`
         .mentee-view-container span[style*="rgb(255, 204, 0)"], 
         .mentee-view-container span[style*="#FFCC00"], 
@@ -93,7 +109,6 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
 
       {/* 헤더 */}
       <header className="flex items-center px-5 py-4 border-b border-gray-100 shrink-0 bg-white z-10">
-        {/* <Link> 대신 router.back()을 사용하는 버튼으로 변경 */}
         <button 
           onClick={() => router.back()} 
           className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
@@ -118,8 +133,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
           </div>
         ) : (
           <>
-
-            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Script ID: {id}</p>
+            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Mentoring ID: {id}</p>
             
             <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
               {mentoringInfo?.title}

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -20,7 +20,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
     const fetchScriptData = async () => {
       setIsLoading(true);
       try {
-        const res = await apiClient.get(`/scripts/${id}`);
+        const res = await apiClient.get(`/api/scripts/${id}`);
         const { mentoring, scripts } = res.data;
 
         // 날짜 포맷 변환

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -1,24 +1,77 @@
 "use client";
 
-import { use, useEffect, useRef } from "react";
+import { use, useEffect, useRef, useState } from "react";
 import Link from "next/link";
-import { ChevronLeft, FileText } from "lucide-react";
+import { ChevronLeft, FileText, Loader2, AlertCircle } from "lucide-react";
+import apiClient from "@/lib/apiClient";
 
 export default function PublishedScriptPage({ params }: { params: Promise<{ id: string }> }) {
   const { id } = use(params);
   const contentRef = useRef<HTMLDivElement>(null);
 
+  // API 연동 상태 관리
+  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
-    // 💡 테스트용 더미 데이터입니다. 마스킹된 영역을 보여주기 위해 span 태그를 포함했습니다.
-    if (contentRef.current && !contentRef.current.innerHTML) {
-      contentRef.current.innerHTML = `During our session today, we discussed the <span style="background-color: #FFCC00;">strategic roadmap</span> for the upcoming quarter. We focused on three main pillars: operational efficiency, stakeholder communication, and technical debt reduction.<br><br>I noticed that your approach to delegating tasks has improved significantly. However, you should still monitor the velocity of the secondary team when sharing the board with <span style="background-color: #FFCC00;">junior designers</span>.`;
+    const fetchScriptData = async () => {
+      setIsLoading(true);
+      try {
+        const res = await apiClient.get(`/scripts/${id}`);
+        const { mentoring, scripts } = res.data;
+
+        // 날짜 포맷 변환
+        const d = new Date(mentoring.startedAt);
+        const dateStr = `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`;
+
+        setMentoringInfo({
+          title: mentoring.title,
+          date: dateStr,
+        });
+
+        if (contentRef.current) {
+          const htmlContent = scripts.map((s: any) => {
+            const speakerName = s.speaker?.nickname || "알 수 없음";
+            const isMentor = s.speaker?.isHostMentor;
+            let text = s.content?.message || "";
+
+            // [비공개 처리] 권한이 없는 비공개 질문인 경우
+            if (s.content?.isPrivate) {
+              return `<div class="mb-4 text-gray-400 italic">🔒 <b>[${speakerName}]</b> ${text}</div>`;
+            }
+
+            // [마스킹 처리] CSS의 투명/노란색 배경 효과를 받기 위해 span 태그로 감싸기
+            if (s.isMasked || s.content?.isMasked) {
+              text = `<span style="background-color: #FFCC00">${text}</span>`;
+            }
+
+            // 발화자 구분 가독성을 위해 이름 색상 다르게 지정
+            const nameColor = isMentor ? "#D97706" : "#2563EB"; 
+
+            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b> ${text}</div>`;
+          }).join('');
+
+          // 스크립트 데이터가 비어있을 경우 방어 코드
+          contentRef.current.innerHTML = htmlContent || "<p class='text-gray-400 text-sm'>대화 내용이 없습니다.</p>";
+        }
+      } catch (err) {
+        console.error("스크립트 열람 실패:", err);
+        setError("스크립트를 불러오는 중 오류가 발생했습니다.");
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    if (id) {
+      fetchScriptData();
     }
-  }, []);
+  }, [id]);
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
       
-      {/* 💡 편집기의 '멘티 뷰' CSS 로직을 그대로 가져왔습니다. */}
+      {/* 편집기의 '멘티 뷰' CSS 로직을 그대로 가져왔습니다. */}
       <style>{`
         .mentee-view-container span[style*="rgb(255, 204, 0)"], 
         .mentee-view-container span[style*="#FFCC00"], 
@@ -42,28 +95,37 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
       {/* 스크립트 본문 영역 */}
       <div className="flex-1 overflow-y-auto px-6 py-8 bg-white custom-scrollbar pb-20">
         
-        <div className="flex items-center gap-2 text-[#FFCC00] mb-3">
-          <FileText className="w-5 h-5" />
-          <span className="text-[13px] font-extrabold tracking-tight">발행 완료 스크립트</span>
-        </div>
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-32 gap-3">
+            <Loader2 className="w-8 h-8 text-[#FFCC00] animate-spin" />
+            <p className="text-[14px] text-gray-400 font-medium">스크립트를 불러오는 중...</p>
+          </div>
+        ) : error ? (
+          <div className="flex flex-col items-center justify-center py-32 gap-3 text-center">
+            <AlertCircle className="w-10 h-10 text-gray-300" />
+            <p className="text-[14px] text-gray-500 font-bold">{error}</p>
+          </div>
+        ) : (
+          <>
 
-        <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Script ID: {id}</p>
-        
-        <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
-          Mentoring Summary - Mar 25, 2026
-        </h2>
+            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Script ID: {id}</p>
+            
+            <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
+              {mentoringInfo?.title}
+              <span className="block text-[15px] font-medium text-gray-400 mt-2 tracking-normal">{mentoringInfo?.date}</span>
+            </h2>
 
-        {/* 💡 편집 기능(contentEditable 등)이 모두 제거된 순수 텍스트 컨테이너입니다.
-          pointer-events-none을 통해 드래그조차 불가능하게 막았습니다. 
-        */}
-        <div 
-          ref={contentRef}
-          className="mentee-view-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight p-6 bg-[#FAFAFA] border border-gray-100 rounded-2xl pointer-events-none shadow-sm"
-        />
-        
-        <p className="text-center text-gray-400 text-[12px] mt-8 font-medium">
-          보안을 위해 일부 텍스트가 블라인드 처리되었습니다.
-        </p>
+            {/* 편집 기능이 제거된 순수 텍스트 컨테이너 (포인터 이벤트 막음) */}
+            <div 
+              ref={contentRef}
+              className="mentee-view-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight p-6 bg-[#FAFAFA] border border-gray-100 rounded-2xl pointer-events-none shadow-sm"
+            />
+            
+            <p className="text-center text-gray-400 text-[12px] mt-8 font-medium">
+              보안을 위해 일부 텍스트가 블라인드 처리되었습니다.
+            </p>
+          </>
+        )}
       </div>
     </main>
   );

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -19,7 +19,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
     const fetchScriptData = async () => {
       setIsLoading(true);
       try {
-        const res = await apiClient.get(`/scripts/${id}`);
+        const res = await apiClient.get(`/api/scripts/${id}`);
         const { mentoring, scripts } = res.data;
 
         // 방어 로직이 적용된 날짜 포맷 변환

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { use, useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import { ChevronLeft, FileText, Loader2, AlertCircle } from "lucide-react";
 import apiClient from "@/lib/apiClient";
 
 export default function PublishedScriptPage({ params }: { params: Promise<{ id: string }> }) {
+  const router = useRouter();
   const { id } = use(params);
   const contentRef = useRef<HTMLDivElement>(null);
 
@@ -86,9 +88,13 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
 
       {/* 헤더 */}
       <header className="flex items-center px-5 py-4 border-b border-gray-100 shrink-0 bg-white z-10">
-        <Link href="/mypage/scripts" className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors">
+        {/* <Link> 대신 router.back()을 사용하는 버튼으로 변경 */}
+        <button 
+          onClick={() => router.back()} 
+          className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
+        >
           <ChevronLeft className="w-6 h-6 text-[#1A1A1A]" strokeWidth={2.5} />
-        </Link>
+        </button>
         <h1 className="text-[17px] font-extrabold tracking-tight ml-2">멘토링 스크립트 열람</h1>
       </header>
 

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -47,12 +47,12 @@ export default function ScriptListPage() {
       setIsLoading(true);
       try {
         // [1] 유저 정보 조회하여 멘토 여부 확인
-        const userRes = await apiClient.get("/users/me");
+        const userRes = await apiClient.get("/api/users/me");
         setIsUserMentor(userRes.data?.user?.role === "MENTOR");
 
         // [2] 스크립트 목록 조회
         const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
-        const scriptRes = await apiClient.get(`/scripts?type=${typeParam}`);
+        const scriptRes = await apiClient.get(`/api/scripts?type=${typeParam}`);
         
         const mappedScripts: ScriptItem[] = scriptRes.data.mentorings.map((m: any) => {
           const d = new Date(m.startedAt);

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -10,7 +10,7 @@ type ScriptItem = {
   mentorName: string;
   topic: string;
   date: string;
-  isPublished: boolean; // TODO: 현재 API에 없으므로 임시로 true 처리
+  isPublished: boolean;
   isGroup: boolean;
   profileColor: string;
 };
@@ -31,13 +31,14 @@ export default function ScriptListPage() {
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
   const [scripts, setScripts] = useState<ScriptItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  
+  // 현재 접속 유저 권한 상태
   const [isUserMentor, setIsUserMentor] = useState(false);
 
   // 탭 클릭 시 URL 쿼리 파라미터를 업데이트하는 함수
   const handleTabChange = (tab: "1:1" | "1:N") => {
     setActiveTab(tab);
     const type = tab === "1:1" ? "one-on-one" : "group";
-    // 페이지 스크롤을 유지하면서 URL만 변경.
     router.replace(`/mypage/scripts?type=${type}`, { scroll: false });
   };
 
@@ -45,18 +46,38 @@ export default function ScriptListPage() {
   useEffect(() => {
     const fetchInitialData = async () => {
       setIsLoading(true);
+      
+      // 💡 [1] 유저 권한 확인 (스크립트 로딩과 분리하여 안전하게 실행)
+      let isMentor = false;
       try {
-        // [1] 유저 정보 조회하여 멘토 여부 확인
-        const userRes = await apiClient.get("/api/users/me");
-        setIsUserMentor(userRes.data?.user?.role === "MENTOR");
-
-        // [2] 스크립트 목록 조회
-        const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
-        const scriptRes = await apiClient.get(`/api/scripts?type=${typeParam}`);
+        const userRes = await apiClient.get("/users/me");
         
+        // 🚨 F12 개발자 도구의 '콘솔(Console)' 탭에서 이 로그를 반드시 확인하세요!
+        console.log("👤 내 정보 API 응답:", userRes.data); 
+
+        // 💡 콘솔에 찍힌 데이터 구조에 맞춰 아래 조건을 수정해야 합니다!
+        // (예시 1) isMentor = userRes.data.role === "MENTOR";
+        // (예시 2) isMentor = userRes.data.userType === "mentor";
+        isMentor = userRes.data?.role === "MENTOR"; 
+        
+        setIsUserMentor(isMentor);
+      } catch (userError) {
+        console.error("유저 정보 로딩 실패:", userError);
+      }
+
+      // [2] 스크립트 목록 조회
+      try {
+        const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
+        const scriptRes = await apiClient.get(`/scripts?type=${typeParam}`);
+        
+        // 💡 백엔드가 보내주는 진짜 데이터를 확인하기 위한 로그 추가!
+        console.log("📝 스크립트 API 응답:", scriptRes.data);
+
         const mappedScripts: ScriptItem[] = scriptRes.data.mentorings.map((m: any) => {
-          const d = new Date(m.startedAt);
-          const dateStr = `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`;
+          const d = m.startedAt ? new Date(m.startedAt) : null;
+          const dateStr = d 
+            ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
+            : "날짜 미상";
           
           return {
             id: Number(m.mentoringId),
@@ -65,13 +86,13 @@ export default function ScriptListPage() {
             date: dateStr,
             isGroup: m.isGroup,
             profileColor: COLORS[Number(m.mentoringId) % COLORS.length],
-            isPublished: true, // ⚠️ 임시 고정값
+            isPublished: Boolean(m.isScriptPublished),
           };
         });
 
         setScripts(mappedScripts);
       } catch (error) {
-        console.error("데이터 로딩 실패:", error);
+        console.error("스크립트 데이터 로딩 실패:", error);
       } finally {
         setIsLoading(false);
       }
@@ -98,12 +119,15 @@ export default function ScriptListPage() {
     return list;
   }, [scripts, searchQuery, sortOrder]);
 
-  // 💡 3. 유저 역할에 맞게 페이지 라우팅 로직 수정
+  // 💡 라우팅 로직: 멘토의 발행 전은 편집 뷰, 발행 완료는 열람 뷰
   const handleScriptClick = (scriptId: number, isPublished: boolean) => {
-    if (isUserMentor && !isPublished) {
-      router.push(`/script/${scriptId}`); 
-    } else if (isPublished) {
-      router.push(`/mypage/scripts/${scriptId}`); 
+    if (!isPublished) {
+      if (isUserMentor) {
+        router.push(`/script/${scriptId}`); // 멘토: 미발행 스크립트 클릭 시 편집 뷰로 이동
+      }
+      // 멘티: 미발행 스크립트는 UI 단에서 클릭을 막으므로 여기 도달하지 않음
+    } else {
+      router.push(`/mypage/scripts/${scriptId}`); // 공통: 발행 완료 스크립트 클릭 시 열람 뷰로 이동
     }
   };
 
@@ -146,7 +170,6 @@ export default function ScriptListPage() {
         )}
       </header>
 
-      {/* onClick 이벤트에서 handleTabChange 호출 */}
       <div className="flex w-full border-b border-gray-100">
         <button 
           onClick={() => handleTabChange("1:1")} 
@@ -185,15 +208,16 @@ export default function ScriptListPage() {
           </div>
         ) : processedScripts.length > 0 ? (
           processedScripts.map((script) => {
-            // 💡 5. 역할 기반 조건부 렌더링 로직 적용
+            // 💡 멘티이면서 미발행 상태인 스크립트 판별
             const isMenteeWaiting = !isUserMentor && !script.isPublished;
 
             return (
               <div 
                 key={script.id} 
+                // 💡 멘티 대기중일 때는 클릭 방지
                 onClick={() => !isMenteeWaiting && handleScriptClick(script.id, script.isPublished)}
                 className={`flex flex-col bg-white border border-gray-100 rounded-2xl p-5 shadow-sm transition-all
-                  ${isMenteeWaiting ? 'opacity-50 cursor-not-allowed bg-gray-50' : 'cursor-pointer hover:shadow-md active:scale-[0.98]'}
+                  ${isMenteeWaiting ? 'opacity-60 cursor-not-allowed bg-gray-50' : 'cursor-pointer hover:shadow-md active:scale-[0.98]'}
                 `}
               >
                 <div className="flex items-start justify-between mb-4">
@@ -229,11 +253,12 @@ export default function ScriptListPage() {
                     ) : (
                       <div className="flex items-center gap-1 text-[#FFCC00] font-bold">
                         <Edit3 className="w-3.5 h-3.5" />
+                        {/* 멘토면 "편집 필요", 멘티면 "발행 대기중" 출력 */}
                         {isUserMentor ? "편집 필요" : "발행 대기중"}
                       </div>
                     )}
                   </div>
-                  <ChevronRight className="w-4 h-4 text-gray-300" />
+                  <ChevronRight className={`w-4 h-4 ${isMenteeWaiting ? 'text-gray-200' : 'text-gray-300'}`} />
                 </div>
               </div>
             );

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -47,17 +47,11 @@ export default function ScriptListPage() {
     const fetchInitialData = async () => {
       setIsLoading(true);
       
-      // 💡 [1] 유저 권한 확인 (스크립트 로딩과 분리하여 안전하게 실행)
+      // [1] 유저 권한 확인 (스크립트 로딩과 분리하여 안전하게 실행)
       let isMentor = false;
       try {
-        const userRes = await apiClient.get("/users/me");
-        
-        // 🚨 F12 개발자 도구의 '콘솔(Console)' 탭에서 이 로그를 반드시 확인하세요!
-        console.log("👤 내 정보 API 응답:", userRes.data); 
+        const userRes = await apiClient.get("/api/users/me");
 
-        // 💡 콘솔에 찍힌 데이터 구조에 맞춰 아래 조건을 수정해야 합니다!
-        // (예시 1) isMentor = userRes.data.role === "MENTOR";
-        // (예시 2) isMentor = userRes.data.userType === "mentor";
         isMentor = userRes.data?.role === "MENTOR"; 
         
         setIsUserMentor(isMentor);
@@ -68,11 +62,8 @@ export default function ScriptListPage() {
       // [2] 스크립트 목록 조회
       try {
         const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
-        const scriptRes = await apiClient.get(`/scripts?type=${typeParam}`);
+        const scriptRes = await apiClient.get(`/api/scripts?type=${typeParam}`);
         
-        // 💡 백엔드가 보내주는 진짜 데이터를 확인하기 위한 로그 추가!
-        console.log("📝 스크립트 API 응답:", scriptRes.data);
-
         const mappedScripts: ScriptItem[] = scriptRes.data.mentorings.map((m: any) => {
           const d = m.startedAt ? new Date(m.startedAt) : null;
           const dateStr = d 
@@ -119,7 +110,7 @@ export default function ScriptListPage() {
     return list;
   }, [scripts, searchQuery, sortOrder]);
 
-  // 💡 라우팅 로직: 멘토의 발행 전은 편집 뷰, 발행 완료는 열람 뷰
+  // 라우팅 로직: 멘토의 발행 전은 편집 뷰, 발행 완료는 열람 뷰
   const handleScriptClick = (scriptId: number, isPublished: boolean) => {
     if (!isPublished) {
       if (isUserMentor) {
@@ -208,13 +199,13 @@ export default function ScriptListPage() {
           </div>
         ) : processedScripts.length > 0 ? (
           processedScripts.map((script) => {
-            // 💡 멘티이면서 미발행 상태인 스크립트 판별
+            // 멘티이면서 미발행 상태인 스크립트 판별
             const isMenteeWaiting = !isUserMentor && !script.isPublished;
 
             return (
               <div 
                 key={script.id} 
-                // 💡 멘티 대기중일 때는 클릭 방지
+                // 멘티 대기중일 때는 클릭 방지
                 onClick={() => !isMenteeWaiting && handleScriptClick(script.id, script.isPublished)}
                 className={`flex flex-col bg-white border border-gray-100 rounded-2xl p-5 shadow-sm transition-all
                   ${isMenteeWaiting ? 'opacity-60 cursor-not-allowed bg-gray-50' : 'cursor-pointer hover:shadow-md active:scale-[0.98]'}

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useState, useMemo, useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { ChevronLeft, FileText, Calendar, User, Users, ChevronRight, Edit3, CheckCircle2, Search } from "lucide-react";
-
 import apiClient from "@/lib/apiClient";
 
 type ScriptItem = {
@@ -20,32 +19,36 @@ const COLORS = ["bg-blue-500", "bg-emerald-500", "bg-purple-900", "bg-orange-900
 
 export default function ScriptListPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   
+  // URL 쿼리 파라미터(?type=group)를 읽어 초기 탭 상태 결정
+  const currentTabParam = searchParams.get("type") === "group" ? "1:N" : "1:1";
+  const [activeTab, setActiveTab] = useState<"1:1" | "1:N">(currentTabParam);
+
   // 상태 관리
-  const [activeTab, setActiveTab] = useState<"1:1" | "1:N">("1:1");
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
-
-  // API 상태 관리
   const [scripts, setScripts] = useState<ScriptItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  
-  // 💡 1. 유저 권한 상태 추가
   const [isUserMentor, setIsUserMentor] = useState(false);
 
-  // 💡 2. 초기 로딩 시 유저 정보 및 스크립트 목록 가져오기
+  // 탭 클릭 시 URL 쿼리 파라미터를 업데이트하는 함수
+  const handleTabChange = (tab: "1:1" | "1:N") => {
+    setActiveTab(tab);
+    const type = tab === "1:1" ? "one-on-one" : "group";
+    // 페이지 스크롤을 유지하면서 URL만 변경.
+    router.replace(`/mypage/scripts?type=${type}`, { scroll: false });
+  };
+
+  // 초기 로딩 시 유저 정보 및 스크립트 목록 가져오기
   useEffect(() => {
     const fetchInitialData = async () => {
       setIsLoading(true);
       try {
         // [1] 유저 정보 조회하여 멘토 여부 확인
         const userRes = await apiClient.get("/users/me");
-        if (userRes.data?.user?.role === "MENTOR") {
-          setIsUserMentor(true);
-        } else {
-          setIsUserMentor(false);
-        }
+        setIsUserMentor(userRes.data?.user?.role === "MENTOR");
 
         // [2] 스크립트 목록 조회
         const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
@@ -143,14 +146,19 @@ export default function ScriptListPage() {
         )}
       </header>
 
-      {/* 💡 4. 하드코딩된 테스트 전환 버튼 삭제 */}
-
+      {/* onClick 이벤트에서 handleTabChange 호출 */}
       <div className="flex w-full border-b border-gray-100">
-        <button onClick={() => {setActiveTab("1:1"); setSearchQuery("");}} className={`flex-1 py-4 text-[15px] font-bold transition-all relative ${activeTab === "1:1" ? "text-[#1A1A1A]" : "text-gray-400"}`}>
+        <button 
+          onClick={() => handleTabChange("1:1")} 
+          className={`flex-1 py-4 text-[15px] font-bold transition-all relative ${activeTab === "1:1" ? "text-[#1A1A1A]" : "text-gray-400"}`}
+        >
           1:1 멘토링
           {activeTab === "1:1" && <div className="absolute bottom-0 left-0 w-full h-[2px] bg-[#1A1A1A]" />}
         </button>
-        <button onClick={() => {setActiveTab("1:N"); setSearchQuery("");}} className={`flex-1 py-4 text-[15px] font-bold transition-all relative ${activeTab === "1:N" ? "text-[#1A1A1A]" : "text-gray-400"}`}>
+        <button 
+          onClick={() => handleTabChange("1:N")} 
+          className={`flex-1 py-4 text-[15px] font-bold transition-all relative ${activeTab === "1:N" ? "text-[#1A1A1A]" : "text-gray-400"}`}
+        >
           1:N 멘토링
           {activeTab === "1:N" && <div className="absolute bottom-0 left-0 w-full h-[2px] bg-[#1A1A1A]" />}
         </button>

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -1,97 +1,103 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronLeft, FileText, Calendar, User, Users, ChevronRight, Edit3, CheckCircle2, Search } from "lucide-react";
 
-// 💡 1. 1:1 스크립트와 1:N 스크립트를 아우르는 공통 타입을 정의합니다.
+import apiClient from "@/lib/apiClient";
+
 type ScriptItem = {
   id: number;
   mentorName: string;
   topic: string;
   date: string;
-  isPublished: boolean;
-  profileColor?: string;     // 1:1 전용 속성 (선택적)
-  thumbnailColor?: string;   // 1:N 전용 속성 (선택적)
+  isPublished: boolean; // TODO: 현재 API에 없으므로 임시로 true 처리
+  isGroup: boolean;
+  profileColor: string;
 };
 
-// 💡 2. MOCK_SCRIPTS 객체에 방금 만든 타입을 명시해 줍니다.
-const MOCK_SCRIPTS: { ONE_ON_ONE: ScriptItem[]; ONE_TO_N: ScriptItem[] } = {
-  ONE_ON_ONE: [
-    {
-      id: 1,
-      mentorName: "AI네이티브개발자",
-      topic: "백엔드 신입 포트폴리오 전략",
-      date: "2026. 04. 25",
-      profileColor: "bg-blue-500",
-      isPublished: true, 
-    },
-    {
-      id: 2,
-      mentorName: "프론트엔드장인",
-      topic: "React 성능 최적화 심화 멘토링",
-      date: "2026. 04. 28",
-      profileColor: "bg-emerald-500",
-      isPublished: false, 
-    },
-  ],
-  ONE_TO_N: [
-    {
-      id: 101,
-      mentorName: "게임개발자K",
-      topic: "Unreal Engine 5 구조 설계 노하우 라이브",
-      date: "2026. 04. 20",
-      thumbnailColor: "bg-purple-900",
-      isPublished: true,
-    },
-    {
-      id: 102,
-      mentorName: "기획왕",
-      topic: "주니어 PM을 위한 데이터 지표 읽기",
-      date: "2026. 04. 27",
-      thumbnailColor: "bg-orange-900",
-      isPublished: false,
-    }
-  ]
-};
+const COLORS = ["bg-blue-500", "bg-emerald-500", "bg-purple-900", "bg-orange-900", "bg-pink-600"];
 
 export default function ScriptListPage() {
   const router = useRouter();
   
   // 상태 관리
   const [activeTab, setActiveTab] = useState<"1:1" | "1:N">("1:1");
-  const [userRole, setUserRole] = useState<"MENTEE" | "MENTOR">("MENTEE");
-  
-  // 💡 검색 및 정렬을 위한 상태 추가
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState("");
   const [sortOrder, setSortOrder] = useState<"newest" | "oldest">("newest");
 
-  // 💡 데이터 필터링 및 정렬 로직 (useMemo로 최적화)
-  const processedScripts = useMemo(() => {
-    let list = activeTab === "1:1" ? MOCK_SCRIPTS.ONE_ON_ONE : MOCK_SCRIPTS.ONE_TO_N;
+  // API 상태 관리
+  const [scripts, setScripts] = useState<ScriptItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  
+  // 💡 1. 유저 권한 상태 추가
+  const [isUserMentor, setIsUserMentor] = useState(false);
 
-    // 1. 검색어 필터링 (주제 제목 기준)
+  // 💡 2. 초기 로딩 시 유저 정보 및 스크립트 목록 가져오기
+  useEffect(() => {
+    const fetchInitialData = async () => {
+      setIsLoading(true);
+      try {
+        // [1] 유저 정보 조회하여 멘토 여부 확인
+        const userRes = await apiClient.get("/users/me");
+        if (userRes.data?.user?.role === "MENTOR") {
+          setIsUserMentor(true);
+        } else {
+          setIsUserMentor(false);
+        }
+
+        // [2] 스크립트 목록 조회
+        const typeParam = activeTab === "1:1" ? "one-on-one" : "group";
+        const scriptRes = await apiClient.get(`/scripts?type=${typeParam}`);
+        
+        const mappedScripts: ScriptItem[] = scriptRes.data.mentorings.map((m: any) => {
+          const d = new Date(m.startedAt);
+          const dateStr = `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`;
+          
+          return {
+            id: Number(m.mentoringId),
+            mentorName: m.host?.nickname || "알 수 없음",
+            topic: m.title,
+            date: dateStr,
+            isGroup: m.isGroup,
+            profileColor: COLORS[Number(m.mentoringId) % COLORS.length],
+            isPublished: true, // ⚠️ 임시 고정값
+          };
+        });
+
+        setScripts(mappedScripts);
+      } catch (error) {
+        console.error("데이터 로딩 실패:", error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchInitialData();
+  }, [activeTab]);
+
+  const processedScripts = useMemo(() => {
+    let list = [...scripts];
+
     if (searchQuery.trim() !== "") {
       list = list.filter(script => 
         script.topic.toLowerCase().includes(searchQuery.toLowerCase())
       );
     }
 
-    // 2. 날짜 정렬
-    list = [...list].sort((a, b) => {
-      // "2026. 04. 25" 형식을 "2026-04-25" 형식으로 변환하여 안전하게 Date 객체로 만듭니다.
+    list.sort((a, b) => {
       const dateA = new Date(a.date.split(". ").join("-")).getTime();
       const dateB = new Date(b.date.split(". ").join("-")).getTime();
-      
       return sortOrder === "newest" ? dateB - dateA : dateA - dateB;
     });
 
     return list;
-  }, [activeTab, searchQuery, sortOrder]);
+  }, [scripts, searchQuery, sortOrder]);
 
+  // 💡 3. 유저 역할에 맞게 페이지 라우팅 로직 수정
   const handleScriptClick = (scriptId: number, isPublished: boolean) => {
-    if (userRole === "MENTOR" && !isPublished) {
+    if (isUserMentor && !isPublished) {
       router.push(`/script/${scriptId}`); 
     } else if (isPublished) {
       router.push(`/mypage/scripts/${scriptId}`); 
@@ -101,7 +107,6 @@ export default function ScriptListPage() {
   return (
     <main className="flex flex-col w-full bg-white text-[#1A1A1A] font-sans min-h-[100dvh] pb-[80px]">
       
-      {/* 💡 헤더 - 검색 버튼 및 검색창 입력 UI 추가 */}
       <header className="flex items-center justify-between px-2 py-4 sticky top-0 bg-white z-20 border-b border-gray-50">
         {!isSearchOpen ? (
           <>
@@ -138,23 +143,7 @@ export default function ScriptListPage() {
         )}
       </header>
 
-      <div className="px-5 py-3 bg-gray-50 border-b border-gray-100 flex items-center justify-between">
-        <span className="text-[13px] font-bold text-gray-500">현재 접속 계정 테스트</span>
-        <div className="flex bg-gray-200 p-1 rounded-lg">
-          <button 
-            onClick={() => setUserRole("MENTEE")}
-            className={`px-3 py-1 text-[12px] font-bold rounded-md transition-all ${userRole === "MENTEE" ? "bg-white shadow-sm" : "text-gray-500"}`}
-          >
-            멘티 모드
-          </button>
-          <button 
-            onClick={() => setUserRole("MENTOR")}
-            className={`px-3 py-1 text-[12px] font-bold rounded-md transition-all ${userRole === "MENTOR" ? "bg-[#1A1A1A] text-[#FFCC00] shadow-sm" : "text-gray-500"}`}
-          >
-            멘토 모드
-          </button>
-        </div>
-      </div>
+      {/* 💡 4. 하드코딩된 테스트 전환 버튼 삭제 */}
 
       <div className="flex w-full border-b border-gray-100">
         <button onClick={() => {setActiveTab("1:1"); setSearchQuery("");}} className={`flex-1 py-4 text-[15px] font-bold transition-all relative ${activeTab === "1:1" ? "text-[#1A1A1A]" : "text-gray-400"}`}>
@@ -167,7 +156,6 @@ export default function ScriptListPage() {
         </button>
       </div>
 
-      {/* 💡 정렬 셀렉트 박스 및 결과 건수 */}
       <div className="flex items-center justify-between px-5 py-3 mt-1">
         <span className="text-[13px] font-bold text-gray-500">
           총 {processedScripts.length}건
@@ -182,11 +170,15 @@ export default function ScriptListPage() {
         </select>
       </div>
 
-      {/* 리스트 렌더링 (processedScripts 사용) */}
       <div className="flex flex-col px-5 pb-5 gap-4">
-        {processedScripts.length > 0 ? (
+        {isLoading ? (
+          <div className="flex justify-center py-20">
+            <div className="w-8 h-8 border-4 border-gray-200 border-t-[#FFCC00] rounded-full animate-spin"></div>
+          </div>
+        ) : processedScripts.length > 0 ? (
           processedScripts.map((script) => {
-            const isMenteeWaiting = userRole === "MENTEE" && !script.isPublished;
+            // 💡 5. 역할 기반 조건부 렌더링 로직 적용
+            const isMenteeWaiting = !isUserMentor && !script.isPublished;
 
             return (
               <div 
@@ -198,13 +190,13 @@ export default function ScriptListPage() {
               >
                 <div className="flex items-start justify-between mb-4">
                   <div className="flex items-center gap-3">
-                    {activeTab === "1:1" ? (
-                      <div className={`w-10 h-10 rounded-full ${script.profileColor} flex items-center justify-center text-white shrink-0`}>
-                        <User className="w-5 h-5" />
+                    {script.isGroup ? (
+                      <div className={`w-10 h-10 rounded-lg ${script.profileColor} flex items-center justify-center text-white shrink-0`}>
+                        <Users className="w-5 h-5" />
                       </div>
                     ) : (
-                      <div className={`w-10 h-10 rounded-lg ${script.thumbnailColor} flex items-center justify-center text-white shrink-0`}>
-                        <Users className="w-5 h-5" />
+                      <div className={`w-10 h-10 rounded-full ${script.profileColor} flex items-center justify-center text-white shrink-0`}>
+                        <User className="w-5 h-5" />
                       </div>
                     )}
                     <div className="flex flex-col">
@@ -229,7 +221,7 @@ export default function ScriptListPage() {
                     ) : (
                       <div className="flex items-center gap-1 text-[#FFCC00] font-bold">
                         <Edit3 className="w-3.5 h-3.5" />
-                        {userRole === "MENTOR" ? "편집 필요" : "발행 대기중"}
+                        {isUserMentor ? "편집 필요" : "발행 대기중"}
                       </div>
                     )}
                   </div>

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -28,7 +28,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     const fetchScriptData = async () => {
       setIsLoading(true);
       try {
-        const res = await apiClient.get(`/scripts/${id}`);
+        const res = await apiClient.get(`/api/scripts/${id}`);
         const { mentoring, scripts } = res.data;
 
         const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
@@ -158,7 +158,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
         };
       });
 
-      await apiClient.patch(`/scripts/${id}/publish`, { scripts: payloadScripts });
+      await apiClient.patch(`/api/scripts/${id}/publish`, { scripts: payloadScripts });
       
       alert("성공적으로 발행되었습니다!");
       setIsPublishPopupOpen(false);
@@ -172,7 +172,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     }
   };
 
-  // 3. 💡 에디터 키보드 제어 (Enter 줄바꿈 완전 차단)
+  // 3. 에디터 키보드 제어 (Enter 줄바꿈 차단)
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
     if (e.key === 'Enter') {
       e.preventDefault(); // Enter 키의 기본 동작(줄바꿈, 블록 분리)을 완벽히 무시합니다.
@@ -311,7 +311,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
               suppressContentEditableWarning
               onClick={handleEditorClick}
               onInput={updateUndoState}
-              onKeyDown={handleKeyDown} // 💡 핵심: 여기서 Enter 동작을 완벽히 차단합니다.
+              onKeyDown={handleKeyDown}
               onKeyUp={updateUndoState}
               className={`editor-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight transition-all p-4 -mx-4 rounded-xl
                 ${isMenteeView ? 'mentee-view bg-[#FAFAFA] border border-gray-100 pointer-events-none' : 'focus:ring-2 focus:ring-[#FFCC00]/30 cursor-text'}

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-// 💡 1. params Promise를 풀기 위해 React에서 'use'를 추가로 불러옵니다.
 import { useState, useEffect, useRef, use } from "react";
-import Link from "next/link";
-import { ChevronLeft, Undo2, Save, Send, Bell, MousePointer2, Grab, Eraser, EyeOff } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ChevronLeft, Undo2, Send, Bell, MousePointer2, Grab, Eraser, EyeOff, Loader2 } from "lucide-react";
 
-// 💡 2. params의 타입을 Promise로 감싸줍니다.
+import apiClient from "@/lib/apiClient";
+
 export default function ScriptEditPage({ params }: { params: Promise<{ id: string }> }) {
-  // 💡 3. use() 훅을 사용하여 비동기 params 객체에서 id 값을 안전하게 꺼냅니다.
+  const router = useRouter();
   const { id } = use(params);
 
   const [isMenteeView, setIsMenteeView] = useState(false);
@@ -17,19 +17,170 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
   const [canUndo, setCanUndo] = useState(false);
   const [clickRangeStart, setClickRangeStart] = useState<Range | null>(null);
   
+  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string } | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isPublishing, setIsPublishing] = useState(false);
+
   const editorRef = useRef<HTMLDivElement>(null);
 
+  // 1. 초기 데이터 로드
   useEffect(() => {
-    if (editorRef.current && !editorRef.current.innerHTML) {
-      editorRef.current.innerHTML = `During our session today, we discussed the strategic roadmap for the upcoming quarter. We focused on three main pillars: operational efficiency, stakeholder communication, and technical debt reduction.<br><br>I noticed that your approach to delegating tasks has improved significantly. However, you should still monitor the velocity of the secondary team when sharing the board with junior designers.`;
-    }
-    updateUndoState();
-  }, []);
+    const fetchScriptData = async () => {
+      setIsLoading(true);
+      try {
+        const res = await apiClient.get(`/scripts/${id}`);
+        const { mentoring, scripts } = res.data;
 
-  const updateUndoState = () => {
-    setCanUndo(document.queryCommandEnabled('undo'));
+        const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
+        const dateStr = d 
+          ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
+          : "날짜 정보 없음";
+
+        setMentoringInfo({ title: mentoring.title, date: dateStr });
+
+        if (editorRef.current) {
+          const htmlContent = scripts.map((s: any) => {
+            const scriptId = s.scriptId;
+            const speakerName = s.speaker?.nickname || "알 수 없음";
+            const isMentor = s.speaker?.isHostMentor;
+            
+            const timestamp = s.content?.timestamp 
+              ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none" contenteditable="false">${s.content.timestamp}</span>` 
+              : "";
+
+            let textHTML = "";
+
+            if (s.content?.isPrivate || s.isPrivate) {
+              textHTML = s.content?.text || "비공개 질문입니다.";
+              return `<div class="mb-4 text-gray-400 italic" contenteditable="false">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
+            }
+
+            if (s.content?.pieces && Array.isArray(s.content.pieces)) {
+              textHTML = s.content.pieces.map((piece: any) => {
+                const escapedText = (piece.text || "").replace(/\n/g, "<br>");
+                if (piece.isMasked) {
+                  return `<span style="background-color: #FFCC00">${escapedText}</span>`;
+                }
+                return escapedText;
+              }).join('');
+            } else {
+              textHTML = (s.content?.text || s.content?.message || "").replace(/\n/g, "<br>");
+              if (s.masked || s.isMasked || s.content?.isMasked) {
+                textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+              }
+            }
+
+            const nameColor = isMentor ? "#D97706" : "#2563EB"; 
+
+            return `<div class="mb-4 script-block" data-script-id="${scriptId}">
+              <b style="color: ${nameColor};" contenteditable="false">[${speakerName}]</b>${timestamp}<br />
+              <span class="inline-block mt-0.5 script-content">${textHTML}</span>
+            </div>`;
+          }).join('');
+          
+          editorRef.current.innerHTML = htmlContent || "<p class='text-gray-400'>내용을 찾을 수 없습니다.</p>";
+        }
+      } catch (error) {
+        console.error("데이터 로드 실패:", error);
+      } finally {
+        setIsLoading(false);
+        updateUndoState();
+      }
+    };
+
+    if (id) fetchScriptData();
+  }, [id]);
+
+  // 2. 스크립트 발행 (데이터 수집)
+  const handlePublish = async () => {
+    if (!editorRef.current || isPublishing) return;
+    setIsPublishing(true);
+
+    try {
+      const scriptBlocks = editorRef.current.querySelectorAll('.script-block');
+      
+      const payloadMap = new Map<string, { text: string; isMasked: boolean }[]>();
+
+      scriptBlocks.forEach((block) => {
+        const scriptId = block.getAttribute('data-script-id');
+        const contentNode = block.querySelector('.script-content');
+        
+        if (!scriptId || !contentNode) return;
+
+        const pieces: { text: string; isMasked: boolean }[] = [];
+        
+        const parseNode = (node: Node, isCurrentlyMasked: boolean) => {
+          if (node.nodeType === Node.TEXT_NODE) {
+            if (node.textContent) {
+              pieces.push({ text: node.textContent, isMasked: isCurrentlyMasked });
+            }
+          } else if (node.nodeType === Node.ELEMENT_NODE) {
+            const el = node as HTMLElement;
+            const tag = el.tagName.toUpperCase();
+
+            // 엔터를 막았기 때문에 BR 태그가 생길 일은 없지만, 기존 데이터 호환을 위해 남겨둠
+            if (tag === 'BR') {
+              pieces.push({ text: '\n', isMasked: isCurrentlyMasked });
+              return;
+            }
+
+            const bg = el.style.backgroundColor;
+            const isNodeMasked = bg.includes('rgb(255, 204, 0)') || bg.includes('#FFCC00') || bg.includes('#ffcc00');
+            const effectiveMask = isCurrentlyMasked || isNodeMasked;
+
+            el.childNodes.forEach(child => parseNode(child, effectiveMask));
+          }
+        };
+
+        contentNode.childNodes.forEach(child => parseNode(child, false));
+
+        if (!payloadMap.has(scriptId)) {
+          payloadMap.set(scriptId, pieces);
+        } else {
+          const existing = payloadMap.get(scriptId)!;
+          existing.push(...pieces);
+        }
+      });
+
+      const payloadScripts = Array.from(payloadMap.entries()).map(([scriptId, rawPieces]) => {
+        const mergedPieces = rawPieces.reduce((acc, current) => {
+          if (acc.length > 0 && acc[acc.length - 1].isMasked === current.isMasked) {
+            acc[acc.length - 1].text += current.text;
+          } else {
+            acc.push({ ...current });
+          }
+          return acc;
+        }, [] as { text: string; isMasked: boolean }[]);
+
+        return {
+          scriptId: scriptId,
+          content: { pieces: mergedPieces }
+        };
+      });
+
+      await apiClient.patch(`/scripts/${id}/publish`, { scripts: payloadScripts });
+      
+      alert("성공적으로 발행되었습니다!");
+      setIsPublishPopupOpen(false);
+      router.push('/mypage/scripts'); 
+      
+    } catch (error: any) {
+      console.error("스크립트 발행 실패:", error);
+      alert(error.response?.data?.message || "발행에 실패했습니다. 다시 시도해주세요.");
+    } finally {
+      setIsPublishing(false);
+    }
   };
 
+  // 3. 💡 에디터 키보드 제어 (Enter 줄바꿈 완전 차단)
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault(); // Enter 키의 기본 동작(줄바꿈, 블록 분리)을 완벽히 무시합니다.
+      return; // 아무 작업도 수행하지 않고 종료
+    }
+  };
+
+  const updateUndoState = () => setCanUndo(document.queryCommandEnabled('undo'));
   const applyMask = (color: string) => {
     if (editorRef.current) editorRef.current.focus();
     if (!document.execCommand('hiliteColor', false, color)) {
@@ -38,12 +189,10 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     updateUndoState();
     setClickRangeStart(null);
   };
-
   const handleAction = (action: 'mask' | 'erase') => {
     if (action === 'mask') applyMask('#FFCC00');
     else if (action === 'erase') applyMask('transparent');
   };
-
   const handleUndo = () => {
     document.execCommand('undo');
     updateUndoState();
@@ -55,10 +204,8 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     if (editMode !== 'click' || isMenteeView) return;
 
     const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-
-    if (!sel.isCollapsed) {
-      setClickRangeStart(null);
+    if (!sel || sel.rangeCount === 0 || !sel.isCollapsed) {
+      if (sel && !sel.isCollapsed) setClickRangeStart(null);
       return;
     }
 
@@ -84,9 +231,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     }
   };
 
-  useEffect(() => {
-    setClickRangeStart(null);
-  }, [editMode]);
+  useEffect(() => { setClickRangeStart(null); }, [editMode]);
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
@@ -106,10 +251,9 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
       <header className="flex items-center justify-between px-5 py-4 border-b border-gray-100 shrink-0 bg-white z-10">
         <div className="flex items-center gap-3">
-          {/* 뒤로 가기 버튼: 브라우저 환경을 고려해 단순 링크에서 router.back() 등을 사용할 수도 있습니다. */}
-          <Link href="/mypage/scripts" className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors">
+          <button onClick={() => router.back()} className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors">
             <ChevronLeft className="w-6 h-6 text-[#1A1A1A]" strokeWidth={2.5} />
-          </Link>
+          </button>
           <h1 className="text-[17px] font-extrabold tracking-tight">스크립트 편집 & 리뷰</h1>
         </div>
         
@@ -134,26 +278,13 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
         </div>
         
         <div className="flex items-center gap-2">
-          <button 
-            onMouseDown={(e) => e.preventDefault()} 
-            onClick={() => handleAction('mask')} 
-            className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" 
-            title="선택된 영역 마스킹"
-          >
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹">
             <EyeOff className="w-4 h-4" />
           </button>
-
-          <button 
-            onMouseDown={(e) => e.preventDefault()} 
-            onClick={() => handleAction('erase')} 
-            className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" 
-            title="선택된 영역 마스킹 해제"
-          >
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('erase')} className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹 해제">
             <Eraser className="w-4 h-4" />
           </button>
-
           <div className="h-4 w-[1px] bg-gray-300 mx-1" />
-          
           <button onMouseDown={(e) => e.preventDefault()} onClick={handleUndo} disabled={!canUndo} className={`p-2 rounded-lg transition-colors ${canUndo ? 'text-gray-700 hover:bg-gray-200' : 'text-gray-300 cursor-not-allowed'}`} title="실행 취소">
             <Undo2 className="w-4 h-4" />
           </button>
@@ -161,33 +292,45 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 py-8 bg-white custom-scrollbar">
-        {/* 💡 4. 위에서 use()로 꺼낸 id를 직접 사용합니다. */}
-        <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Script ID: {id}</p>
-        
-        <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
-          Mentoring Summary - Mar 25, 2026
-        </h2>
+        {isLoading ? (
+          <div className="flex flex-col items-center justify-center py-20 gap-3">
+            <Loader2 className="w-8 h-8 text-[#FFCC00] animate-spin" />
+            <p className="text-[14px] text-gray-400">데이터를 불러오는 중입니다...</p>
+          </div>
+        ) : (
+          <>
+            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Mentoring ID: {id}</p>
+            <h2 className="text-[26px] font-extrabold text-[#1A1A1A] leading-tight mb-8">
+              {mentoringInfo?.title}
+              <span className="block text-[15px] font-medium text-gray-400 mt-2 tracking-normal">{mentoringInfo?.date}</span>
+            </h2>
 
-        <div 
-          ref={editorRef}
-          contentEditable={!isMenteeView}
-          suppressContentEditableWarning
-          onClick={handleEditorClick}
-          onInput={updateUndoState}
-          onKeyUp={updateUndoState}
-          className={`editor-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight transition-all p-4 -mx-4 rounded-xl
-            ${isMenteeView ? 'mentee-view bg-[#FAFAFA] border border-gray-100 pointer-events-none' : 'focus:ring-2 focus:ring-[#FFCC00]/30 cursor-text'}
-          `}
-        />
+            <div 
+              ref={editorRef}
+              contentEditable={!isMenteeView}
+              suppressContentEditableWarning
+              onClick={handleEditorClick}
+              onInput={updateUndoState}
+              onKeyDown={handleKeyDown} // 💡 핵심: 여기서 Enter 동작을 완벽히 차단합니다.
+              onKeyUp={updateUndoState}
+              className={`editor-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight transition-all p-4 -mx-4 rounded-xl
+                ${isMenteeView ? 'mentee-view bg-[#FAFAFA] border border-gray-100 pointer-events-none' : 'focus:ring-2 focus:ring-[#FFCC00]/30 cursor-text'}
+              `}
+            />
+          </>
+        )}
       </div>
 
-      <div className="w-full px-5 py-4 bg-white border-t border-gray-100 flex gap-3 shrink-0 pb-safe z-20">
-        <button className="flex flex-col items-center justify-center w-20 bg-white text-gray-600 hover:bg-gray-50 rounded-2xl border border-gray-200 active:scale-95 transition-transform">
-          <Save className="w-5 h-5 mb-1" />
-          <span className="text-[11px] font-bold">임시 저장</span>
-        </button>
-        <button onClick={() => setIsPublishPopupOpen(true)} className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-extrabold text-[16px] py-4 rounded-2xl hover:bg-[#E6B800] transition-colors flex items-center justify-center gap-2 active:scale-[0.98] shadow-sm">
-          <Send className="w-5 h-5" /> 발행하기
+      <div className="w-full px-5 py-4 bg-white border-t border-gray-100 flex shrink-0 pb-safe z-20">
+        <button 
+          onClick={() => setIsPublishPopupOpen(true)} 
+          disabled={isPublishing}
+          className={`flex-1 bg-[#FFCC00] text-[#1A1A1A] font-extrabold text-[16px] py-4 rounded-2xl transition-colors flex items-center justify-center gap-2 shadow-sm
+            ${isPublishing ? 'opacity-60 cursor-not-allowed' : 'hover:bg-[#E6B800] active:scale-[0.98]'}
+          `}
+        >
+          {isPublishing ? <Loader2 className="w-5 h-5 animate-spin" /> : <Send className="w-5 h-5" />}
+          {isPublishing ? '발행 중...' : '발행하기'}
         </button>
       </div>
 
@@ -199,12 +342,23 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
             </div>
             <h3 className="text-[19px] font-extrabold text-center mb-3">정말 발행하시겠습니까?</h3>
             <p className="text-gray-500 text-[13px] text-center mb-8 leading-relaxed">
-              발행 시 멘티에게 알림이 전송됩니다.<br />
-              마스킹 처리가 완벽한지 다시 한 번 확인해 주세요.
+              발행 시 멘티에게 알림이 전송되며<br />더 이상 스크립트를 <b>수정할 수 없습니다.</b>
             </p>
             <div className="flex gap-3 w-full">
-              <button onClick={() => setIsPublishPopupOpen(false)} className="flex-1 bg-[#F2F4F6] text-gray-600 font-bold py-3.5 rounded-xl transition-all hover:bg-gray-200 active:scale-95">취소</button>
-              <button className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-bold py-3.5 rounded-xl shadow-sm transition-all hover:bg-[#E6B800] active:scale-95">발행</button>
+              <button 
+                disabled={isPublishing}
+                onClick={() => setIsPublishPopupOpen(false)} 
+                className="flex-1 bg-[#F2F4F6] text-gray-600 font-bold py-3.5 rounded-xl transition-all hover:bg-gray-200 active:scale-95"
+              >
+                취소
+              </button>
+              <button 
+                disabled={isPublishing}
+                onClick={handlePublish}
+                className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-bold py-3.5 rounded-xl shadow-sm transition-all hover:bg-[#E6B800] active:scale-95 flex justify-center items-center"
+              >
+                {isPublishing ? <Loader2 className="w-5 h-5 animate-spin" /> : "발행"}
+              </button>
             </div>
           </div>
         </div>

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -248,6 +248,7 @@ router.get('/:mentoringId', requireUser, async (req, res, next) => {
                     endedAt: mentoring.endedAt,
                     status: mentoring.status,
                     isGroup: mentoring.isGroup,
+                    isScriptPublished: mentoring.isScriptPublished,
                     host: {
                         mentorId: mentoring.hostMentor.mentorProfile?.mentorId ?? null,
                         userId: mentoring.hostMentor.userId,

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -177,6 +177,7 @@ router.get('/', requireUser, async (req, res, next) => {
                     startedAt: mentoring.startedAt,
                     endedAt: mentoring.endedAt ?? null,
                     isGroup: mentoring.isGroup,
+                    isScriptPublished: mentoring.isScriptPublished,
                     host: {
                         userId: mentoring.hostMentor.userId,
                         nickname: mentoring.hostMentor.nickname,


### PR DESCRIPTION
## 연관된 이슈

#71 

## 작업 내용

**백엔드**
- script.js에 isScriptPublished 값을 프론트엔드로 전송하는 코드 추가

**프론트엔드**
- 스크립트 목록 화면, 스크립트 열람 화면, 스크립트 편집 화면에 api 연동 및 목업 데이터 삭제
- 발행 대기 스크립트: 멘토->편집 가능 / 멘티->클릭 비활성화
- 발행 완료 스크립트: 멘토/멘티->열람 가능
- 스크립트 편집: 엔터 키 입력 시 줄바꿈 이후 데이터가 저장되지 않아 해당 키 입력 막음 
- 마이페이지 프로필 사진은 사용자 역할(멘토/멘티)에 따라 바뀌도록 수정
  
## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

배포 DB에 스크립트 데이터가 없어 로컬 DB에서 실행 부탁드립니다.
배포 DB에 데이터 추가하셔서 테스트 하셔도 됩니다.

**리뷰 방법**
1. 로컬 DB실행
2. 로컬 DB의 mentoring 데이터 중 하나와 연결되는 mentoringHistory, Script 데이터 추가 및 저장
3. /services/core-api 터미널과 /apps/demo-web 터미널에서 `npm run dev` 명령어 실행(배포 DB 사용 시 /apps/demo-web 터미널만 실행)
4. http://localhost:3000/login 으로 접속 후 userId "1"로 로그인(멘토)
5. 마이페이지로 접속 하여 프로필 사진 확인 후 스크립트 목록 버튼 클릭
6. Script 데이터와 연결된 Mentoring 데이터의 `isScriptPublished` 값을 true/false로 변경하며 스크립트 상태 확인
7. 미발행 스크립트 클릭 시 편집 뷰 정상 연결 여부 확인
8. 스크립트 임의 편집 후 발행하여 정상 발행 여부 확인 및 발행 완료 스크립트 클릭 시 열람 뷰 정상 연결 여부 확인
9. 로그아웃 후 userId "2"로 로그인(멘티)
10. 5번 동일하게 진행 후, 6번 과정에서 `isScriptPublished==false` 일 때 해당 스크립트 클릭 비활성화 확인
11. `isScriptPublished==true` 일 때 스크립트 클릭 시 열람 뷰 정상 연결 여부 확인