### PR TITLE
Feat/질문 추천 생성 API 구현

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8,6 +8,272 @@ servers:
   - url: http://localhost:4002
 
 paths:
+  /questions/recommendations:
+    port: 4000
+    post:
+      summary: 질문 추천 생성 프록시
+      description: 로그인 사용자의 멘토링 세션 접근 권한을 확인하고, DB의 멘티/멘토 정보를 조합해 question-service의 AI 질문 추천 API를 호출합니다. `x-user-id` 헤더가 필요합니다.
+      parameters:
+        - in: header
+          name: x-user-id
+          required: true
+          schema:
+            type: string
+          description: 현재 사용자 ID
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - sessionId
+                - context
+              properties:
+                sessionId:
+                  oneOf:
+                    - type: integer
+                    - type: string
+                  example: 1
+                  description: 멘토링 세션 ID
+                topic:
+                  type: string
+                  example: React 상태 관리
+                  description: 생략하면 멘토링 제목을 사용합니다.
+                context:
+                  type: string
+                  example: useState와 useReducer의 차이를 학습 중이며, 어떤 상황에서 useReducer를 써야 하는지 궁금해하고 있습니다.
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                  default: 3
+                  example: 3
+      responses:
+        '200':
+          description: 추천 질문 생성 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - questions
+                properties:
+                  questions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - content
+                        - category
+                        - reason
+                      properties:
+                        content:
+                          type: string
+                          example: useState 대신 useReducer를 사용하는 기준은 무엇인가요?
+                        category:
+                          type: string
+                          enum:
+                            - concept
+                            - reasoning
+                            - application
+                            - comparison
+                            - follow_up
+                          example: comparison
+                        reason:
+                          type: string
+                          example: 멘티 수준과 멘토 전문 분야에 맞는 후속 질문입니다.
+        '400':
+          description: 입력값 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: QUESTION_RECOMMENDATION_INVALID_INPUT
+                  message:
+                    type: string
+                    example: context is required
+        '404':
+          description: 세션 없음 또는 접근 불가
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: QUESTION_RECOMMENDATION_SESSION_NOT_FOUND
+                  message:
+                    type: string
+                    example: mentoring session not found or access denied
+        '502':
+          description: question-service 또는 AI 호출 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: QUESTION_RECOMMENDATION_GENERATION_FAILED
+                  message:
+                    type: string
+                    example: failed to generate question recommendations
+
+  /api/questions/recommendations:
+    port: 4003
+    post:
+      summary: 질문 추천 생성
+      description: 멘토링 맥락, 멘티 정보, 멘토 정보를 기반으로 AI가 추천 질문을 생성합니다. mock 또는 rule 기반 fallback은 사용하지 않습니다.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - context
+                - mentee
+                - mentor
+              properties:
+                sessionId:
+                  type: integer
+                  nullable: true
+                  example: 1
+                topic:
+                  type: string
+                  example: React 상태 관리
+                context:
+                  type: string
+                  example: useState와 useReducer의 차이를 학습 중이며, 어떤 상황에서 useReducer를 써야 하는지 궁금해하고 있습니다.
+                count:
+                  type: integer
+                  minimum: 1
+                  maximum: 5
+                  default: 3
+                  example: 3
+                mentee:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      oneOf:
+                        - type: integer
+                        - type: string
+                      example: 10
+                    name:
+                      type: string
+                      example: 김민지
+                    level:
+                      type: string
+                      example: beginner
+                    interests:
+                      type: array
+                      items:
+                        type: string
+                      example:
+                        - frontend
+                        - React
+                    goals:
+                      type: array
+                      items:
+                        type: string
+                      example:
+                        - React 상태 관리 이해
+                        - 프로젝트에 적용
+                mentor:
+                  type: object
+                  required:
+                    - id
+                  properties:
+                    id:
+                      oneOf:
+                        - type: integer
+                        - type: string
+                      example: 3
+                    name:
+                      type: string
+                      example: 이준호
+                    expertise:
+                      type: array
+                      items:
+                        type: string
+                      example:
+                        - frontend
+                        - React
+                        - architecture
+                    role:
+                      type: string
+                      example: senior frontend engineer
+      responses:
+        '200':
+          description: 추천 질문 생성 성공
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - service
+                  - questions
+                properties:
+                  service:
+                    type: string
+                    example: question-service
+                  questions:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                        - content
+                        - category
+                        - reason
+                      properties:
+                        content:
+                          type: string
+                          example: useState 대신 useReducer를 사용하는 기준은 무엇인가요?
+                        category:
+                          type: string
+                          enum:
+                            - concept
+                            - reasoning
+                            - application
+                            - comparison
+                            - follow_up
+                          example: comparison
+                        reason:
+                          type: string
+                          example: 멘티가 beginner 수준이고 React 상태 관리 개념을 학습 중이기 때문입니다.
+        '400':
+          description: 입력값 오류
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: QUESTION_RECOMMENDATION_INVALID_INPUT
+                  message:
+                    type: string
+                    example: context is required
+        '502':
+          description: AI 호출 또는 응답 파싱 실패
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: string
+                    example: QUESTION_RECOMMENDATION_GENERATION_FAILED
+                  message:
+                    type: string
+                    example: failed to generate question recommendations
+
   /health:
     port: 4000
     get:

--- a/package-lock.json
+++ b/package-lock.json
@@ -6834,7 +6834,9 @@
       "name": "@carpoolink/question-service",
       "version": "0.1.0",
       "dependencies": {
-        "express": "^5.2.1"
+        "dotenv": "^17.4.1",
+        "express": "^5.2.1",
+        "openai": "^6.34.0"
       },
       "devDependencies": {
         "nodemon": "^3.1.14"

--- a/services/core-api/question-recommendations.http
+++ b/services/core-api/question-recommendations.http
@@ -1,0 +1,11 @@
+### Question recommendations through core-api
+POST http://localhost:4000/questions/recommendations
+Content-Type: application/json
+x-user-id: 10
+
+{
+  "sessionId": 1,
+  "topic": "React 상태 관리",
+  "context": "useState와 useReducer의 차이를 학습 중이며, 어떤 상황에서 useReducer를 써야 하는지 궁금해하고 있습니다.",
+  "count": 3
+}

--- a/services/core-api/src/app.js
+++ b/services/core-api/src/app.js
@@ -8,7 +8,7 @@ import apiRouter from './routes/index.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
+dotenv.config({ path: path.resolve(__dirname, '../../../.env'), quiet: true });
 
 const app = express();
 

--- a/services/core-api/src/lib/questionRecommendationProxy.js
+++ b/services/core-api/src/lib/questionRecommendationProxy.js
@@ -1,0 +1,204 @@
+const DEFAULT_QUESTION_SERVICE_URL = 'http://localhost:4003';
+
+export class QuestionRecommendationProxyError extends Error {
+    constructor(message, status = 500, code = 'QUESTION_RECOMMENDATION_PROXY_FAILED') {
+        super(message);
+        this.name = 'QuestionRecommendationProxyError';
+        this.status = status;
+        this.code = code;
+    }
+}
+
+function toTrimmedString(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function toStringId(value) {
+    if (value === undefined || value === null) {
+        return null;
+    }
+
+    return String(value);
+}
+
+function asStringArray(value) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .map(item => toTrimmedString(item))
+        .filter(Boolean);
+}
+
+function normalizeAnswerabilityContext(value = {}) {
+    if (!value || typeof value !== 'object') {
+        return {};
+    }
+
+    return {
+        sessionTopic: toTrimmedString(value.sessionTopic),
+        previousScriptSections: asStringArray(value.previousScriptSections),
+        currentScriptSection: toTrimmedString(value.currentScriptSection),
+        currentSlideTitle: toTrimmedString(value.currentSlideTitle),
+        nextScriptSection: toTrimmedString(value.nextScriptSection),
+        recentMentorUtterances: asStringArray(value.recentMentorUtterances),
+        menteeProfile: toTrimmedString(value.menteeProfile),
+        mentorProfile: toTrimmedString(value.mentorProfile),
+        mentorExpertiseEvidence: asStringArray(value.mentorExpertiseEvidence),
+        mentorPastScripts: asStringArray(value.mentorPastScripts),
+        answeredQuestions: asStringArray(value.answeredQuestions),
+        queuedQuestions: asStringArray(value.queuedQuestions),
+    };
+}
+
+function readMentorInfoList(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return [];
+    }
+
+    for (const key of keys) {
+        const value = info[key];
+        if (Array.isArray(value)) {
+            return asStringArray(value);
+        }
+    }
+
+    return [];
+}
+
+function readMentorInfoText(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return '';
+    }
+
+    for (const key of keys) {
+        const value = toTrimmedString(info[key]);
+        if (value) {
+            return value;
+        }
+    }
+
+    return '';
+}
+
+export function parseSessionId(value) {
+    if (value === undefined || value === null || String(value).trim() === '') {
+        throw new QuestionRecommendationProxyError(
+            'sessionId is required',
+            400,
+            'QUESTION_RECOMMENDATION_SESSION_REQUIRED',
+        );
+    }
+
+    try {
+        return BigInt(value);
+    } catch {
+        throw new QuestionRecommendationProxyError(
+            'invalid sessionId',
+            400,
+            'QUESTION_RECOMMENDATION_INVALID_INPUT',
+        );
+    }
+}
+
+export function selectMenteeParticipant(mentoring, currentUserId) {
+    const participants = mentoring?.participants ?? [];
+    const currentUserParticipant = participants.find(
+        participant => participant.userId === currentUserId && participant.user?.role === 'MENTEE',
+    );
+
+    if (currentUserParticipant) {
+        return currentUserParticipant.user;
+    }
+
+    return participants.find(participant => participant.user?.role === 'MENTEE')?.user ?? null;
+}
+
+export function buildQuestionRecommendationPayload({ body, mentoring, currentUserId }) {
+    const menteeUser = selectMenteeParticipant(mentoring, currentUserId);
+    const mentorUser = mentoring?.hostMentor;
+    const mentorProfile = mentorUser?.mentorProfile;
+    const menteeProfile = menteeUser?.menteeProfile;
+    const mentorInfo = mentorProfile?.info;
+    const fieldNames = mentorProfile?.fields?.map(field => field.fieldName) ?? [];
+    const mentorInfoExpertise = readMentorInfoList(mentorInfo, ['expertise', 'skills', 'fields']);
+    const mentorRole = readMentorInfoText(mentorInfo, ['role', 'job', 'position', 'title']);
+    const answerabilityContext = normalizeAnswerabilityContext(body.answerabilityContext);
+
+    if (!menteeUser || !mentorUser) {
+        throw new QuestionRecommendationProxyError(
+            'mentee and mentor information are required',
+            400,
+            'QUESTION_RECOMMENDATION_PARTICIPANT_REQUIRED',
+        );
+    }
+
+    return {
+        sessionId: toStringId(mentoring.mentoringId),
+        topic: toTrimmedString(body.topic) || mentoring.title,
+        context: body.context,
+        count: body.count,
+        mentee: {
+            id: toStringId(menteeProfile?.menteeId ?? menteeUser.userId),
+            name: menteeUser.nickname,
+            level: menteeProfile?.surveyResult?.title ?? '',
+            interests: [],
+            goals: menteeProfile?.surveyResult?.title ? [menteeProfile.surveyResult.title] : [],
+        },
+        mentor: {
+            id: toStringId(mentorProfile?.mentorId ?? mentorUser.userId),
+            name: mentorUser.nickname,
+            expertise: [...new Set([...fieldNames, ...mentorInfoExpertise])],
+            role: mentorRole || mentorUser.role,
+        },
+        answerabilityContext: {
+            ...answerabilityContext,
+            sessionTopic: answerabilityContext.sessionTopic || toTrimmedString(body.topic) || mentoring.title,
+            menteeProfile: answerabilityContext.menteeProfile
+                || [
+                    menteeUser.role,
+                    menteeProfile?.surveyResult?.title,
+                ].filter(Boolean).join(', '),
+            mentorProfile: answerabilityContext.mentorProfile
+                || [
+                    mentorUser.role,
+                    mentorRole,
+                    fieldNames.join(', '),
+                ].filter(Boolean).join(', '),
+        },
+    };
+}
+
+export function getQuestionServiceUrl() {
+    return process.env.QUESTION_SERVICE_URL || DEFAULT_QUESTION_SERVICE_URL;
+}
+
+export async function requestQuestionRecommendations(payload, options = {}) {
+    const baseUrl = options.baseUrl ?? getQuestionServiceUrl();
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${baseUrl}/api/questions/recommendations`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    });
+
+    let responseBody = null;
+    try {
+        responseBody = await response.json();
+    } catch {
+        responseBody = null;
+    }
+
+    if (!response.ok) {
+        throw new QuestionRecommendationProxyError(
+            responseBody?.message ?? 'failed to generate question recommendations',
+            response.status,
+            responseBody?.code ?? 'QUESTION_RECOMMENDATION_SERVICE_FAILED',
+        );
+    }
+
+    return responseBody;
+}

--- a/services/core-api/src/lib/questionRecommendationProxy.test.js
+++ b/services/core-api/src/lib/questionRecommendationProxy.test.js
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    buildQuestionRecommendationPayload,
+    parseSessionId,
+    QuestionRecommendationProxyError,
+    requestQuestionRecommendations,
+    selectMenteeParticipant,
+} from './questionRecommendationProxy.js';
+
+const currentUserId = 20n;
+
+const mentoring = {
+    mentoringId: 1n,
+    title: 'React 상태 관리',
+    hostMentor: {
+        userId: 3n,
+        nickname: '이준호',
+        role: 'MENTOR',
+        mentorProfile: {
+            mentorId: 30n,
+            info: {
+                role: 'senior frontend engineer',
+                expertise: ['architecture'],
+            },
+            fields: [
+                { fieldName: 'CAREER' },
+                { fieldName: 'GROWTH' },
+            ],
+        },
+    },
+    participants: [
+        {
+            userId: currentUserId,
+            user: {
+                userId: currentUserId,
+                nickname: '김민지',
+                role: 'MENTEE',
+                menteeProfile: {
+                    menteeId: 10n,
+                    surveyResult: {
+                        title: '취업 준비형',
+                    },
+                },
+            },
+        },
+    ],
+};
+
+test('parses sessionId as bigint', () => {
+    assert.equal(parseSessionId('123'), 123n);
+});
+
+test('rejects missing sessionId', () => {
+    assert.throws(
+        () => parseSessionId(null),
+        error => error instanceof QuestionRecommendationProxyError
+            && error.code === 'QUESTION_RECOMMENDATION_SESSION_REQUIRED'
+            && error.status === 400,
+    );
+});
+
+test('selects current mentee participant first', () => {
+    const mentee = selectMenteeParticipant(mentoring, currentUserId);
+
+    assert.equal(mentee.userId, currentUserId);
+});
+
+test('builds question-service recommendation payload from mentoring data', () => {
+    const payload = buildQuestionRecommendationPayload({
+        body: {
+            topic: '',
+            context: 'useReducer를 언제 써야 할지 고민 중입니다.',
+            count: 3,
+            answerabilityContext: {
+                currentSlideTitle: '상태 관리 복잡도',
+                recentMentorUtterances: ['useReducer는 상태 변경 규칙이 복잡할 때 고려할 수 있어요.'],
+                answeredQuestions: ['useReducer와 useState의 기본 차이는 무엇인가요?'],
+            },
+        },
+        mentoring,
+        currentUserId,
+    });
+
+    assert.deepEqual(payload, {
+        sessionId: '1',
+        topic: 'React 상태 관리',
+        context: 'useReducer를 언제 써야 할지 고민 중입니다.',
+        count: 3,
+        mentee: {
+            id: '10',
+            name: '김민지',
+            level: '취업 준비형',
+            interests: [],
+            goals: ['취업 준비형'],
+        },
+        mentor: {
+            id: '30',
+            name: '이준호',
+            expertise: ['CAREER', 'GROWTH', 'architecture'],
+            role: 'senior frontend engineer',
+        },
+        answerabilityContext: {
+            sessionTopic: 'React 상태 관리',
+            previousScriptSections: [],
+            currentScriptSection: '',
+            currentSlideTitle: '상태 관리 복잡도',
+            nextScriptSection: '',
+            recentMentorUtterances: ['useReducer는 상태 변경 규칙이 복잡할 때 고려할 수 있어요.'],
+            menteeProfile: 'MENTEE, 취업 준비형',
+            mentorProfile: 'MENTOR, senior frontend engineer, CAREER, GROWTH',
+            mentorExpertiseEvidence: [],
+            mentorPastScripts: [],
+            answeredQuestions: ['useReducer와 useState의 기본 차이는 무엇인가요?'],
+            queuedQuestions: [],
+        },
+    });
+});
+
+test('forwards recommendation request to question-service', async () => {
+    const calls = [];
+    const result = await requestQuestionRecommendations(
+        { context: 'hello' },
+        {
+            baseUrl: 'http://question-service',
+            fetchImpl: async (url, options) => {
+                calls.push({ url, options });
+                return {
+                    ok: true,
+                    json: async () => ({
+                        service: 'question-service',
+                        questions: [
+                            {
+                                content: '무엇을 먼저 확인하면 좋을까요?',
+                                category: 'concept',
+                                reason: '맥락 확인 질문입니다.',
+                            },
+                        ],
+                    }),
+                };
+            },
+        },
+    );
+
+    assert.equal(calls[0].url, 'http://question-service/api/questions/recommendations');
+    assert.equal(calls[0].options.method, 'POST');
+    assert.deepEqual(JSON.parse(calls[0].options.body), { context: 'hello' });
+    assert.equal(result.questions.length, 1);
+});
+
+test('propagates question-service errors', async () => {
+    await assert.rejects(
+        requestQuestionRecommendations(
+            { context: 'hello' },
+            {
+                baseUrl: 'http://question-service',
+                fetchImpl: async () => ({
+                    ok: false,
+                    status: 502,
+                    json: async () => ({
+                        code: 'QUESTION_RECOMMENDATION_GENERATION_FAILED',
+                        message: 'failed to generate question recommendations',
+                    }),
+                }),
+            },
+        ),
+        error => error instanceof QuestionRecommendationProxyError
+            && error.status === 502
+            && error.code === 'QUESTION_RECOMMENDATION_GENERATION_FAILED',
+    );
+});

--- a/services/core-api/src/routes/index.js
+++ b/services/core-api/src/routes/index.js
@@ -4,6 +4,7 @@ import usersRouter from './users.js';
 import mentorsRouter from './mentors.js';
 import mentoringsRouter from './mentorings.js';
 import scriptsRouter from './scripts.js';
+import questionsRouter from './questions.js';
 
 const router = Router();
 
@@ -12,5 +13,6 @@ router.use('/users', usersRouter);
 router.use('/mentors', mentorsRouter);
 router.use('/mentorings', mentoringsRouter);
 router.use('/scripts', scriptsRouter);
+router.use('/questions', questionsRouter);
 
 export default router;

--- a/services/core-api/src/routes/questions.js
+++ b/services/core-api/src/routes/questions.js
@@ -1,0 +1,91 @@
+import { Router } from 'express';
+import { prisma } from '@carpoolink/database';
+import { requireUser } from '../middleware/requireUser.js';
+import { serialize } from '../utils/serialize.js';
+import {
+    buildQuestionRecommendationPayload,
+    parseSessionId,
+    QuestionRecommendationProxyError,
+    requestQuestionRecommendations,
+} from '../lib/questionRecommendationProxy.js';
+
+const router = Router();
+
+function isInvalidContext(value) {
+    return typeof value !== 'string' || !value.trim();
+}
+
+router.post('/recommendations', requireUser, async (req, res, next) => {
+    try {
+        if (isInvalidContext(req.body?.context)) {
+            return res.status(400).json({
+                code: 'QUESTION_RECOMMENDATION_INVALID_INPUT',
+                message: 'context is required',
+            });
+        }
+
+        const mentoringId = parseSessionId(req.body?.sessionId);
+        const mentoring = await prisma.mentoring.findFirst({
+            where: {
+                mentoringId,
+                OR: [
+                    { userId: req.user.userId },
+                    {
+                        participants: {
+                            some: { userId: req.user.userId },
+                        },
+                    },
+                ],
+            },
+            include: {
+                hostMentor: {
+                    include: {
+                        mentorProfile: {
+                            include: { fields: true },
+                        },
+                    },
+                },
+                participants: {
+                    include: {
+                        user: {
+                            include: {
+                                menteeProfile: {
+                                    include: { surveyResult: true },
+                                },
+                            },
+                        },
+                    },
+                },
+            },
+        });
+
+        if (!mentoring) {
+            return res.status(404).json({
+                code: 'QUESTION_RECOMMENDATION_SESSION_NOT_FOUND',
+                message: 'mentoring session not found or access denied',
+            });
+        }
+
+        const payload = buildQuestionRecommendationPayload({
+            body: req.body,
+            mentoring,
+            currentUserId: req.user.userId,
+        });
+        const result = await requestQuestionRecommendations(payload);
+
+        return res.json(serialize({
+            questions: result.questions ?? [],
+        }));
+    } catch (error) {
+        if (error instanceof QuestionRecommendationProxyError) {
+            return res.status(error.status).json({
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        next(error);
+    }
+});
+
+export default router;

--- a/services/question-service/outputs/question-recommendation-api-tests/recommendation-api-test-2026-05-12T11-51-16-240Z.json
+++ b/services/question-service/outputs/question-recommendation-api-tests/recommendation-api-test-2026-05-12T11-51-16-240Z.json
@@ -1,0 +1,115 @@
+{
+  "status": "success",
+  "startedAt": "2026-05-12T11:51:16.241Z",
+  "completedAt": "2026-05-12T11:51:19.368Z",
+  "request": {
+    "model": "gpt-5-nano",
+    "reasoningEffort": "minimal",
+    "params": {
+      "sessionId": 42,
+      "topic": "프론트엔드 취업 포트폴리오에서 상태 관리 경험 설명하기",
+      "context": "멘티는 신입 프론트엔드 개발자 취업을 준비하고 있으며, React 프로젝트를 포트폴리오에 정리하고 있습니다.\n최근 프로젝트에서 장바구니, 필터, 모달, 비동기 로딩 상태가 섞이면서 useState만으로 상태 변경 흐름을 추적하기 어려웠습니다.\n멘토는 상태가 여러 이벤트에 의해 바뀌거나 변경 규칙이 복잡해질 때 useReducer를 고려할 수 있다고 설명했습니다.\n멘티는 아직 useReducer를 실제로 적용해 본 경험이 적고, 면접에서 useState와 useReducer의 차이를 어떻게 설명해야 할지 고민하고 있습니다.\n멘티가 이어서 물어볼 질문을 추천해 주세요.",
+      "count": 3,
+      "mentee": {
+        "id": 10,
+        "level": "junior-ready",
+        "interests": [
+          "React",
+          "frontend",
+          "portfolio"
+        ],
+        "goals": [
+          "상태 관리 선택 기준 이해",
+          "면접에서 프로젝트 경험 설명하기",
+          "포트폴리오 개선 방향 찾기"
+        ]
+      },
+      "mentor": {
+        "id": 3,
+        "expertise": [
+          "React",
+          "frontend architecture",
+          "technical interview"
+        ],
+        "role": "senior frontend engineer"
+      },
+      "answerabilityContext": {
+        "sessionTopic": "프론트엔드 취업 포트폴리오에서 상태 관리 경험 설명하기",
+        "previousScriptSections": [
+          "멘토는 포트폴리오에서 단순히 사용 기술을 나열하기보다 어떤 문제를 발견했고 어떤 기준으로 개선했는지를 설명하는 것이 중요하다고 안내했습니다.",
+          "멘토는 면접 답변에서 문제 상황, 선택지 비교, 선택 이유, 결과 순서로 말하면 이해하기 쉽다고 설명했습니다."
+        ],
+        "currentScriptSection": "현재 멘토는 장바구니, 필터, 모달, 비동기 로딩 상태가 섞인 React 프로젝트에서 useState만으로 상태 변경 흐름을 추적하기 어려웠던 상황을 예로 들고 있습니다.",
+        "currentSlideTitle": "상태 관리 복잡도와 useReducer 선택 기준",
+        "nextScriptSection": "다음에는 useReducer로 상태 전환 규칙을 정리한 경험을 포트폴리오와 면접 답변에 녹이는 방법을 다룰 예정입니다.",
+        "recentMentorUtterances": [
+          "상태가 여러 이벤트에 의해 바뀌고 변경 규칙이 복잡하면 useReducer를 고려할 수 있어요.",
+          "면접에서는 useReducer를 썼다는 사실보다 왜 useState만으로 부족했는지를 설명하는 게 더 중요합니다.",
+          "포트폴리오에는 상태 전환 규칙을 어떻게 정리했는지 보여주는 예시가 있으면 좋아요."
+        ],
+        "menteeProfile": "신입 프론트엔드 개발자 취업 준비생. React 프로젝트를 포트폴리오로 정리 중이며 상태 관리 선택 기준과 면접 설명 방식이 고민입니다.",
+        "mentorProfile": "시니어 프론트엔드 엔지니어. React 아키텍처, 상태 관리 리팩터링, 기술 면접 코칭 경험이 있습니다.",
+        "mentorExpertiseEvidence": [
+          "React 프로젝트에서 useState, useReducer, 전역 상태 관리 선택 기준을 리뷰한 경험이 있습니다.",
+          "신입 개발자의 포트폴리오 프로젝트 설명과 기술 면접 답변을 코칭한 경험이 있습니다."
+        ],
+        "mentorPastScripts": [
+          "상태 관리 선택은 기술 이름보다 상태 변경 규칙의 복잡도와 추적 가능성을 기준으로 설명하면 좋습니다.",
+          "면접 답변은 문제 상황, 대안, 선택 이유, 결과를 짧게 연결해야 합니다."
+        ],
+        "answeredQuestions": [
+          "useReducer와 useState의 기본적인 차이는 무엇인가요?"
+        ],
+        "queuedQuestions": [
+          "Redux도 같이 공부해야 하나요?"
+        ]
+      }
+    }
+  },
+  "pricing": {
+    "source": "https://platform.openai.com/docs/pricing",
+    "currency": "USD",
+    "unit": "per_1m_tokens",
+    "input": 0.05,
+    "output": 0.4
+  },
+  "costEstimate": {
+    "inputTokens": 1377,
+    "outputTokens": 254,
+    "estimatedUsd": 0.00017045
+  },
+  "response": {
+    "questions": [
+      {
+        "content": "상태 흐름이 복잡할 때 useReducer를 도입한 구체적인 기준을 포트폴리오에 어떻게 보여주면 좋을까요?",
+        "category": "concept",
+        "reason": "상태 관리 선택 기준을 포트폴리오에 설명하는 데 필요한 명확한 기준 제시를 요청하는 질문으로 바로 답변 가능할 가능성이 높습니다."
+      },
+      {
+        "content": "내가 본 프로젝트에서 useState로 한계가 있었던 구체적 사례를 면접용 한 문장 설명으로 어떻게 구성하면 좋을까요?",
+        "category": "application",
+        "reason": "문제 상황과 선택 이유를 간단히 요약하는 방법을 물어보는 질문으로 즉시 적용 가능하게 돕습니다."
+      },
+      {
+        "content": "useReducer를 활용한 상태 전환 규칙을 포트폴리오에 한 화면으로 시각화해 보여주려면 어떤 구성 요소가 필요할까요?",
+        "category": "application",
+        "reason": "포트폴리오 구성을 구체적으로 설계하는 데 필요한 검토 포인트를 얻을 수 있습니다."
+      }
+    ],
+    "metadata": {
+      "model": "gpt-5-nano",
+      "responseId": "resp_040699c32bed2a4c006a031434b3408190a8a2029c7fc2a86a",
+      "usage": {
+        "input_tokens": 1377,
+        "input_tokens_details": {
+          "cached_tokens": 0
+        },
+        "output_tokens": 254,
+        "output_tokens_details": {
+          "reasoning_tokens": 0
+        },
+        "total_tokens": 1631
+      }
+    }
+  }
+}

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -6,10 +6,13 @@
     "main": "src/server.js",
     "scripts": {
         "start": "node src/server.js",
-        "dev": "nodemon src/server.js"
+        "dev": "nodemon src/server.js",
+        "test": "node --test \"src/**/*.test.js\""
     },
     "dependencies": {
-        "express": "^5.2.1"
+        "dotenv": "^17.4.1",
+        "express": "^5.2.1",
+        "openai": "^6.34.0"
     },
     "devDependencies": {
         "nodemon": "^3.1.14"

--- a/services/question-service/question-recommendations.http
+++ b/services/question-service/question-recommendations.http
@@ -1,0 +1,23 @@
+### Question recommendations
+POST http://localhost:4003/api/questions/recommendations
+Content-Type: application/json
+
+{
+  "sessionId": 1,
+  "topic": "React 상태 관리",
+  "context": "useState와 useReducer의 차이를 학습 중이며, 어떤 상황에서 useReducer를 써야 하는지 궁금해하고 있습니다.",
+  "count": 3,
+  "mentee": {
+    "id": 10,
+    "name": "김민지",
+    "level": "beginner",
+    "interests": ["frontend", "React"],
+    "goals": ["React 상태 관리 이해", "프로젝트에 적용"]
+  },
+  "mentor": {
+    "id": 3,
+    "name": "이준호",
+    "expertise": ["frontend", "React", "architecture"],
+    "role": "senior frontend engineer"
+  }
+}

--- a/services/question-service/scripts/run-question-recommendation-api-check.js
+++ b/services/question-service/scripts/run-question-recommendation-api-check.js
@@ -1,0 +1,160 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+import { generateQuestionRecommendations } from '../src/lib/questionRecommendationClient.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
+dotenv.config({ path: path.join(repoRoot, '.env'), quiet: true });
+
+const outputDir = path.join(__dirname, '..', 'outputs', 'question-recommendation-api-tests');
+const timestamp = new Date().toISOString().replace(/[:.]/g, '-');
+const outputPath = path.join(outputDir, `recommendation-api-test-${timestamp}.json`);
+
+const model = process.env.QUESTION_RECOMMENDATION_TEST_MODEL || 'gpt-5-nano';
+const reasoningEffort = process.env.QUESTION_RECOMMENDATION_TEST_REASONING_EFFORT || 'minimal';
+const pricing = {
+    source: 'https://platform.openai.com/docs/pricing',
+    currency: 'USD',
+    unit: 'per_1m_tokens',
+    input: 0.05,
+    output: 0.40,
+};
+
+const params = {
+    sessionId: 42,
+    topic: '프론트엔드 취업 포트폴리오에서 상태 관리 경험 설명하기',
+    context: [
+        '멘티는 신입 프론트엔드 개발자 취업을 준비하고 있으며, React 프로젝트를 포트폴리오에 정리하고 있습니다.',
+        '최근 프로젝트에서 장바구니, 필터, 모달, 비동기 로딩 상태가 섞이면서 useState만으로 상태 변경 흐름을 추적하기 어려웠습니다.',
+        '멘토는 상태가 여러 이벤트에 의해 바뀌거나 변경 규칙이 복잡해질 때 useReducer를 고려할 수 있다고 설명했습니다.',
+        '멘티는 아직 useReducer를 실제로 적용해 본 경험이 적고, 면접에서 useState와 useReducer의 차이를 어떻게 설명해야 할지 고민하고 있습니다.',
+        '멘티가 이어서 물어볼 질문을 추천해 주세요.',
+    ].join('\n'),
+    count: 3,
+    mentee: {
+        id: 10,
+        level: 'junior-ready',
+        interests: ['React', 'frontend', 'portfolio'],
+        goals: ['상태 관리 선택 기준 이해', '면접에서 프로젝트 경험 설명하기', '포트폴리오 개선 방향 찾기'],
+    },
+    mentor: {
+        id: 3,
+        expertise: ['React', 'frontend architecture', 'technical interview'],
+        role: 'senior frontend engineer',
+    },
+    answerabilityContext: {
+        sessionTopic: '프론트엔드 취업 포트폴리오에서 상태 관리 경험 설명하기',
+        previousScriptSections: [
+            '멘토는 포트폴리오에서 단순히 사용 기술을 나열하기보다 어떤 문제를 발견했고 어떤 기준으로 개선했는지를 설명하는 것이 중요하다고 안내했습니다.',
+            '멘토는 면접 답변에서 문제 상황, 선택지 비교, 선택 이유, 결과 순서로 말하면 이해하기 쉽다고 설명했습니다.',
+        ],
+        currentScriptSection: '현재 멘토는 장바구니, 필터, 모달, 비동기 로딩 상태가 섞인 React 프로젝트에서 useState만으로 상태 변경 흐름을 추적하기 어려웠던 상황을 예로 들고 있습니다.',
+        currentSlideTitle: '상태 관리 복잡도와 useReducer 선택 기준',
+        nextScriptSection: '다음에는 useReducer로 상태 전환 규칙을 정리한 경험을 포트폴리오와 면접 답변에 녹이는 방법을 다룰 예정입니다.',
+        recentMentorUtterances: [
+            '상태가 여러 이벤트에 의해 바뀌고 변경 규칙이 복잡하면 useReducer를 고려할 수 있어요.',
+            '면접에서는 useReducer를 썼다는 사실보다 왜 useState만으로 부족했는지를 설명하는 게 더 중요합니다.',
+            '포트폴리오에는 상태 전환 규칙을 어떻게 정리했는지 보여주는 예시가 있으면 좋아요.',
+        ],
+        menteeProfile: '신입 프론트엔드 개발자 취업 준비생. React 프로젝트를 포트폴리오로 정리 중이며 상태 관리 선택 기준과 면접 설명 방식이 고민입니다.',
+        mentorProfile: '시니어 프론트엔드 엔지니어. React 아키텍처, 상태 관리 리팩터링, 기술 면접 코칭 경험이 있습니다.',
+        mentorExpertiseEvidence: [
+            'React 프로젝트에서 useState, useReducer, 전역 상태 관리 선택 기준을 리뷰한 경험이 있습니다.',
+            '신입 개발자의 포트폴리오 프로젝트 설명과 기술 면접 답변을 코칭한 경험이 있습니다.',
+        ],
+        mentorPastScripts: [
+            '상태 관리 선택은 기술 이름보다 상태 변경 규칙의 복잡도와 추적 가능성을 기준으로 설명하면 좋습니다.',
+            '면접 답변은 문제 상황, 대안, 선택 이유, 결과를 짧게 연결해야 합니다.',
+        ],
+        answeredQuestions: [
+            'useReducer와 useState의 기본적인 차이는 무엇인가요?',
+        ],
+        queuedQuestions: [
+            'Redux도 같이 공부해야 하나요?',
+        ],
+    },
+};
+
+function estimateCost(usage) {
+    if (!usage) {
+        return null;
+    }
+
+    const inputTokens = usage.input_tokens ?? usage.prompt_tokens ?? 0;
+    const outputTokens = usage.output_tokens ?? usage.completion_tokens ?? 0;
+
+    return {
+        inputTokens,
+        outputTokens,
+        estimatedUsd: Number(((inputTokens * pricing.input + outputTokens * pricing.output) / 1_000_000).toFixed(8)),
+    };
+}
+
+async function main() {
+    const startedAt = new Date().toISOString();
+    let record;
+
+    try {
+        const result = await generateQuestionRecommendations(params, {
+            model,
+            reasoningEffort,
+            includeMetadata: true,
+        });
+        const completedAt = new Date().toISOString();
+        const usage = result.metadata?.usage ?? null;
+
+        record = {
+            status: 'success',
+            startedAt,
+            completedAt,
+            request: {
+                model,
+                reasoningEffort,
+                params,
+            },
+            pricing,
+            costEstimate: estimateCost(usage),
+            response: result,
+        };
+    } catch (error) {
+        const completedAt = new Date().toISOString();
+        record = {
+            status: 'failed',
+            startedAt,
+            completedAt,
+            request: {
+                model,
+                reasoningEffort,
+                params,
+            },
+            pricing,
+            error: {
+                name: error.name,
+                code: error.code ?? null,
+                status: error.status ?? null,
+                message: error.message,
+            },
+        };
+    }
+
+    await fs.mkdir(outputDir, { recursive: true });
+    await fs.writeFile(outputPath, `${JSON.stringify(record, null, 2)}\n`, 'utf8');
+    console.log(outputPath);
+    console.log(JSON.stringify({
+        status: record.status,
+        model,
+        costEstimate: record.costEstimate ?? null,
+        questionCount: record.response?.questions?.length ?? 0,
+        error: record.error ?? null,
+    }, null, 2));
+
+    if (record.status !== 'success') {
+        process.exitCode = 1;
+    }
+}
+
+await main();

--- a/services/question-service/src/lib/questionRecommendationClient.js
+++ b/services/question-service/src/lib/questionRecommendationClient.js
@@ -1,0 +1,351 @@
+import OpenAI from 'openai';
+
+export const QUESTION_RECOMMENDATION_CATEGORIES = [
+    'concept',
+    'reasoning',
+    'application',
+    'comparison',
+    'follow_up',
+];
+
+const DEFAULT_RECOMMENDATION_COUNT = 3;
+const MAX_RECOMMENDATION_COUNT = 5;
+const DEFAULT_MODEL = 'gpt-5.2';
+const REASONING_EFFORTS = ['minimal', 'low', 'medium', 'high'];
+
+const ANSWERABILITY_GUIDANCE = {
+    goal: 'Generate questions that the mentor can answer well in the current mentoring flow.',
+    priorityGroups: ['answer_now', 'answer_soon', 'collect_or_merge', 'hold', 'needs_context'],
+    scoringDimensions: {
+        clarity: {
+            weight: 0.18,
+            guidance: 'Prefer one clear question with concrete wording. Avoid vague pronouns and overloaded multi-part questions.',
+        },
+        sufficiency: {
+            weight: 0.22,
+            guidance: 'Include enough context from the mentee situation so the mentor can answer without asking for basic clarification.',
+        },
+        relevance: {
+            weight: 0.25,
+            guidance: 'Stay tightly connected to the session topic and the current mentoring context.',
+        },
+        flowFit: {
+            weight: 0.20,
+            guidance: 'Prefer questions that naturally follow recent mentor explanations and current script/slide content.',
+        },
+        expertise: {
+            weight: 0.15,
+            guidance: 'Aim at areas supported by the mentor profile, evidence, and past scripts.',
+        },
+        redundancyPenalty: {
+            weight: -0.12,
+            guidance: 'Avoid questions already answered or already waiting in the queue.',
+        },
+    },
+    outputRules: [
+        'Each recommendation should be likely to rank as answer_now or answer_soon.',
+        'Do not generate questions that need more context before they can be answered.',
+        'Do not repeat answeredQuestions or queuedQuestions semantically.',
+        'Prefer practical, session-specific questions over generic study questions.',
+        'Write each question as one concise Korean sentence from the mentee perspective.',
+        'Ask for guidance, review, examples, or criteria that the mentor can provide; do not ask the mentor to share their own private files or artifacts.',
+    ],
+};
+
+const recommendationResponseFormat = {
+    type: 'json_schema',
+    name: 'question_recommendations',
+    description: 'Recommended mentoring questions tailored to the mentee, mentor, and session context.',
+    strict: true,
+    schema: {
+        type: 'object',
+        additionalProperties: false,
+        required: ['questions'],
+        properties: {
+            questions: {
+                type: 'array',
+                minItems: 1,
+                maxItems: MAX_RECOMMENDATION_COUNT,
+                items: {
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['content', 'category', 'reason'],
+                    properties: {
+                        content: {
+                            type: 'string',
+                            minLength: 1,
+                        },
+                        category: {
+                            type: 'string',
+                            enum: QUESTION_RECOMMENDATION_CATEGORIES,
+                        },
+                        reason: {
+                            type: 'string',
+                            minLength: 1,
+                        },
+                    },
+                },
+            },
+        },
+    },
+};
+
+export class QuestionRecommendationError extends Error {
+    constructor(message, code, status = 500) {
+        super(message);
+        this.name = 'QuestionRecommendationError';
+        this.code = code;
+        this.status = status;
+    }
+}
+
+function toTrimmedString(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeStringArray(value) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .map(item => toTrimmedString(item))
+        .filter(Boolean);
+}
+
+function normalizeCount(value) {
+    if (value === undefined || value === null) {
+        return DEFAULT_RECOMMENDATION_COUNT;
+    }
+
+    const count = Number(value);
+    if (!Number.isInteger(count) || count < 1) {
+        throw new QuestionRecommendationError(
+            '`count` must be an integer between 1 and 5.',
+            'QUESTION_RECOMMENDATION_INVALID_INPUT',
+            400,
+        );
+    }
+
+    return Math.min(count, MAX_RECOMMENDATION_COUNT);
+}
+
+function normalizeParticipant(value, role) {
+    if (!value || typeof value !== 'object') {
+        throw new QuestionRecommendationError(
+            'mentee and mentor information are required',
+            'QUESTION_RECOMMENDATION_PARTICIPANT_REQUIRED',
+            400,
+        );
+    }
+
+    const id = value.id ?? value.userId ?? value.mentorId ?? value.menteeId;
+    if (id === undefined || id === null || String(id).trim() === '') {
+        throw new QuestionRecommendationError(
+            `${role}.id is required`,
+            'QUESTION_RECOMMENDATION_PARTICIPANT_REQUIRED',
+            400,
+        );
+    }
+
+    if (role === 'mentee') {
+        return {
+            id: String(id),
+            level: toTrimmedString(value.level),
+            interests: normalizeStringArray(value.interests),
+            goals: normalizeStringArray(value.goals),
+        };
+    }
+
+    return {
+        id: String(id),
+        expertise: normalizeStringArray(value.expertise),
+        role: toTrimmedString(value.role),
+    };
+}
+
+function normalizeAnswerabilityContext(value = {}) {
+    if (!value || typeof value !== 'object') {
+        return {};
+    }
+
+    return {
+        sessionTopic: toTrimmedString(value.sessionTopic),
+        previousScriptSections: normalizeStringArray(value.previousScriptSections),
+        currentScriptSection: toTrimmedString(value.currentScriptSection),
+        currentSlideTitle: toTrimmedString(value.currentSlideTitle),
+        nextScriptSection: toTrimmedString(value.nextScriptSection),
+        recentMentorUtterances: normalizeStringArray(value.recentMentorUtterances),
+        menteeProfile: toTrimmedString(value.menteeProfile),
+        mentorProfile: toTrimmedString(value.mentorProfile),
+        mentorExpertiseEvidence: normalizeStringArray(value.mentorExpertiseEvidence),
+        mentorPastScripts: normalizeStringArray(value.mentorPastScripts),
+        answeredQuestions: normalizeStringArray(value.answeredQuestions),
+        queuedQuestions: normalizeStringArray(value.queuedQuestions),
+    };
+}
+
+export function normalizeRecommendationRequest(input = {}) {
+    const context = toTrimmedString(input.context);
+    if (!context) {
+        throw new QuestionRecommendationError(
+            'context is required',
+            'QUESTION_RECOMMENDATION_INVALID_INPUT',
+            400,
+        );
+    }
+
+    return {
+        sessionId: input.sessionId ?? null,
+        topic: toTrimmedString(input.topic),
+        context,
+        count: normalizeCount(input.count),
+        mentee: normalizeParticipant(input.mentee, 'mentee'),
+        mentor: normalizeParticipant(input.mentor, 'mentor'),
+        answerabilityContext: normalizeAnswerabilityContext(input.answerabilityContext),
+    };
+}
+
+function buildPromptPayload(request) {
+    return {
+        sessionId: request.sessionId,
+        topic: request.topic || null,
+        context: request.context,
+        count: request.count,
+        mentee: request.mentee,
+        mentor: request.mentor,
+        categories: QUESTION_RECOMMENDATION_CATEGORIES,
+        answerabilityGuidance: ANSWERABILITY_GUIDANCE,
+        answerabilityContext: request.answerabilityContext,
+    };
+}
+
+function createOpenAIClient() {
+    return new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+    });
+}
+
+function parseRecommendationResponse(response) {
+    const rawText = response?.output_text;
+    if (typeof rawText !== 'string' || !rawText.trim()) {
+        throw new QuestionRecommendationError(
+            'invalid recommendation response format',
+            'QUESTION_RECOMMENDATION_INVALID_AI_RESPONSE',
+            502,
+        );
+    }
+
+    try {
+        return JSON.parse(rawText);
+    } catch {
+        throw new QuestionRecommendationError(
+            'invalid recommendation response format',
+            'QUESTION_RECOMMENDATION_INVALID_AI_RESPONSE',
+            502,
+        );
+    }
+}
+
+function normalizeGeneratedQuestions(parsedResponse, count) {
+    if (!parsedResponse || !Array.isArray(parsedResponse.questions)) {
+        throw new QuestionRecommendationError(
+            'invalid recommendation response format',
+            'QUESTION_RECOMMENDATION_INVALID_AI_RESPONSE',
+            502,
+        );
+    }
+
+    const seenContents = new Set();
+    const questions = [];
+
+    for (const question of parsedResponse.questions) {
+        const content = toTrimmedString(question?.content);
+        const category = toTrimmedString(question?.category);
+        const reason = toTrimmedString(question?.reason);
+        const normalizedContentKey = content.replace(/\s+/g, ' ').toLowerCase();
+
+        if (
+            !content
+            || !reason
+            || !QUESTION_RECOMMENDATION_CATEGORIES.includes(category)
+            || seenContents.has(normalizedContentKey)
+        ) {
+            continue;
+        }
+
+        seenContents.add(normalizedContentKey);
+        questions.push({ content, category, reason });
+
+        if (questions.length === count) {
+            break;
+        }
+    }
+
+    if (questions.length === 0) {
+        throw new QuestionRecommendationError(
+            'invalid recommendation response format',
+            'QUESTION_RECOMMENDATION_INVALID_AI_RESPONSE',
+            502,
+        );
+    }
+
+    return questions;
+}
+
+export async function generateQuestionRecommendations(input, options = {}) {
+    const request = normalizeRecommendationRequest(input);
+    const client = options.client ?? createOpenAIClient();
+    const model = options.model ?? process.env.QUESTION_RECOMMENDATION_MODEL ?? DEFAULT_MODEL;
+    const reasoningEffort = options.reasoningEffort ?? process.env.QUESTION_RECOMMENDATION_REASONING_EFFORT;
+
+    let response;
+    try {
+        const responsePayload = {
+            model,
+            instructions: [
+                'You recommend Korean mentoring questions optimized for Answerability.',
+                'Generate questions a mentee can ask a mentor directly.',
+                'Use the mentee profile to adjust difficulty and wording.',
+                'Use the mentor profile to aim questions at what the mentor can answer well.',
+                'Use the provided Answerability scoring dimensions to make questions clear, sufficient, relevant, flow-fit, mentor-expertise aligned, and non-redundant.',
+                'Prefer questions that would be classified as answer_now or answer_soon.',
+                'Write concise one-sentence questions that the mentee can send as-is.',
+                'Do not ask the mentor to share private artifacts; ask for advice about the mentee context instead.',
+                'Do not invent private facts. Do not include names in the generated questions.',
+                'Return only the requested JSON schema.',
+            ].join('\n'),
+            input: JSON.stringify(buildPromptPayload(request)),
+            text: {
+                format: recommendationResponseFormat,
+            },
+        };
+
+        if (REASONING_EFFORTS.includes(reasoningEffort)) {
+            responsePayload.reasoning = { effort: reasoningEffort };
+        }
+
+        response = await client.responses.create(responsePayload);
+    } catch (error) {
+        throw new QuestionRecommendationError(
+            'failed to generate question recommendations',
+            'QUESTION_RECOMMENDATION_GENERATION_FAILED',
+            error.status ?? 502,
+        );
+    }
+
+    const parsedResponse = parseRecommendationResponse(response);
+    const result = {
+        questions: normalizeGeneratedQuestions(parsedResponse, request.count),
+    };
+
+    if (options.includeMetadata) {
+        result.metadata = {
+            model,
+            responseId: response.id ?? null,
+            usage: response.usage ?? null,
+        };
+    }
+
+    return result;
+}

--- a/services/question-service/src/lib/questionRecommendationClient.test.js
+++ b/services/question-service/src/lib/questionRecommendationClient.test.js
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+    generateQuestionRecommendations,
+    normalizeRecommendationRequest,
+    QuestionRecommendationError,
+} from './questionRecommendationClient.js';
+
+const validRequest = {
+    sessionId: 1,
+    topic: 'React 상태 관리',
+    context: 'useState와 useReducer의 차이를 학습 중입니다.',
+    count: 3,
+    mentee: {
+        id: 10,
+        level: 'beginner',
+        interests: ['frontend', 'React'],
+        goals: ['React 상태 관리 이해'],
+    },
+    mentor: {
+        id: 3,
+        expertise: ['frontend', 'React'],
+        role: 'senior frontend engineer',
+    },
+};
+
+test('normalizes recommendation requests with default count', () => {
+    const request = normalizeRecommendationRequest({
+        ...validRequest,
+        count: undefined,
+    });
+
+    assert.equal(request.count, 3);
+    assert.equal(request.context, validRequest.context);
+    assert.equal(request.mentee.id, '10');
+    assert.equal(request.mentor.id, '3');
+});
+
+test('caps recommendation count at five', () => {
+    const request = normalizeRecommendationRequest({
+        ...validRequest,
+        count: 10,
+    });
+
+    assert.equal(request.count, 5);
+});
+
+test('rejects missing context', () => {
+    assert.throws(
+        () => normalizeRecommendationRequest({ ...validRequest, context: '' }),
+        error => error instanceof QuestionRecommendationError
+            && error.code === 'QUESTION_RECOMMENDATION_INVALID_INPUT'
+            && error.status === 400,
+    );
+});
+
+test('rejects missing participant information', () => {
+    assert.throws(
+        () => normalizeRecommendationRequest({ ...validRequest, mentor: null }),
+        error => error instanceof QuestionRecommendationError
+            && error.code === 'QUESTION_RECOMMENDATION_PARTICIPANT_REQUIRED'
+            && error.status === 400,
+    );
+});
+
+test('generates and deduplicates AI recommendations', async () => {
+    const createCalls = [];
+    const fakeClient = {
+        responses: {
+            create: async payload => {
+                createCalls.push(payload);
+                return {
+                    output_text: JSON.stringify({
+                        questions: [
+                            {
+                                content: 'useReducer를 사용하는 기준은 무엇인가요?',
+                                category: 'concept',
+                                reason: '멘티 수준에 맞는 핵심 개념 질문입니다.',
+                            },
+                            {
+                                content: 'useReducer를 사용하는 기준은 무엇인가요?',
+                                category: 'concept',
+                                reason: '중복 질문입니다.',
+                            },
+                            {
+                                content: '프로젝트에서 useReducer가 적합한 상황은 무엇인가요?',
+                                category: 'application',
+                                reason: '멘토의 실무 경험을 끌어낼 수 있습니다.',
+                            },
+                        ],
+                    }),
+                };
+            },
+        },
+    };
+
+    const result = await generateQuestionRecommendations(validRequest, {
+        client: fakeClient,
+        model: 'test-model',
+    });
+
+    assert.equal(createCalls.length, 1);
+    assert.equal(createCalls[0].model, 'test-model');
+    assert.equal(createCalls[0].text.format.type, 'json_schema');
+    assert.match(createCalls[0].instructions, /Answerability/);
+    const promptPayload = JSON.parse(createCalls[0].input);
+    assert.equal(promptPayload.answerabilityGuidance.scoringDimensions.relevance.weight, 0.25);
+    assert.deepEqual(result.questions, [
+        {
+            content: 'useReducer를 사용하는 기준은 무엇인가요?',
+            category: 'concept',
+            reason: '멘티 수준에 맞는 핵심 개념 질문입니다.',
+        },
+        {
+            content: '프로젝트에서 useReducer가 적합한 상황은 무엇인가요?',
+            category: 'application',
+            reason: '멘토의 실무 경험을 끌어낼 수 있습니다.',
+        },
+    ]);
+});
+
+test('wraps AI failures with recommendation error code', async () => {
+    const fakeClient = {
+        responses: {
+            create: async () => {
+                throw new Error('network failed');
+            },
+        },
+    };
+
+    await assert.rejects(
+        generateQuestionRecommendations(validRequest, { client: fakeClient }),
+        error => error instanceof QuestionRecommendationError
+            && error.code === 'QUESTION_RECOMMENDATION_GENERATION_FAILED'
+            && error.status === 502,
+    );
+});

--- a/services/question-service/src/server.js
+++ b/services/question-service/src/server.js
@@ -1,6 +1,19 @@
 import express from 'express';
+import dotenv from 'dotenv';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { clusterQuestions } from './lib/questionClusterClient.js';
 import { predictQuestion } from './lib/questionDetectorClient.js';
+import { rankQuestion, rankQuestions } from './lib/answerabilityClient.js';
+import {
+    generateQuestionRecommendations,
+    QuestionRecommendationError,
+} from './lib/questionRecommendationClient.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, '../../../.env'), quiet: true });
 
 const app = express();
 const PORT = process.env.QUESTION_SERVICE_PORT || 4003;
@@ -69,6 +82,52 @@ app.post('/api/question-clustering/cluster', async (req, res) => {
         return res.status(500).json({
             error: 'QUESTION_CLUSTERING_FAILED',
             message: error.message,
+        });
+    }
+});
+
+app.post('/api/questions/rank', async (req, res) => {
+    try {
+        const result = await rankQuestion(req.body ?? {});
+        return res.json({ service: 'question-service', ...result });
+    } catch (error) {
+        const isInvalidRequest = error.message.includes('must be a non-empty string');
+        return res.status(isInvalidRequest ? 400 : 500).json({
+            error: isInvalidRequest ? 'INVALID_REQUEST' : 'RANKING_FAILED',
+            message: error.message,
+        });
+    }
+});
+
+app.post('/api/questions/rank-batch', async (req, res) => {
+    try {
+        const result = await rankQuestions(req.body ?? {});
+        return res.json({ service: 'question-service', ...result });
+    } catch (error) {
+        const isInvalidRequest = error.message.includes('questions') || error.message.includes('non-empty string');
+        return res.status(isInvalidRequest ? 400 : 500).json({
+            error: isInvalidRequest ? 'INVALID_REQUEST' : 'RANKING_FAILED',
+            message: error.message,
+        });
+    }
+});
+
+app.post('/api/questions/recommendations', async (req, res) => {
+    try {
+        const result = await generateQuestionRecommendations(req.body ?? {});
+        return res.json({ service: 'question-service', ...result });
+    } catch (error) {
+        if (error instanceof QuestionRecommendationError) {
+            return res.status(error.status).json({
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        console.error('[question-service] recommendation failed:', error);
+        return res.status(500).json({
+            code: 'QUESTION_RECOMMENDATION_INTERNAL_ERROR',
+            message: 'failed to generate question recommendations',
         });
     }
 });


### PR DESCRIPTION
## 연관된 이슈
#82 

## 작업 내용
질문 추천 생성 API를 추가했습니다.

- question-service에 AI 기반 질문 추천 생성 엔드포인트 추가
- POST /api/questions/recommendations
- core-api에 프론트 연동용 프록시 엔드포인트 추가
- POST /questions/recommendations
- 멘토링 세션, 멘티/멘토 정보, Answerability 관련 컨텍스트를 기반으로 추천 질문을 생성하도록 구현
  - Answerability 기준 반영
  - clarity
  - sufficiency
  - relevance
  - flowFit
  - expertise
  - redundancyPenalty

- OpenAI Structured Output을 사용해 추천 질문 응답 형식 고정
- 추천 질문 생성 요청/응답 OpenAPI 문서 추가
- question-service/core-api 단위 테스트 추가
- 실제 OpenAI API 호출 결과 JSON 저장

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

다음 부분을 중점적으로 봐주시면 좋겠습니다.

- Answerability 기준을 프롬프트 입력으로 넘기는 방식이 적절한지
- core-api에서 멘토링 세션 정보를 기반으로 멘티/멘토 payload를 구성하는 방식이 맞는지
- 추천 질문 응답 구조가 프론트엔드에서 사용하기 충분한지
- 실제 호출 테스트 결과 기준으로 질문 품질이 멘토링 상황에 적합한지