### PR TITLE
1:1 멘토링 chat-service 연결

### DIFF
--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useRef, useEffect } from "react";
 import { Mic, MicOff, Volume2, VolumeX, Send, PhoneOff } from "lucide-react";
+import { io, Socket } from "socket.io-client"; // 💡 Socket.IO 추가
 import { useMentoringSession } from "@/hooks/useMentoringSession";
 import { useWebRtcSession } from "@/hooks/useWebRtcSession";
 
@@ -14,6 +15,7 @@ interface ChatMessage {
 export default function PrivateMentoringPage() {
   const [role, setRole] = useState<string>("MENTEE");
   const [userId, setUserId] = useState<number>(2);
+  const [userName, setUserName] = useState<string>("익명"); // 💡 유저 이름 상태 추가
 
   const remoteAudioRef = useRef<HTMLAudioElement>(null);
 
@@ -23,16 +25,22 @@ export default function PrivateMentoringPage() {
   const [chatInput, setChatInput] = useState("");
   const [elapsedTime, setElapsedTime] = useState(0);
 
+  // 💡 실시간 채팅 상태
+  const [chatSocket, setChatSocket] = useState<Socket | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]); // 더미 데이터 제거
+
   useEffect(() => {
     const storedRole = localStorage.getItem("role")?.toUpperCase();
-
     if (storedRole) setRole(storedRole);
 
     const storedUserId = localStorage.getItem("userId");
     if (storedUserId) setUserId(Number(storedUserId));
+
+    const storedName = localStorage.getItem("nickname") || "익명";
+    setUserName(storedName);
   }, []);
 
-  // 1. 소켓 및 멘토링 세션 연결
+  // 1. 소켓 및 멘토링 세션 연결 (화상/음성용 4002번)
   const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
     useMentoringSession({ role, userId });
 
@@ -43,20 +51,79 @@ export default function PrivateMentoringPage() {
       mentoringId: sessionData?.mentoringId?.toString() || "",
       peerId: peerId || "",
       role,
-      mentoringType: "ONE_ON_ONE", // 💡 1:1 멘토링 타입 명시
+      mentoringType: "ONE_ON_ONE",
     });
-
-  const [messages, setMessages] = useState<ChatMessage[]>([
-    { id: 1, sender: "other", text: "Let's look at the color system. The \"No-Line\" rule is critical for that premium feel." },
-    { id: 2, sender: "me", text: "Got it. I'm removing all the 1px borders now and using tonal layering instead." },
-    { id: 3, sender: "other", text: "Excellent. Also, make sure the surface hierarchy follows that \"stacked paper\" logic we talked about earlier." },
-    { id: 4, sender: "other", text: "That makes sense. Have you considered the typographic hierarchy for the display font?" },
-    { id: 5, sender: "me", text: "I'm trying to use Manrope for" },
-  ]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // 💡 [추가] 원격 오디오 스트림 수신 및 연결
+  // 💡 [추가] 실제 채팅 서버(4001번) 연결 로직
+  useEffect(() => {
+    const mentoringIdStr = sessionData?.mentoringId?.toString();
+    if (!mentoringIdStr || !userId) return;
+
+    // 배포 환경이면 Nginx 라우팅, 로컬이면 4001번 포트로 연결
+    const CHAT_SERVER_URL = process.env.NEXT_PUBLIC_CHAT_API_URL || "http://localhost:4001";
+    const socketPath = "/chat/socket.io";
+
+    const newChatSocket = io(CHAT_SERVER_URL, {
+      path: socketPath,
+      withCredentials: true,
+      transports: ["websocket", "polling"],
+    });
+
+    newChatSocket.on("connect", () => {
+      console.log("✅ [1:1 채팅] 소켓 연결 성공!");
+
+      // 💡 여기서 백엔드의 verifyChatJoinAccess 가 작동하여 권한을 검사합니다!
+      newChatSocket.emit("join_chat", {
+        mentoringId: Number(mentoringIdStr),
+        userId: Number(userId),
+        userName
+      }, (res: any) => {
+        if (res?.ok) {
+          console.log("✅ [1:1 채팅] 방 입장 완료!");
+          // 입장 성공 시 과거 채팅 내역 불러오기
+          newChatSocket.emit("get_message_history", { mentoringId: Number(mentoringIdStr) });
+        } else {
+          // 입장권(History)이 없거나 방이 종료된 경우 튕겨냄
+          console.error(`❌ [1:1 채팅] 방 입장 실패:`, res?.error);
+          alert(res?.error || "채팅방 참여 권한이 없습니다.");
+          window.location.href = "/mentoring_list/1on1_list";
+        }
+      });
+    });
+
+    // 과거 채팅 내역 수신
+    newChatSocket.on("message_history", (historyData: any[]) => {
+      const mapped = historyData.map(m => ({
+        id: m.mentoringChatId || m.id,
+        sender: String(m.userId) === String(userId) ? "me" : "other",
+        text: m.content,
+      })) as ChatMessage[];
+      setMessages(mapped);
+    });
+
+    // 새 메시지 수신
+    newChatSocket.on("new_message", (m: any) => {
+      // 💡 핵심 수정: 서버가 보내준 메시지가 '내가 보낸 것'이라면 무시합니다!
+      // (이미 handleSendMessage에서 내 화면에 그렸기 때문)
+      if (String(m.userId) === String(userId)) return;
+
+      setMessages(prev => [...prev, {
+        id: m.mentoringChatId || m.id || Date.now(),
+        sender: "other",
+        text: m.content,
+      }]);
+    });
+
+    setChatSocket(newChatSocket);
+
+    return () => {
+      newChatSocket.disconnect();
+    };
+  }, [sessionData?.mentoringId, userId, userName]);
+
+  // 원격 오디오 스트림 수신 및 연결
   useEffect(() => {
     if (remoteAudioRef.current && remoteStreams.size > 0) {
       const combinedStream = new MediaStream();
@@ -78,14 +145,12 @@ export default function PrivateMentoringPage() {
     }
   }, [remoteStreams]);
 
-  // 💡 [추가] 스피커 On/Off에 따른 오디오 음소거 처리
   useEffect(() => {
     if (remoteAudioRef.current) {
       remoteAudioRef.current.muted = !isSpeakerOn;
     }
   }, [isSpeakerOn]);
 
-  // 타이머
   useEffect(() => {
     const timerInterval = setInterval(() => {
       setElapsedTime((prevTime) => prevTime + 1);
@@ -93,16 +158,12 @@ export default function PrivateMentoringPage() {
     return () => clearInterval(timerInterval);
   }, []);
 
-  // 💡 [추가] 멘토가 멘토링을 종료하면 멘티 자동 이동
   useEffect(() => {
     if (!socket) return;
-
     const handleMentoringEnded = () => {
       window.location.href = "/mentoring_list/1on1_list";
     };
-
     socket.on("mentoring:ended", handleMentoringEnded);
-
     return () => {
       socket.off("mentoring:ended", handleMentoringEnded);
     };
@@ -122,25 +183,42 @@ export default function PrivateMentoringPage() {
     }
   }, [messages, isChatMode]);
 
+  // 💡 [수정된 채팅 전송 함수]
   const handleSendMessage = () => {
-    if (!chatInput.trim()) return;
-    setMessages((prev) => [...prev, { id: Date.now(), sender: "me", text: chatInput }]);
+    // 1. 방어 로직 (내용이 없거나, 소켓이 없거나, 방 번호가 없으면 중단)
+    if (!chatInput.trim() || !chatSocket || !sessionData?.mentoringId) {
+      console.warn("⚠️ 전송 불가 상태:", { input: chatInput, socket: !!chatSocket, roomId: sessionData?.mentoringId });
+      return;
+    }
+
+    // 2. 서버로 메시지 전송
+    chatSocket.emit("send_message", {
+      mentoringId: Number(sessionData.mentoringId),
+      userId: Number(userId),
+      content: chatInput
+    });
+
+    // 3. 💡 핵심: 서버 응답을 기다리지 않고 내 화면에 즉시 메시지 말풍선 띄우기!
+    setMessages(prev => [...prev, {
+      id: Date.now(), // 임시 고유 ID 부여
+      sender: "me",
+      text: chatInput,
+    }]);
+
+    // 4. 입력창 비우고 채팅 모드 유지
     setChatInput("");
     setIsChatMode(true);
   };
 
   const handleEndMentoring = async () => {
     await endMentoring();
-    window.location.href = "/mentoring_list/1on1_list"; // 종료 후 이동할 경로 (필요시 수정)
+    window.location.href = "/mentoring_list/1on1_list";
   };
 
   return (
     <main className="flex flex-col w-full h-full bg-[#F8F9FA] text-[#1A1A1A] relative font-sans overflow-hidden">
-
-      {/* 💡 숨겨진 오디오 태그 (상대방 음성 출력용) */}
       <audio ref={remoteAudioRef} autoPlay />
 
-      {/* 상단 헤더 */}
       <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative">
         <button
           onClick={() => setIsChatMode(false)}
@@ -156,7 +234,6 @@ export default function PrivateMentoringPage() {
             <h1 className="text-[17px] font-extrabold tracking-tight">
               {sessionData ? sessionData.host.nickname : "멘토링 중"}
             </h1>
-            {/* 연결 상태 표시 뱃지 */}
             <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`}></div>
           </div>
           <span className="text-[12px] font-medium text-gray-500 mt-0.5 font-mono tracking-tight">
@@ -171,10 +248,7 @@ export default function PrivateMentoringPage() {
         )}
       </header>
 
-      {/* 내부 가변 콘텐츠 영역 */}
       <div className="flex-1 relative overflow-hidden flex flex-col">
-
-        {/* 전역 상태 알림 플로팅 팝업 컨테이너 (마이크, 스피커) */}
         <div className="absolute top-3.5 left-1/2 -translate-x-1/2 z-[60] flex flex-col items-center pointer-events-none">
           <div className={`transition-all duration-400 ease-[cubic-bezier(0.16,1,0.3,1)] origin-top flex justify-center
             ${!isMicOn ? 'max-h-14 opacity-100 scale-100 translate-y-0 mb-2' : 'max-h-0 opacity-0 scale-95 -translate-y-2 mb-0'}
@@ -195,17 +269,12 @@ export default function PrivateMentoringPage() {
           </div>
         </div>
 
-        {/* ------------------------------------
-            A. 1:1 통화 모드 (접힌 상태)
-            ------------------------------------ */}
         <div className={`absolute inset-0 flex flex-col transition-all duration-500 ease-in-out ${isChatMode ? '-translate-y-full opacity-0 pointer-events-none' : 'translate-y-0 opacity-100'}`}>
-
           <div className="flex-1 flex flex-col items-center justify-center px-6 relative z-0">
             <div className="flex-1 w-full min-h-[30px]"></div>
 
             <div className="flex flex-col items-center shrink-0">
               <div className="relative flex items-center justify-center w-52 h-52 mb-3">
-                {/* 오디오가 들어오고 있을 때만 파동 애니메이션을 보여줄 수도 있습니다 */}
                 <div className="absolute inset-0 border border-gray-300 rounded-full animate-[ping_3s_ease-out_infinite] opacity-50"></div>
                 <div className="absolute inset-4 border border-gray-200 rounded-full animate-[ping_3s_ease-out_infinite_1s] opacity-70"></div>
                 <div className="absolute inset-8 border border-gray-100 rounded-full animate-[ping_3s_ease-out_infinite_2s]"></div>
@@ -216,14 +285,12 @@ export default function PrivateMentoringPage() {
               </div>
 
               <h2 className="text-2xl font-extrabold mb-1">{sessionData ? sessionData.host.nickname : "연결 중..."}</h2>
-              <p className="text-gray-500 text-[14px]">{isLoading ? "세션 정보를 불러오는 중입니다" : "Product Design Lead @ Studio"}</p>
+              <p className="text-gray-500 text-[14px]">{isLoading ? "세션 정보를 불러오는 중입니다" : "1:1 멘토링 세션"}</p>
 
               <div className="flex gap-4 mt-8">
-                {/* 💡 마이크 제어 (useWebRtcSession의 setMicOn 연동) */}
                 <button onClick={() => setMicOn(!isMicOn)} className={`w-14 h-14 rounded-full flex items-center justify-center transition-all shadow-md active:scale-95 ${isMicOn ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-white text-gray-700'}`}>
                   {isMicOn ? <Mic className="w-6 h-6" /> : <MicOff className="w-6 h-6" />}
                 </button>
-                {/* 💡 스피커 제어 */}
                 <button onClick={() => setIsSpeakerOn(!isSpeakerOn)} className={`w-14 h-14 rounded-full flex items-center justify-center transition-all shadow-md active:scale-95 ${isSpeakerOn ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-white text-gray-700'}`}>
                   {isSpeakerOn ? <Volume2 className="w-6 h-6" /> : <VolumeX className="w-6 h-6" />}
                 </button>
@@ -233,7 +300,6 @@ export default function PrivateMentoringPage() {
             <div className="flex-1 w-full pb-6"></div>
           </div>
 
-          {/* 채팅 미리보기 시트 */}
           <div
             onClick={() => setIsChatMode(true)}
             className="w-full bg-white rounded-t-[32px] shadow-[0_-10px_40px_rgba(0,0,0,0.06)] pt-4 px-5 pb-2 cursor-pointer flex flex-col relative z-10 transition-transform hover:translate-y-[-2px]"
@@ -241,39 +307,45 @@ export default function PrivateMentoringPage() {
             <div className="w-10 h-1.5 bg-gray-200 rounded-full mx-auto mb-5"></div>
 
             <div className="flex flex-col gap-3 pointer-events-none">
-              {messages.slice(-2).map((msg) => (
-                <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'}`}>
-                  <div className={`max-w-[85%] px-4 py-3 rounded-2xl text-[14px] leading-snug break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
-                    {msg.text}
+              {messages.length === 0 ? (
+                <div className="text-center text-gray-400 text-sm py-2">아직 메시지가 없습니다.</div>
+              ) : (
+                messages.slice(-2).map((msg) => (
+                  <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'}`}>
+                    <div className={`max-w-[85%] px-4 py-3 rounded-2xl text-[14px] leading-snug break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
+                      {msg.text}
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))
+              )}
             </div>
           </div>
         </div>
 
-        {/* ------------------------------------
-            B. 전체 텍스트 채팅 모드
-            ------------------------------------ */}
         <div className={`absolute inset-0 flex flex-col bg-white transition-all duration-500 ease-in-out ${!isChatMode ? 'translate-y-full opacity-0 pointer-events-none' : 'translate-y-0 opacity-100'}`}>
           <div className="flex-1 overflow-y-auto px-5 py-4 flex flex-col gap-4 custom-scrollbar pb-4">
             <div className="flex justify-center my-2">
               <span className="bg-gray-100 text-gray-500 text-[11px] font-bold px-3 py-1.5 rounded-full">오늘</span>
             </div>
 
-            {messages.map((msg) => (
-              <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'} animate-in fade-in slide-in-from-bottom-2`}>
-                <div className={`max-w-[80%] px-4 py-3.5 rounded-2xl text-[15px] leading-relaxed break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
-                  {msg.text}
+            {messages.length === 0 ? (
+               <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+                  메시지를 입력해 첫 인사를 나눠보세요.
+               </div>
+            ) : (
+              messages.map((msg) => (
+                <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'} animate-in fade-in slide-in-from-bottom-2`}>
+                  <div className={`max-w-[80%] px-4 py-3.5 rounded-2xl text-[15px] leading-relaxed break-keep shadow-sm ${msg.sender === 'me' ? 'bg-[#FFCC00] text-[#1A1A1A] rounded-tr-sm' : 'bg-[#F2F4F6] text-[#1A1A1A] rounded-tl-sm'}`}>
+                    {msg.text}
+                  </div>
                 </div>
-              </div>
-            ))}
+              ))
+            )}
             <div ref={messagesEndRef} />
           </div>
         </div>
       </div>
 
-      {/* 공통 전역 하단 입력창 */}
       <div className={`w-full px-5 bg-white shrink-0 z-30 transition-all duration-500 ease-in-out flex flex-col justify-end py-3
         ${isChatMode ? 'border-t border-gray-100 shadow-[0_-10px_20px_rgba(0,0,0,0.02)]' : ''}
       `}>
@@ -289,14 +361,14 @@ export default function PrivateMentoringPage() {
           />
           <button
             onClick={handleSendMessage}
-            className="absolute right-2 p-2 bg-[#FFCC00] hover:bg-[#E6B800] rounded-full transition-colors active:scale-90 shadow-sm"
+            disabled={!chatSocket}
+            className="absolute right-2 p-2 bg-[#FFCC00] hover:bg-[#E6B800] disabled:opacity-50 rounded-full transition-colors active:scale-90 shadow-sm"
           >
             <Send className="w-4 h-4 text-[#1A1A1A]" />
           </button>
         </div>
       </div>
 
-      {/* 종료 팝업 모달 */}
       {isEndPopupOpen && (
         <div className="absolute inset-0 bg-black/60 z-[100] flex items-center justify-center p-6 backdrop-blur-sm animate-in fade-in duration-200">
           <div className="bg-white w-full max-w-[320px] rounded-[32px] p-8 shadow-2xl animate-in zoom-in-95 duration-200 flex flex-col items-center">
@@ -311,7 +383,6 @@ export default function PrivateMentoringPage() {
               추후 녹음본은 제공되지 않습니다.
             </p>
             <div className="flex flex-col gap-3 w-full">
-              {/* 💡 멘토링 종료 로직 연동 */}
               <button
                 onClick={handleEndMentoring}
                 className="w-full bg-[#FFCC00] text-[#1A1A1A] text-[15px] font-bold py-4 rounded-2xl hover:bg-[#E6B800] transition-colors text-center active:scale-[0.98]"

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -189,12 +189,24 @@ export default function PrivateMentoringPage() {
     }
   }, [isSpeakerOn]);
 
+  // ✅ [새로운 타이머 로직] 서버 시간에 맞춰 동기화
   useEffect(() => {
+    // DB에 시작 시간이 기록되어 있지 않다면 타이머를 돌리지 않음
+    if (!sessionData?.startedAt) return;
+
+    // 방이 공식적으로 시작된 시간 (절대 시간)
+    const startTimeMs = new Date(sessionData.startedAt).getTime();
+
     const timerInterval = setInterval(() => {
-      setElapsedTime((prevTime) => prevTime + 1);
+      const nowMs = Date.now(); // 내 컴퓨터의 현재 시간
+      const diffInSeconds = Math.floor((nowMs - startTimeMs) / 1000);
+      
+      // 멘티가 약간 일찍 들어왔을 때 타이머가 음수로 가는 것 방지
+      setElapsedTime(diffInSeconds > 0 ? diffInSeconds : 0);
     }, 1000);
+
     return () => clearInterval(timerInterval);
-  }, []);
+  }, [sessionData?.startedAt]);
 
   useEffect(() => {
     if (!socket) return;

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -219,20 +219,25 @@ export default function PrivateMentoringPage() {
     <main className="flex flex-col w-full h-full bg-[#F8F9FA] text-[#1A1A1A] relative font-sans overflow-hidden">
       <audio ref={remoteAudioRef} autoPlay />
 
-      <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative">
-        <button
-          onClick={() => setIsChatMode(false)}
-          className={`p-1 hover:bg-gray-100 rounded-full transition-all duration-300
-            ${isChatMode ? 'opacity-100 cursor-pointer' : 'opacity-0 pointer-events-none'}
-          `}
-        >
-          <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 text-[#FFCC00]" />
-        </button>
+      <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative h-[60px]">
+        
+        {/* 1. 왼쪽 영역 (뒤로가기 버튼) - flex-1을 주어 공간 확보 */}
+        <div className="flex-1 flex justify-start z-10">
+          <button
+            onClick={() => setIsChatMode(false)}
+            className={`p-1 hover:bg-gray-100 rounded-full transition-all duration-300
+              ${isChatMode ? 'opacity-100 cursor-pointer' : 'opacity-0 pointer-events-none'}
+            `}
+          >
+            <img src="/icons/arrow.svg" alt="화살표 아이콘" className="w-5 h-5 text-[#FFCC00]" />
+          </button>
+        </div>
 
-        <div className="flex flex-col items-center">
+        {/* 2. 💡 중앙 영역 (닉네임/시간) - 절대 위치(absolute)로 완벽한 중앙 고정 */}
+        <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center pointer-events-none w-max">
           <div className="flex items-center gap-2">
-            <h1 className="text-[17px] font-extrabold tracking-tight">
-              {sessionData ? sessionData.host.nickname : "멘토링 중"}
+            <h1 className="text-[17px] font-extrabold tracking-tight text-[#1A1A1A]">
+              {opponentNickname}
             </h1>
             <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`}></div>
           </div>
@@ -241,11 +246,18 @@ export default function PrivateMentoringPage() {
           </span>
         </div>
 
-        {role !== "MENTEE" && (
-          <button onClick={() => setIsEndPopupOpen(true)} className="text-red-500 font-bold text-[15px] p-1">
-            종료
-          </button>
-        )}
+        {/* 3. 오른쪽 영역 (종료 버튼) - flex-1을 주어 왼쪽과 균형을 맞춤 */}
+        <div className="flex-1 flex justify-end z-10">
+          {role !== "MENTEE" ? (
+            <button onClick={() => setIsEndPopupOpen(true)} className="text-red-500 font-bold text-[15px] p-1">
+              종료
+            </button>
+          ) : (
+            /* 멘티일 경우 버튼은 안 보이지만, 레이아웃 공간은 차지하도록 빈 div 유지 (선택사항) */
+            <div className="w-8"></div>
+          )}
+        </div>
+
       </header>
 
       <div className="flex-1 relative overflow-hidden flex flex-col">

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -17,6 +17,9 @@ export default function PrivateMentoringPage() {
   const [userId, setUserId] = useState<number>(2);
   const [userName, setUserName] = useState<string>("익명"); // 💡 유저 이름 상태 추가
 
+  // 💡 [추가] 상대방 닉네임을 담을 새로운 상태
+  const [opponentNickname, setOpponentNickname] = useState<string>("상대방 연결 대기 중...");
+
   const remoteAudioRef = useRef<HTMLAudioElement>(null);
 
   const [isChatMode, setIsChatMode] = useState(false);
@@ -30,7 +33,7 @@ export default function PrivateMentoringPage() {
   const [messages, setMessages] = useState<ChatMessage[]>([]); // 더미 데이터 제거
 
   useEffect(() => {
-    const storedRole = localStorage.getItem("role")?.toUpperCase();
+    const storedRole = localStorage.getItem("userRole")?.toUpperCase();
     if (storedRole) setRole(storedRole);
 
     const storedUserId = localStorage.getItem("userId");
@@ -56,6 +59,19 @@ export default function PrivateMentoringPage() {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
+  // 💡 [추가] 내가 누구냐에 따라 기본 상대방 이름 세팅
+  useEffect(() => {
+    if (sessionData) {
+      if (role === "MENTEE") {
+        // 내가 멘티면 상대방은 당연히 방장(멘토)
+        setOpponentNickname(sessionData.host.nickname);
+      } else {
+        // 내가 멘토면 멘티 접속을 기다림
+        setOpponentNickname("멘티 (연결 대기 중)");
+      }
+    }
+  }, [sessionData, role]);
+
   // 💡 [추가] 실제 채팅 서버(4001번) 연결 로직
   useEffect(() => {
     const mentoringIdStr = sessionData?.mentoringId?.toString();
@@ -74,7 +90,6 @@ export default function PrivateMentoringPage() {
     newChatSocket.on("connect", () => {
       console.log("✅ [1:1 채팅] 소켓 연결 성공!");
 
-      // 💡 여기서 백엔드의 verifyChatJoinAccess 가 작동하여 권한을 검사합니다!
       newChatSocket.emit("join_chat", {
         mentoringId: Number(mentoringIdStr),
         userId: Number(userId),
@@ -82,10 +97,8 @@ export default function PrivateMentoringPage() {
       }, (res: any) => {
         if (res?.ok) {
           console.log("✅ [1:1 채팅] 방 입장 완료!");
-          // 입장 성공 시 과거 채팅 내역 불러오기
           newChatSocket.emit("get_message_history", { mentoringId: Number(mentoringIdStr) });
         } else {
-          // 입장권(History)이 없거나 방이 종료된 경우 튕겨냄
           console.error(`❌ [1:1 채팅] 방 입장 실패:`, res?.error);
           alert(res?.error || "채팅방 참여 권한이 없습니다.");
           window.location.href = "/mentoring_list/1on1_list";
@@ -93,21 +106,46 @@ export default function PrivateMentoringPage() {
       });
     });
 
-    // 과거 채팅 내역 수신
+    // 💡 [추가] 상대방이 접속했을 때 실시간으로 이름표 업데이트
+    newChatSocket.on("user_joined", (data: any) => {
+      console.log("👋 상대방 입장 이벤트 수신:", data);
+
+      const incomingNickname = data.nickname || data.userName;
+      
+      // 내 닉네임과 다른 사람(상대방)이 들어왔을 때만 업데이트
+      if (incomingNickname && incomingNickname !== userName) {
+        setOpponentNickname(incomingNickname);
+      }
+    });
+
+    // 💡 과거 채팅 내역에서 상대방 진짜 이름 가져오기
     newChatSocket.on("message_history", (historyData: any[]) => {
-      const mapped = historyData.map(m => ({
-        id: m.mentoringChatId || m.id,
-        sender: String(m.userId) === String(userId) ? "me" : "other",
-        text: m.content,
-      })) as ChatMessage[];
+      const mapped = historyData.map(m => {
+        const isMe = String(m.userId) === String(userId);
+        
+        // 내 메시지가 아닌데 이름 정보가 있다면 업데이트!
+        if (!isMe && (m.user?.nickname || m.userName)) {
+          setOpponentNickname(m.user?.nickname || m.userName);
+        }
+
+        return {
+          id: m.mentoringChatId || m.id,
+          sender: isMe ? "me" : "other",
+          text: m.content,
+        };
+      }) as ChatMessage[];
+      
       setMessages(mapped);
     });
 
-    // 새 메시지 수신
+    // 💡 새 메시지가 왔을 때도 상대방 진짜 이름 업데이트
     newChatSocket.on("new_message", (m: any) => {
-      // 💡 핵심 수정: 서버가 보내준 메시지가 '내가 보낸 것'이라면 무시합니다!
-      // (이미 handleSendMessage에서 내 화면에 그렸기 때문)
       if (String(m.userId) === String(userId)) return;
+
+      // 상대방 이름 정보가 포함되어 있다면 업데이트
+      if (m.user?.nickname || m.userName) {
+        setOpponentNickname(m.user?.nickname || m.userName);
+      }
 
       setMessages(prev => [...prev, {
         id: m.mentoringChatId || m.id || Date.now(),
@@ -121,7 +159,7 @@ export default function PrivateMentoringPage() {
     return () => {
       newChatSocket.disconnect();
     };
-  }, [sessionData?.mentoringId, userId, userName]);
+  }, [sessionData?.mentoringId, userId, userName, role]); // role 의존성 추가 권장
 
   // 원격 오디오 스트림 수신 및 연결
   useEffect(() => {
@@ -296,7 +334,8 @@ export default function PrivateMentoringPage() {
                 </div>
               </div>
 
-              <h2 className="text-2xl font-extrabold mb-1">{sessionData ? sessionData.host.nickname : "연결 중..."}</h2>
+              {/* 💡 [수정] 중앙 프로필 이름 변경 */}
+              <h2 className="text-2xl font-extrabold mb-1">{opponentNickname}</h2>
               <p className="text-gray-500 text-[14px]">{isLoading ? "세션 정보를 불러오는 중입니다" : "1:1 멘토링 세션"}</p>
 
               <div className="flex gap-4 mt-8">

--- a/apps/demo-web/hooks/useMentoringSession.ts
+++ b/apps/demo-web/hooks/useMentoringSession.ts
@@ -46,15 +46,26 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
             const res = await apiClient.get(`/media/mentorings/${mentoringId}`);
             const data = res.data;
 
+            console.log("🔍 미디어 서버 응답 데이터:", data); // 데이터 구조 확인용
+
             if (isMountedRef.current) {
+                // 1. 서버 응답 구조 대응 (mentoring 객체 안에 있거나, 평평한 구조이거나)
+                const mentoringInfo = data.mentoring || data;
+
                 setSessionData({
-                    mentoringId: data.mentoring.mentoringId,
-                    title: data?.mentoring?.title || "멘토링 세션",
-                    status: data?.mentoring?.status || "ON_AIR",
-                    participantCount: data?.media.peers.length || 0,
-                    host: { userId: data?.mentoring?.userId || 0, nickname: data?.mentoring?.nickname || "호스트" },
+                    // mentoringInfo에서 ID를 가져오되, 없으면 URL 파라미터의 mentoringId를 숫자로 변환해 사용
+                    mentoringId: mentoringInfo?.mentoringId || Number(mentoringId),
+                    title: mentoringInfo?.title || "멘토링 세션",
+                    status: mentoringInfo?.status || "ON_AIR",
+                    participantCount: data?.media?.peers?.length || 0,
+                    
+                    host: { 
+                        userId: mentoringInfo?.userId || 0, 
+                        nickname: mentoringInfo?.nickname || "호스트" 
+                    },
                 });
-                setParticipantCount(data?.mentoring?.participantCount || 0);
+                // 참여자 수 상태 업데이트
+                setParticipantCount(data?.media?.peers?.length || 0);
             }
         } catch (err) {
             if (isMountedRef.current) {

--- a/apps/demo-web/hooks/useMentoringSession.ts
+++ b/apps/demo-web/hooks/useMentoringSession.ts
@@ -12,6 +12,7 @@ interface MentoringSessionData {
         userId: number;
         nickname: string;
     };
+    startedAt?: string | null;
 }
 
 interface UseMentoringSessionOptions {
@@ -58,11 +59,11 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
                     title: mentoringInfo?.title || "멘토링 세션",
                     status: mentoringInfo?.status || "ON_AIR",
                     participantCount: data?.media?.peers?.length || 0,
-                    
                     host: { 
                         userId: mentoringInfo?.userId || 0, 
                         nickname: mentoringInfo?.nickname || "호스트" 
                     },
+                    startedAt: mentoringInfo?.startedAt || null,
                 });
                 // 참여자 수 상태 업데이트
                 setParticipantCount(data?.media?.peers?.length || 0);

--- a/services/chat-service/src/socket/socketHandler.js
+++ b/services/chat-service/src/socket/socketHandler.js
@@ -205,7 +205,7 @@ export async function handleConnection(socket, io) {
             const userCount = getSocketRoomUserCount(io, mentoringKey);
             io.to(roomName).emit('user_joined', {
                 userId: userKey,
-                userName,
+                nickname: userName,
                 userCount,
                 timestamp: new Date(),
             });

--- a/services/media-server/src/store/mentoringRepository.js
+++ b/services/media-server/src/store/mentoringRepository.js
@@ -19,7 +19,9 @@ function normalizeMentoring(record) {
         status: record.status,
         startedAt: record.startedAt ? new Date(record.startedAt).toISOString() : null,
         endedAt: record.endedAt ? new Date(record.endedAt).toISOString() : null,
-        userId: Number(record.userId)
+        userId: Number(record.userId),
+
+        nickname: record.hostMentor?.nickname || "호스트"
     };
 }
 
@@ -230,6 +232,13 @@ class PrismaMentoringRepository {
         const found = await this.prisma.mentoring.findUnique({
             where: {
                 mentoringId: BigInt(mentoringId)
+            },
+            include: {
+                hostMentor: {
+                    select: {
+                        nickname: true
+                    }
+                }
             }
         });
 


### PR DESCRIPTION
## 연관된 이슈

#91

## 작업 내용

- 1:1 멘토링에 실시간 채팅 송수신 소켓 연결
- 멘토링 입장 시 상대방 입장 상태 및 닉네임 렌더링
- 멘토/멘티 화면의 멘토링 진행 시간 동기화

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

- 멘토/멘티 화면에서 실시간 채팅이 잘 이루어지는지 확인
- 멘토가 먼저 입장했을 때 상단에 "상대방 연결 대기 중..." 문구 출력 여부 확인
- 두 참여자가 모두 방에 입장했을 때 각자 화면에 상대방 닉네임 출력 여부 확인
- 두 참여자가 시간차를 두고 입장 했을 때 상단 바의 진행 시간 동기화 여부 확인(약 1초의 오차는 발생 가능)