### PR TITLE
멘토링 영상/음성 실시간 송출

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - feat/86-mentoring-media
     paths:
       - ".github/workflows/deploy.yml"
       - "services/**"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - feat/86-mentoring-media
     paths:
       - ".github/workflows/deploy.yml"
       - "services/**"

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -174,7 +174,8 @@ export default function PrivateMentoringPage() {
     if (!remoteAudioRef.current || remoteStreams.size === 0) return;
 
     // 1:1 멘토링이므로 복잡한 병합(Merge) 없이 첫 번째 원격 스트림을 그대로 사용합니다.
-    const stream = Array.from(remoteStreams.values())[0];
+    const streamArray = Array.from(remoteStreams.values());
+    const stream = streamArray[streamArray.length - 1];
 
     // 🚨 [핵심] 이미 오디오 태그에 같은 스트림이 연결되어 있다면 덮어쓰지 않습니다.
     // (채팅을 입력할 때마다 srcObject가 재할당되어 미세하게 음성이 끊기는 현상을 원천 차단)

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -309,8 +309,13 @@ export default function PrivateMentoringPage() {
               종료
             </button>
           ) : (
-            /* 멘티일 경우 버튼은 안 보이지만, 레이아웃 공간은 차지하도록 빈 div 유지 (선택사항) */
-            <div className="w-8"></div>
+            // 멘티일 경우 빈 공간 대신 '나가기' 버튼 렌더링 및 페이지 이동 연결
+            <button
+              onClick={() => window.location.href = "/mentoring_list/1on1_list"}
+              className="text-gray-500 hover:text-gray-700 font-bold text-[15px] p-1 transition-colors"
+            >
+              나가기
+            </button>
           )}
         </div>
 

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -169,33 +169,31 @@ export default function PrivateMentoringPage() {
     };
   }, [sessionData?.mentoringId, userId, userName, role]); // role 의존성 추가 권장
 
-  // 원격 오디오 스트림 수신 및 연결
+  // 1. 💡 최적화된 원격 오디오 스트림 수신 및 연결
   useEffect(() => {
-    if (remoteAudioRef.current && remoteStreams.size > 0) {
-      const combinedStream = new MediaStream();
+    if (!remoteAudioRef.current || remoteStreams.size === 0) return;
 
-      remoteStreams.forEach((stream) => {
-        stream.getAudioTracks().forEach((track) => {
-          if (!combinedStream.getTracks().find(t => t.id === track.id)) {
-            combinedStream.addTrack(track);
-          }
-        });
+    // 1:1 멘토링이므로 복잡한 병합(Merge) 없이 첫 번째 원격 스트림을 그대로 사용합니다.
+    const stream = Array.from(remoteStreams.values())[0];
+
+    // 🚨 [핵심] 이미 오디오 태그에 같은 스트림이 연결되어 있다면 덮어쓰지 않습니다.
+    // (채팅을 입력할 때마다 srcObject가 재할당되어 미세하게 음성이 끊기는 현상을 원천 차단)
+    if (remoteAudioRef.current.srcObject !== stream) {
+      remoteAudioRef.current.srcObject = stream;
+      remoteAudioRef.current.play().catch((err) => {
+        console.warn("오디오 재생 실패 (오토플레이 정책 등):", err);
       });
-
-      if (combinedStream.getAudioTracks().length > 0) {
-        remoteAudioRef.current.srcObject = combinedStream;
-        remoteAudioRef.current.play().catch((err) => {
-          console.error("오디오 재생 실패 (오토플레이 정책 등):", err);
-        });
-      }
     }
   }, [remoteStreams]);
 
+  // 2. 💡 [추가] 페이지 이탈 시 오디오 자원 완벽 해제 (메모리 누수 및 백그라운드 재생 방지)
   useEffect(() => {
-    if (remoteAudioRef.current) {
-      remoteAudioRef.current.muted = !isSpeakerOn;
-    }
-  }, [isSpeakerOn]);
+    return () => {
+      if (remoteAudioRef.current) {
+        remoteAudioRef.current.srcObject = null;
+      }
+    };
+  }, []);
 
   // ✅ [새로운 타이머 로직] 서버 시간에 맞춰 동기화
   useEffect(() => {

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -31,6 +31,7 @@ export default function PrivateMentoringPage() {
   // 💡 실시간 채팅 상태
   const [chatSocket, setChatSocket] = useState<Socket | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]); // 더미 데이터 제거
+  const [isChatClosed, setIsChatClosed] = useState(false);
 
   useEffect(() => {
     const storedRole = localStorage.getItem("userRole")?.toUpperCase();
@@ -155,6 +156,12 @@ export default function PrivateMentoringPage() {
       }]);
     });
 
+    newChatSocket.on("room_closed", (data: any) => {
+      setIsChatClosed(true);
+      alert("멘토링이 종료되었습니다.");
+      window.location.href = "/mentoring_list/1on1_list";
+    });
+
     setChatSocket(newChatSocket);
 
     return () => {
@@ -237,7 +244,7 @@ export default function PrivateMentoringPage() {
   // 💡 [수정된 채팅 전송 함수]
   const handleSendMessage = () => {
     // 1. 방어 로직 (내용이 없거나, 소켓이 없거나, 방 번호가 없으면 중단)
-    if (!chatInput.trim() || !chatSocket || !sessionData?.mentoringId) {
+    if (!chatInput.trim() || !chatSocket || !sessionData?.mentoringId || isChatClosed) {
       console.warn("⚠️ 전송 불가 상태:", { input: chatInput, socket: !!chatSocket, roomId: sessionData?.mentoringId });
       return;
     }
@@ -290,7 +297,7 @@ export default function PrivateMentoringPage() {
             <h1 className="text-[17px] font-extrabold tracking-tight text-[#1A1A1A]">
               {opponentNickname}
             </h1>
-            <div className={`w-2 h-2 rounded-full ${isConnected ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`}></div>
+            <div className={`w-2 h-2 rounded-full ${(isConnected && !isChatClosed) ? 'bg-green-500 animate-pulse' : 'bg-red-500'}`}></div>
           </div>
           <span className="text-[12px] font-medium text-gray-500 mt-0.5 font-mono tracking-tight">
             {formatTime(elapsedTime)}
@@ -393,9 +400,9 @@ export default function PrivateMentoringPage() {
             </div>
 
             {messages.length === 0 ? (
-               <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-                  메시지를 입력해 첫 인사를 나눠보세요.
-               </div>
+              <div className="h-full flex items-center justify-center text-gray-500 text-sm">
+                메시지를 입력해 첫 인사를 나눠보세요.
+              </div>
             ) : (
               messages.map((msg) => (
                 <div key={msg.id} className={`flex ${msg.sender === 'me' ? 'justify-end' : 'justify-start'} animate-in fade-in slide-in-from-bottom-2`}>

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -80,10 +80,10 @@ export default function PrivateMentoringPage() {
     if (!mentoringIdStr || !userId) return;
 
     // 배포 환경이면 Nginx 라우팅, 로컬이면 4001번 포트로 연결
-    const CHAT_SERVER_URL = process.env.NEXT_PUBLIC_CHAT_API_URL || "http://localhost:4001";
+    const SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4001";
     const socketPath = "/chat/socket.io";
 
-    const newChatSocket = io(CHAT_SERVER_URL, {
+    const newChatSocket = io(SERVER_URL, {
       path: socketPath,
       withCredentials: true,
       transports: ["websocket", "polling"],

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -54,7 +54,8 @@ export default function PrivateMentoringPage() {
       mentoringId: sessionData?.mentoringId?.toString() || "",
       peerId: peerId || "",
       role,
-      mentoringType: "ONE_ON_ONE",
+      mentoringType: "ONE_ON_ONE", // 💡 1:1 멘토링 타입 명시
+      isJoined: isConnected, // 💡 멘토링 세션에 실제로 연결된 상태를 WebRTC 훅에 전달
     });
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -111,7 +112,7 @@ export default function PrivateMentoringPage() {
       console.log("👋 상대방 입장 이벤트 수신:", data);
 
       const incomingNickname = data.nickname || data.userName;
-      
+
       // 내 닉네임과 다른 사람(상대방)이 들어왔을 때만 업데이트
       if (incomingNickname && incomingNickname !== userName) {
         setOpponentNickname(incomingNickname);
@@ -122,7 +123,7 @@ export default function PrivateMentoringPage() {
     newChatSocket.on("message_history", (historyData: any[]) => {
       const mapped = historyData.map(m => {
         const isMe = String(m.userId) === String(userId);
-        
+
         // 내 메시지가 아닌데 이름 정보가 있다면 업데이트!
         if (!isMe && (m.user?.nickname || m.userName)) {
           setOpponentNickname(m.user?.nickname || m.userName);
@@ -134,7 +135,7 @@ export default function PrivateMentoringPage() {
           text: m.content,
         };
       }) as ChatMessage[];
-      
+
       setMessages(mapped);
     });
 
@@ -200,7 +201,7 @@ export default function PrivateMentoringPage() {
     const timerInterval = setInterval(() => {
       const nowMs = Date.now(); // 내 컴퓨터의 현재 시간
       const diffInSeconds = Math.floor((nowMs - startTimeMs) / 1000);
-      
+
       // 멘티가 약간 일찍 들어왔을 때 타이머가 음수로 가는 것 방지
       setElapsedTime(diffInSeconds > 0 ? diffInSeconds : 0);
     }, 1000);
@@ -270,7 +271,7 @@ export default function PrivateMentoringPage() {
       <audio ref={remoteAudioRef} autoPlay />
 
       <header className="w-full px-5 py-3 flex items-center justify-between shrink-0 bg-white z-30 shadow-sm relative h-[60px]">
-        
+
         {/* 1. 왼쪽 영역 (뒤로가기 버튼) - flex-1을 주어 공간 확보 */}
         <div className="flex-1 flex justify-start z-10">
           <button

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -477,38 +477,44 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
     );
 }
 
+import React, { memo } from "react";
+
 // ============================================================================
-// [미디어 렌더러 컴포넌트] 비디오와 오디오를 구분하여 안전하게 재생
+// [미디어 렌더러 컴포넌트] 비디오와 오디오를 구분하여 안전하게 재생 (깜빡임 방지 버전)
 // ============================================================================
-function MediaRenderer({ stream, onBlocked }: { stream: MediaStream, onBlocked: () => void }) {
+const MediaRenderer = memo(function MediaRenderer({ stream, onBlocked }: { stream: MediaStream, onBlocked: () => void }) {
     const mediaRef = useRef<HTMLMediaElement>(null);
 
-    // 이 스트림이 비디오/오디오 트랙을 가졌는지 각각 확인
     const isVideo = stream.getVideoTracks().length > 0;
     const hasAudio = stream.getAudioTracks().length > 0;
 
+    // 1. 💡 스트림 설정 및 재생 관리 Effect
     useEffect(() => {
         if (mediaRef.current && stream) {
-            mediaRef.current.srcObject = stream;
-            mediaRef.current.play().catch((err) => {
-                console.warn("미디어 자동재생 차단됨:", err.message);
-                if (err.name === "NotAllowedError" || err.message.includes("play() failed")) {
-                    onBlocked();
-                }
-            });
+            // 🚨 [핵심] 이미 엘리먼트에 같은 스트림이 주입되어 있다면 아무것도 하지 않습니다.
+            // srcObject를 매번 새로 대입하면 비디오 파이프라인이 초기화되면서 깜빡임이 발생합니다.
+            if (mediaRef.current.srcObject !== stream) {
+                mediaRef.current.srcObject = stream;
+                mediaRef.current.play().catch((err) => {
+                    console.warn("미디어 자동재생 차단됨:", err.message);
+                    if (err.name === "NotAllowedError" || err.message.includes("play() failed")) {
+                        onBlocked();
+                    }
+                });
+            }
         }
+    }, [stream, onBlocked]); // 이펙트 재실행 시 srcObject를 null로 밀어버리는 코드를 제거함
 
-        // 💡 [추가] 컴포넌트 언마운트 시 미디어 할당 해제 (메모리 누수 및 카메라 자원 낭비 방지)
+    // 2. 💡 진짜 컴포넌트가 '언마운트' 될 때만 미디어 자원을 깔끔하게 해제하는 별도 Effect
+    useEffect(() => {
         return () => {
             if (mediaRef.current) {
                 mediaRef.current.srcObject = null;
             }
         };
-    }, [stream, onBlocked]);
+    }, []); // 의존성 배열을 비워둠으로써 화면에서 아예 사라질 때 딱 1번만 실행됩니다.
 
     if (isVideo) {
-        // 💡 [핵심 수정] 오디오 트랙이 없는 순수 비디오 스트림이면 muted를 강제로 부여!
-        // 이렇게 해야 iOS(아이폰) 및 모바일 크롬에서 사용자 터치 없이도 화면이 부드럽게 자동 재생됩니다.
         return (
             <video
                 ref={mediaRef as any}
@@ -519,7 +525,6 @@ function MediaRenderer({ stream, onBlocked }: { stream: MediaStream, onBlocked: 
             />
         );
     } else {
-        // 오디오는 화면을 차지하지 않도록 숨김 처리
         return <audio ref={mediaRef as any} autoPlay playsInline className="hidden" />;
     }
-}
+});

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 
@@ -130,6 +130,10 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
         mentoringType: "GROUP",
         isJoined: isConnected
     });
+
+    const handleAutoPlayBlocked = useCallback(() => {
+        setIsAutoplayBlocked(true);
+    }, []);
 
     useEffect(() => {
         const CHAT_SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4001";
@@ -321,7 +325,7 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                                 <MediaRenderer
                                     key={id}
                                     stream={stream}
-                                    onBlocked={() => setIsAutoplayBlocked(true)}
+                                    onBlocked={() => handleAutoPlayBlocked}
                                 />
                             ))}
 
@@ -477,22 +481,42 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
 // ============================================================================
 function MediaRenderer({ stream, onBlocked }: { stream: MediaStream, onBlocked: () => void }) {
     const mediaRef = useRef<HTMLMediaElement>(null);
-    // 이 스트림이 비디오 트랙을 가졌는지 확인
+
+    // 이 스트림이 비디오/오디오 트랙을 가졌는지 각각 확인
     const isVideo = stream.getVideoTracks().length > 0;
+    const hasAudio = stream.getAudioTracks().length > 0;
 
     useEffect(() => {
         if (mediaRef.current && stream) {
             mediaRef.current.srcObject = stream;
             mediaRef.current.play().catch((err) => {
+                console.warn("미디어 자동재생 차단됨:", err.message);
                 if (err.name === "NotAllowedError" || err.message.includes("play() failed")) {
                     onBlocked();
                 }
             });
         }
+
+        // 💡 [추가] 컴포넌트 언마운트 시 미디어 할당 해제 (메모리 누수 및 카메라 자원 낭비 방지)
+        return () => {
+            if (mediaRef.current) {
+                mediaRef.current.srcObject = null;
+            }
+        };
     }, [stream, onBlocked]);
 
     if (isVideo) {
-        return <video ref={mediaRef as any} className="absolute inset-0 w-full h-full object-cover" autoPlay playsInline />;
+        // 💡 [핵심 수정] 오디오 트랙이 없는 순수 비디오 스트림이면 muted를 강제로 부여!
+        // 이렇게 해야 iOS(아이폰) 및 모바일 크롬에서 사용자 터치 없이도 화면이 부드럽게 자동 재생됩니다.
+        return (
+            <video
+                ref={mediaRef as any}
+                className="absolute inset-0 w-full h-full object-cover"
+                autoPlay
+                playsInline
+                muted={!hasAudio}
+            />
+        );
     } else {
         // 오디오는 화면을 차지하지 않도록 숨김 처리
         return <audio ref={mediaRef as any} autoPlay playsInline className="hidden" />;

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -194,7 +194,8 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
 
         socket.on("room_closed", (data: any) => {
             setIsChatClosed(true);
-            alert("멘토링이 종료되어 채팅이 마감되었습니다.");
+            alert("멘토링이 종료되었습니다.");
+            window.location.href = "/mentoring_list/live_list";
         });
 
         socket.on("error", (err: any) => {

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -127,7 +127,8 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
         mentoringId,
         peerId: peerId || "",
         role,
-        mentoringType: "GROUP"
+        mentoringType: "GROUP",
+        isJoined: isConnected
     });
 
     useEffect(() => {

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -26,79 +26,58 @@ interface ChatMessage {
     content: string;
 }
 
-// ============================================================================
-// [Wrapper 컴포넌트] 사용자 정보(localStorage)가 준비될 때까지 대기
-// ============================================================================
+// 1. 게이트웨이 컴포넌트: 정보가 준비될 때까지 로딩만 보여줌
 export default function MentorLivePage() {
     const params = useParams();
     const mentoringId = params?.id as string;
 
     const [isReady, setIsReady] = useState(false);
-    const [role, setRole] = useState<string>("MENTOR");
     const [userId, setUserId] = useState<number | null>(null);
+    const [role, setRole] = useState<string>("MENTOR");
     const [userName, setUserName] = useState<string>("멘토");
 
     useEffect(() => {
-        // 1. 로컬스토리지에서 멘토 정보 확정 (멘티 페이지의 initAndJoin 로직과 유사)
+        // 로컬스토리지 정보 확정
         const storedRole = localStorage.getItem("role")?.toUpperCase() || "MENTOR";
         const storedUserId = localStorage.getItem("userId");
         const storedName = localStorage.getItem("nickname") || "멘토";
 
-        setRole(storedRole);
-        setUserName(storedName);
-
         if (storedUserId) {
+            setRole(storedRole);
             setUserId(Number(storedUserId));
-            setIsReady(true); // 정보 로드 완료 시에만 다음 단계로 이동
-        } else {
-            // 멘토인데 ID가 없는 경우 예외 처리
-            console.error("멘토 ID를 찾을 수 없습니다.");
+            setUserName(storedName);
+            setIsReady(true); // 모든 정보가 준비되었을 때만 true
         }
     }, []);
 
-    // 정보를 읽어오는 동안 보여줄 로딩 화면 (멘티 페이지 로딩 UI와 통일)
     if (!isReady || !userId) {
         return (
             <main className="flex flex-col w-full h-[100dvh] bg-[#161616] text-white items-center justify-center space-y-5">
                 <div className="w-12 h-12 border-4 border-[#FFCC00]/20 border-t-[#FFCC00] rounded-full animate-spin"></div>
-                <div className="text-center space-y-1.5">
-                    <h2 className="text-xl font-bold text-gray-200 tracking-tight">방송 세션을 준비 중입니다...</h2>
-                    <p className="text-gray-400 text-sm">최종 권한을 확인하고 미디어 서버에 연결합니다.</p>
-                </div>
+                <p className="text-gray-400">방송 세션을 준비 중입니다...</p>
             </main>
         );
     }
 
-    // 정보가 확정된 후에만 실제 소켓/WebRTC 로직이 있는 컴포넌트 마운트
+    // 💡 정보가 확정된 후, 실제 소켓 로직이 있는 Content 컴포넌트 실행
     return <MentorLiveContent mentoringId={mentoringId} role={role} userId={userId} userName={userName} />;
 }
 
-
-// ============================================================================
-// [실제 화면 컴포넌트] 소켓 연결 및 WebRTC 로직 (참조값 고정)
-// ============================================================================
+// 2. 실제 화면 컴포넌트: 여기서 훅을 호출해야 소켓이 단 한 번만 연결됨
 function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringId: string, role: string, userId: number, userName: string }) {
-
     const videoRef = useRef<HTMLVideoElement>(null);
     const messagesEndRef = useRef<HTMLDivElement>(null);
 
+    const [chats, setChats] = useState<any[]>([]);
+    const [onlineUserCount, setOnlineUserCount] = useState(0);
     const [isChatOpen, setIsChatOpen] = useState(true);
     const [isExitPopupOpen, setIsExitPopupOpen] = useState(false);
-    const [isReading, setIsReading] = useState(false);
     const [currentIdx, setCurrentIdx] = useState(0);
+    const [isReading, setIsReading] = useState(false);
 
-    const [chatSocket, setChatSocket] = useState<Socket | null>(null);
-    const [chats, setChats] = useState<ChatMessage[]>([]);
-    const [onlineUserCount, setOnlineUserCount] = useState<number>(0);
-
-    // 💡 훅에 넘겨주는 옵션들을 useMemo로 고정 (무한 루프 방지 핵심)
-    const mentoringOptions = useMemo(() => ({
-        role,
-        userId,
-    }), [role, userId]);
-
-    const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
-        useMentoringSession(mentoringOptions); // 이제 정보가 확실하므로 isInitialized 가드 불필요
+    // 💡 이제 이 훅들은 컴포넌트가 마운트될 때 단 한 번, 올바른 userId로 실행됩니다.
+    const mentoringOptions = useMemo(() => ({ role, userId }), [role, userId]);
+    const { sessionData, isConnected, peerId, socket, endMentoring, isLoading, error } = useMentoringSession(mentoringOptions);
 
     const webRtcConfig = useMemo(() => ({
         socket,
@@ -108,8 +87,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         mentoringType: "GROUP" as const
     }), [socket, sessionData?.mentoringId, mentoringId, peerId]);
 
-    const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } =
-        useWebRtcSession(webRtcConfig);
+    const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } = useWebRtcSession(webRtcConfig);
 
     // 질문 큐 데이터
     const questionQueue: Question[] = [
@@ -167,8 +145,6 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         newSocket.on("user_joined", (data: any) => setOnlineUserCount(data.userCount));
         newSocket.on("user_left", (data: any) => setOnlineUserCount(data.userCount));
         newSocket.on("online_users", (data: any) => setOnlineUserCount(data.userCount));
-
-        setChatSocket(newSocket);
 
         return () => {
             newSocket.emit("leave_chat", { mentoringId, userId: String(userId), userName });

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -46,8 +46,15 @@ export default function MentorLivePage() {
     const [chats, setChats] = useState<ChatMessage[]>([]);
     const [onlineUserCount, setOnlineUserCount] = useState<number>(0);
 
+    const [isInitialized, setIsInitialized] = useState(false);
+
+    const mentoringOptions = useMemo(() => ({
+        role,
+        userId: userId || 0,
+    }), [role, userId]);
+
     const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
-        useMentoringSession({ role, userId: userId || 0 });
+        useMentoringSession(isInitialized ? mentoringOptions : { role: "MENTOR", userId: 0 });
 
     const webRtcConfig = useMemo(() => ({
         socket,
@@ -75,6 +82,8 @@ export default function MentorLivePage() {
         if (storedUserId) setUserId(Number(storedUserId));
         const storedName = localStorage.getItem("nickname") || "멘토";
         setUserName(storedName);
+
+        setIsInitialized(true);
     }, []);
 
     useEffect(() => {
@@ -142,8 +151,10 @@ export default function MentorLivePage() {
 
     useEffect(() => {
         if (videoRef.current && localStream) {
-            videoRef.current.srcObject = localStream;
-            videoRef.current.play().catch(console.error);
+            if (videoRef.current.srcObject !== localStream) {
+                videoRef.current.srcObject = localStream;
+                videoRef.current.play().catch(console.error);
+            }
         }
     }, [localStream, isCameraOn]);
 

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -84,7 +84,8 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         mentoringId: sessionData?.mentoringId?.toString() || mentoringId,
         peerId: peerId || "",
         role: "MENTOR",
-        mentoringType: "GROUP" as const
+        mentoringType: "GROUP" as const,
+        isJoined: isConnected
     }), [socket, sessionData?.mentoringId, mentoringId, peerId]);
 
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } = useWebRtcSession(webRtcConfig);

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
 import { io, Socket } from "socket.io-client";
@@ -49,14 +49,17 @@ export default function MentorLivePage() {
     const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
         useMentoringSession({ role, userId: userId || 0 });
 
+    const webRtcConfig = useMemo(() => ({
+        socket,
+        mentoringId: sessionData?.mentoringId?.toString() || mentoringId || "",
+        peerId: peerId || "",
+        role: "MENTOR",
+        mentoringType: "GROUP" as const
+    }), [socket, sessionData?.mentoringId, mentoringId, peerId]); // 의존성 관리
+
+    // 메모이제이션된 config 전달
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } =
-        useWebRtcSession({
-            socket,
-            mentoringId: sessionData?.mentoringId?.toString() || mentoringId || "",
-            peerId: peerId || "",
-            role: "MENTOR",
-            mentoringType: "GROUP"
-        });
+        useWebRtcSession(webRtcConfig);
 
     const questionQueue: Question[] = [
         { id: 1, type: "paid", isPrivate: true, author: "김세종", avatar: "👨‍💼", content: '"How do you negotiate equity in a Series B startup without losing the offer?"' },

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -26,13 +26,58 @@ interface ChatMessage {
     content: string;
 }
 
+// ============================================================================
+// [Wrapper 컴포넌트] 사용자 정보(localStorage)가 준비될 때까지 대기
+// ============================================================================
 export default function MentorLivePage() {
     const params = useParams();
     const mentoringId = params?.id as string;
 
+    const [isReady, setIsReady] = useState(false);
     const [role, setRole] = useState<string>("MENTOR");
-    const [userId, setUserId] = useState<number>(2);
+    const [userId, setUserId] = useState<number | null>(null);
     const [userName, setUserName] = useState<string>("멘토");
+
+    useEffect(() => {
+        // 1. 로컬스토리지에서 멘토 정보 확정 (멘티 페이지의 initAndJoin 로직과 유사)
+        const storedRole = localStorage.getItem("role")?.toUpperCase() || "MENTOR";
+        const storedUserId = localStorage.getItem("userId");
+        const storedName = localStorage.getItem("nickname") || "멘토";
+
+        setRole(storedRole);
+        setUserName(storedName);
+
+        if (storedUserId) {
+            setUserId(Number(storedUserId));
+            setIsReady(true); // 정보 로드 완료 시에만 다음 단계로 이동
+        } else {
+            // 멘토인데 ID가 없는 경우 예외 처리
+            console.error("멘토 ID를 찾을 수 없습니다.");
+        }
+    }, []);
+
+    // 정보를 읽어오는 동안 보여줄 로딩 화면 (멘티 페이지 로딩 UI와 통일)
+    if (!isReady || !userId) {
+        return (
+            <main className="flex flex-col w-full h-[100dvh] bg-[#161616] text-white items-center justify-center space-y-5">
+                <div className="w-12 h-12 border-4 border-[#FFCC00]/20 border-t-[#FFCC00] rounded-full animate-spin"></div>
+                <div className="text-center space-y-1.5">
+                    <h2 className="text-xl font-bold text-gray-200 tracking-tight">방송 세션을 준비 중입니다...</h2>
+                    <p className="text-gray-400 text-sm">최종 권한을 확인하고 미디어 서버에 연결합니다.</p>
+                </div>
+            </main>
+        );
+    }
+
+    // 정보가 확정된 후에만 실제 소켓/WebRTC 로직이 있는 컴포넌트 마운트
+    return <MentorLiveContent mentoringId={mentoringId} role={role} userId={userId} userName={userName} />;
+}
+
+
+// ============================================================================
+// [실제 화면 컴포넌트] 소켓 연결 및 WebRTC 로직 (참조값 고정)
+// ============================================================================
+function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringId: string, role: string, userId: number, userName: string }) {
 
     const videoRef = useRef<HTMLVideoElement>(null);
     const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -46,46 +91,34 @@ export default function MentorLivePage() {
     const [chats, setChats] = useState<ChatMessage[]>([]);
     const [onlineUserCount, setOnlineUserCount] = useState<number>(0);
 
-    const [isInitialized, setIsInitialized] = useState(false);
-
+    // 💡 훅에 넘겨주는 옵션들을 useMemo로 고정 (무한 루프 방지 핵심)
     const mentoringOptions = useMemo(() => ({
         role,
-        userId: userId || 0,
+        userId,
     }), [role, userId]);
 
     const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
-        useMentoringSession(isInitialized ? mentoringOptions : { role: "MENTOR", userId: 0 });
+        useMentoringSession(mentoringOptions); // 이제 정보가 확실하므로 isInitialized 가드 불필요
 
     const webRtcConfig = useMemo(() => ({
         socket,
-        mentoringId: sessionData?.mentoringId?.toString() || mentoringId || "",
+        mentoringId: sessionData?.mentoringId?.toString() || mentoringId,
         peerId: peerId || "",
         role: "MENTOR",
         mentoringType: "GROUP" as const
-    }), [socket, sessionData?.mentoringId, mentoringId, peerId]); // 의존성 관리
+    }), [socket, sessionData?.mentoringId, mentoringId, peerId]);
 
-    // 메모이제이션된 config 전달
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } =
         useWebRtcSession(webRtcConfig);
 
+    // 질문 큐 데이터
     const questionQueue: Question[] = [
         { id: 1, type: "paid", isPrivate: true, author: "김세종", avatar: "👨‍💼", content: '"How do you negotiate equity in a Series B startup without losing the offer?"' },
         { id: 2, type: "free", isPrivate: false, author: "이유진", avatar: "👩‍💼", content: '"Can you share some tips on building a tech portfolio from scratch?"' }
     ];
-
     const currentQuestion = questionQueue[currentIdx];
 
-    useEffect(() => {
-        const storedRole = localStorage.getItem("role")?.toUpperCase();
-        if (storedRole) setRole(storedRole);
-        const storedUserId = localStorage.getItem("userId");
-        if (storedUserId) setUserId(Number(storedUserId));
-        const storedName = localStorage.getItem("nickname") || "멘토";
-        setUserName(storedName);
-
-        setIsInitialized(true);
-    }, []);
-
+    // [채팅 소켓 설정]
     useEffect(() => {
         if (!mentoringId || !userId) return;
 
@@ -143,12 +176,7 @@ export default function MentorLivePage() {
         };
     }, [mentoringId, userId, userName]);
 
-    useEffect(() => {
-        if (isChatOpen) {
-            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-        }
-    }, [chats, isChatOpen]);
-
+    // [비디오 스트림 연결]
     useEffect(() => {
         if (videoRef.current && localStream) {
             if (videoRef.current.srcObject !== localStream) {
@@ -158,20 +186,21 @@ export default function MentorLivePage() {
         }
     }, [localStream, isCameraOn]);
 
+    // [채팅 스크롤]
+    useEffect(() => {
+        if (isChatOpen) {
+            messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+        }
+    }, [chats, isChatOpen]);
+
     const handleNextQuestion = () => {
         setCurrentIdx((prev) => (prev + 1) % questionQueue.length);
         setIsReading(false);
     };
 
-    // 멘토링 세션 완전 종료 처리
     const handleConfirmExit = async () => {
         try {
-            // 프론트엔드 WebRTC/Socket.io 세션 종료
-            if (endMentoring) {
-                await endMentoring();
-            }
-
-            // 목록으로 이동
+            if (endMentoring) await endMentoring();
             window.location.href = "/mentoring_list/live_list";
         } catch (err) {
             console.error("멘토링 종료 실패:", err);
@@ -179,11 +208,12 @@ export default function MentorLivePage() {
         }
     };
 
+    // 로딩 및 에러 처리 (Content 컴포넌트 내부용)
     if (isLoading) {
         return (
             <main className="flex flex-col w-full h-[100dvh] bg-[#161616] text-white items-center justify-center">
                 <div className="w-8 h-8 border-4 border-[#FFCC00]/30 border-t-[#FFCC00] rounded-full animate-spin mb-4"></div>
-                <p className="text-gray-300">멘토링 세션 로드 중...</p>
+                <p className="text-gray-300">미디어 세션 연결 중...</p>
             </main>
         );
     }
@@ -203,9 +233,10 @@ export default function MentorLivePage() {
         );
     }
 
+    // 메인 라이브 화면 UI (기존과 동일)
     return (
         <main className="flex flex-col w-full h-[100dvh] bg-[#161616] text-white font-sans overflow-hidden relative">
-
+            {/* ... 헤더, 질문카드, 비디오, 채팅창, 푸터 UI 코드 ... */}
             <header className="w-full px-5 py-4 flex items-center justify-between shrink-0 z-20">
                 <button onClick={() => setIsExitPopupOpen(true)} className="inline-flex items-center text-red-500">
                     <PhoneOff className="w-5 h-5 mr-2" strokeWidth={2.5} />
@@ -224,10 +255,8 @@ export default function MentorLivePage() {
             </header>
 
             <div className="flex-1 flex flex-col px-4 overflow-hidden relative">
-
                 <div className={`flex flex-col transition-all duration-500 ${!isChatOpen ? 'flex-1 justify-center' : 'justify-start pt-2'}`}>
-
-                    {/* 상단 질문 카드 */}
+                    {/* 질문 카드 */}
                     <div className={`w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl flex justify-between gap-4 ${currentQuestion.type === 'paid' ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-[#F0F0F0] text-[#1A1A1A]'}`}>
                         <div className="flex flex-col gap-3 flex-1">
                             <div className="flex items-center justify-between w-full">
@@ -284,44 +313,25 @@ export default function MentorLivePage() {
                     </div>
                 </div>
 
-                {/* 실시간 채팅 내역 (읽기 전용) */}
+                {/* 채팅 목록 */}
                 {isChatOpen && (
                     <div className="flex-1 flex flex-col mt-4 animate-in fade-in slide-in-from-bottom-8 duration-500 overflow-hidden">
                         <div className="flex-1 overflow-y-auto space-y-4 custom-scrollbar pb-6 pr-2">
-                            {chats.length === 0 ? (
-                                <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-                                    아직 채팅 내역이 없습니다.
-                                </div>
-                            ) : (
-                                chats.map((chat) => {
-                                    const isMentor = sessionData?.host?.userId && String(chat.senderId) === String(sessionData.host.userId);
-                                    const profileImage = isMentor ? "/images/mentor_profile.jpg" : "/images/mentee_profile.jpg";
-
-                                    return (
-                                        <div key={chat.id} className="flex gap-3">
-                                            <img
-                                                src={profileImage}
-                                                alt={isMentor ? "멘토 프로필" : "멘티 프로필"}
-                                                className="w-9 h-9 rounded-full object-cover shrink-0 bg-gray-800 border-2 border-[#FFCC00]"
-                                            />
-
-                                            <div className="flex flex-col items-start">
-                                                <div className="flex items-center gap-2 mb-1">
-                                                    <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
-                                                    {chat.type === 'paid' && <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded">유료 질문</span>}
-                                                </div>
-                                                <p className={`text-[15px] leading-relaxed break-all ${chat.type === 'paid' ? 'text-[#FFCC00]' : 'text-gray-100'}`}>
-                                                    {chat.content}
-                                                </p>
-                                            </div>
+                            {chats.map((chat) => (
+                                <div key={chat.id} className="flex gap-3">
+                                    <div className="w-9 h-9 rounded-full bg-gray-800 border-2 border-[#FFCC00] shrink-0" />
+                                    <div className="flex flex-col items-start">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                            {chat.type === 'paid' && <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded">유료 질문</span>}
                                         </div>
-                                    );
-                                })
-                            )}
+                                        <p className={`text-[15px] leading-relaxed break-all ${chat.type === 'paid' ? 'text-[#FFCC00]' : 'text-gray-100'}`}>
+                                            {chat.content}
+                                        </p>
+                                    </div>
+                                </div>
+                            ))}
                             <div ref={messagesEndRef} />
-                        </div>
-                        <div className="pb-4 text-center">
-                            <span className="text-[11px] text-gray-600 font-medium tracking-tight">멘토 화면에서는 채팅 조회만 가능합니다.</span>
                         </div>
                     </div>
                 )}
@@ -339,7 +349,7 @@ export default function MentorLivePage() {
                 </button>
             </footer>
 
-            {/* 종료 팝업 */}
+            {/* 방송 종료 팝업 */}
             {isExitPopupOpen && (
                 <div className="absolute inset-0 bg-black/80 z-[100] flex items-center justify-center p-6 backdrop-blur-sm">
                     <div className="bg-[#1A1A1A] w-full max-w-sm rounded-[32px] p-8 border border-gray-800 text-center">

--- a/apps/demo-web/hooks/useMentoringSession.ts
+++ b/apps/demo-web/hooks/useMentoringSession.ts
@@ -47,8 +47,6 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
             const res = await apiClient.get(`/media/mentorings/${mentoringId}`);
             const data = res.data;
 
-            console.log("🔍 미디어 서버 응답 데이터:", data); // 데이터 구조 확인용
-
             if (isMountedRef.current) {
                 // 1. 서버 응답 구조 대응 (mentoring 객체 안에 있거나, 평평한 구조이거나)
                 const mentoringInfo = data.mentoring || data;
@@ -112,12 +110,6 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
                 }
                 console.log("Media server connected:", socket.id);
 
-                console.log("📤 [joinMentoring] 서버로 방 입장 요청 발송 데이터:", {
-                    mentoringId: Number(mentoringId),
-                    role: options.role,
-                    userId: options.userId?.toString() || "",
-                });
-
                 // joinMentoring 액션 발송
                 socket.emit(
                     "signal",
@@ -131,16 +123,13 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
                         },
                     },
                     (response: any) => {
-                        // 💡 [추가] 서버로부터 응답이 오면 조건문 이전에 무조건 찍히는 로그
-                        console.log("📩 [joinMentoring] 서버 응답 수신 완료:", response);
-
                         if (!isMountedRef.current) {
                             console.warn("⚠️ 서버 응답을 받았으나 컴포넌트가 이미 언마운트되었습니다.");
                             return;
                         }
 
                         if (response?.ok) {
-                            console.log("🎉 Joined mentoring 성공:", response.data);
+                            console.log("🎉 Joined mentoring");
                             setPeerId(response.data?.peerId || socket.id);
                             setIsConnected(true);
                         } else {

--- a/apps/demo-web/hooks/useMentoringSession.ts
+++ b/apps/demo-web/hooks/useMentoringSession.ts
@@ -59,9 +59,9 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
                     title: mentoringInfo?.title || "멘토링 세션",
                     status: mentoringInfo?.status || "ON_AIR",
                     participantCount: data?.media?.peers?.length || 0,
-                    host: { 
-                        userId: mentoringInfo?.userId || 0, 
-                        nickname: mentoringInfo?.nickname || "호스트" 
+                    host: {
+                        userId: mentoringInfo?.userId || 0,
+                        nickname: mentoringInfo?.nickname || "호스트"
                     },
                     startedAt: mentoringInfo?.startedAt || null,
                 });
@@ -106,8 +106,17 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
             );
 
             socket.on("connect", () => {
-                if (!isMountedRef.current) return;
+                if (!isMountedRef.current) {
+                    console.warn("⚠️ 소켓이 연결되었으나 컴포넌트가 언마운트 상태입니다.");
+                    return;
+                }
                 console.log("Media server connected:", socket.id);
+
+                console.log("📤 [joinMentoring] 서버로 방 입장 요청 발송 데이터:", {
+                    mentoringId: Number(mentoringId),
+                    role: options.role,
+                    userId: options.userId?.toString() || "",
+                });
 
                 // joinMentoring 액션 발송
                 socket.emit(
@@ -122,17 +131,30 @@ export function useMentoringSession(options: UseMentoringSessionOptions) {
                         },
                     },
                     (response: any) => {
-                        if (!isMountedRef.current) return;
+                        // 💡 [추가] 서버로부터 응답이 오면 조건문 이전에 무조건 찍히는 로그
+                        console.log("📩 [joinMentoring] 서버 응답 수신 완료:", response);
+
+                        if (!isMountedRef.current) {
+                            console.warn("⚠️ 서버 응답을 받았으나 컴포넌트가 이미 언마운트되었습니다.");
+                            return;
+                        }
 
                         if (response?.ok) {
-                            console.log("Joined mentoring:", response.data);
+                            console.log("🎉 Joined mentoring 성공:", response.data);
                             setPeerId(response.data?.peerId || socket.id);
                             setIsConnected(true);
                         } else {
+                            // 💡 [추가] 실패 시 브라우저 콘솔에 빨간색으로 에러를 명시적으로 출력
+                            console.error("❌ joinMentoring 서버 처리 실패 원인:", response?.error || response);
                             setError(response?.error || "멘토링 참여 실패");
                         }
                     }
                 );
+            });
+
+            // 💡 [추가] 소켓 자체의 연결 에러 세부 진단
+            socket.on("connect_error", (err) => {
+                console.error("🚨 소켓 연결 자체에 에러 발생 (connect_error):", err.message, err);
             });
 
             socket.on("signal", (message: any) => {

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -106,7 +106,8 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
                     if (res?.ok) {
                         resolve(res);
                     } else {
-                        reject(new Error(res?.error || `서버 에러 발생: ${JSON.stringify(res)}`));
+                        const errorMsg = res?.error || "Unknown server error";
+                        reject(new Error(errorMsg));
                     }
                 });
             });

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -140,7 +140,7 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
     }, [config.socket?.id, config.peerId, localStream]);
 
     // 3. Send Transport 생성
-    const createSendTransport = (device: Device): Promise<MediaSoupTypes.Transport> => {
+    const createSendTransport = useCallback((device: Device): Promise<MediaSoupTypes.Transport> => {
         return new Promise((resolve, reject) => {
             if (!config.socket) return reject(new Error("소켓이 없습니다"));
 
@@ -197,10 +197,10 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
                 }
             );
         });
-    }
+    }, [config.socket]);
 
     // 4. Recv Transport 생성
-    const createRecvTransport = (device: Device): Promise<MediaSoupTypes.Transport> => {
+    const createRecvTransport = useCallback((device: Device): Promise<MediaSoupTypes.Transport> => {
         return new Promise((resolve, reject) => {
             if (!config.socket) return reject(new Error("소켓이 없습니다"));
 
@@ -254,7 +254,7 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
                 }
             )
         })
-    }
+    }, [config.socket]);
 
     // 5. Producer 생성 (로컬 미디어 송출)
     const produceAudio = useCallback(
@@ -440,7 +440,10 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
         // 🚨 [핵심] 연결이 끊겼거나 아직 방(joinMentoring)에 입장하기 전이라면 
         // WebRTC 실행을 중단하고 기존 장치 상태들을 전부 초기화하여 재연결 충돌을 방지합니다.
         if (!config.isJoined) {
-            setIsReady(false);
+            if (isReady) {
+                setIsReady(false);
+                setRemoteStreams(new Map());
+            }
             isInitializingRef.current = false;
             deviceRef.current = null;
             sendTransportRef.current = null;

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -121,13 +121,13 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
             return device;
         } catch (err) {
             const errorMsg = err instanceof Error ? err.message : "Device 초기화 실패";
-            console.error("❌ Device init error:", err);
+            console.error("❌ Device init error:", JSON.stringify(err, Object.getOwnPropertyNames(err)));
             if (isMountedRef.current) {
                 setError(errorMsg);
             }
             throw err;
         }
-    }, [config.socket]);
+    }, [config.socket?.id, config.peerId, localStream]);
 
     // 3. Send Transport 생성
     const createSendTransport = (device: Device): Promise<MediaSoupTypes.Transport> => {
@@ -429,7 +429,7 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
 
         const init = async () => {
             try {
-                if (isReady || isInitializingRef.current) {
+                if (isReady || isInitializingRef.current || error) {
                     return;
                 }
 

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -411,6 +411,26 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
 
                     // 💡 [수정] 위에서 만든 통합 헬퍼 함수를 호출합니다.
                     await requestConsume(producerId, kind);
+                } else if (message.event === "producer-closed") {
+                    // 상대방이 나가거나 연결이 끊겨 프로듀서가 닫힌 경우 자원 정리
+
+                    console.log("🚪 Producer closed:", message.data);
+                    const { producerId } = message.data;
+
+                    setRemoteStreams((prev) => {
+                        const newMap = new Map(prev);
+                        newMap.delete(producerId);
+                        return newMap;
+                    });
+
+                    for (const [consumerId, consumer] of consumersRef.current.entries()) {
+                        if (consumer.producerId === producerId) {
+                            consumer.close();
+                            consumersRef.current.delete(consumerId);
+                            console.log(`✅ Closed consumer for producer: ${producerId}`);
+                            break;
+                        }
+                    }
                 }
             } catch (err) {
                 console.error("Signal 처리 오류:", err);

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -1,8 +1,6 @@
 import { useEffect, useRef, useState, useCallback, use } from "react";
 import { Device, types as MediaSoupTypes } from "mediasoup-client";
 import { Socket } from "socket.io-client";
-import { resolve } from "path";
-import { request } from "http";
 
 interface WebRtcSessionConfig {
     socket: Socket | null;
@@ -103,7 +101,7 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
                     requestId: `get-rtp-caps-${Date.now()}`,
                     action: "getRtpCapabilities",
                     data: {},
-                }, (res: any) => res?.of ? resolve(res) : reject(new Error(res?.error)));
+                }, (res: any) => res?.ok ? resolve(res) : reject(new Error(res?.error)));
             });
 
             console.log("🚀 Loading MediaSoup device...");

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -8,6 +8,7 @@ interface WebRtcSessionConfig {
     peerId: string;
     role: string;
     mentoringType?: "GROUP" | "ONE_ON_ONE";
+    isJoined: boolean;
     onRemoteStream?: (stream: MediaStream) => void;
     onError?: (error: string) => void;
 }
@@ -436,24 +437,34 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
     useEffect(() => {
         isMountedRef.current = true;
 
+        // 🚨 [핵심] 연결이 끊겼거나 아직 방(joinMentoring)에 입장하기 전이라면 
+        // WebRTC 실행을 중단하고 기존 장치 상태들을 전부 초기화하여 재연결 충돌을 방지합니다.
+        if (!config.isJoined) {
+            setIsReady(false);
+            isInitializingRef.current = false;
+            deviceRef.current = null;
+            sendTransportRef.current = null;
+            recvTransportRef.current = null;
+            producersRef.current.clear();
+            consumersRef.current.clear();
+            setRemoteStreams(new Map());
+            return;
+        }
+
         const init = async () => {
             try {
                 if (isReady || isInitializingRef.current || error) {
                     return;
                 }
 
-                // 1. 기본 연결 상태 확인
-                // 소켓과 peerId가 있을 때만 미디어 서버 연결(mediasoup) 로직 진행
-                if (!config.socket?.connected || !config.peerId) {
+                // 1. 기본 연결 및 방 참여 상태 확인
+                if (!config.socket?.connected || !config.peerId || !config.isJoined) {
                     return;
                 }
 
-                // 멘토링 타입에 따라 스트림 필수 여부 확인
-                // 1:N 멘티는 localStream이 null이어도 초기화를 계속 진행해야 합니다 (수신을 위해)
                 const isOneToOne = config.mentoringType === "ONE_ON_ONE";
                 const needsLocalStream = config.role === "MENTOR" || isOneToOne;
 
-                // 스트림이 꼭 필요한 역할인데 아직 준비가 안 됐다면 대기
                 if (needsLocalStream && !localStream) {
                     console.log("Waiting for local stream...");
                     return;
@@ -461,47 +472,36 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
 
                 isInitializingRef.current = true;
 
-                // 2. Mediasoup 장치 및 트랜스포트 생성 (송/수신 공통)
+                // 2. Mediasoup 장치 및 트랜스포트 생성
                 const device = await initDevice();
                 const sendTransport = await createSendTransport(device);
-
                 await createRecvTransport(device);
 
                 // 3. 송출(Produce) 로직
-                // localStream이 존재할 때만 실행되도록 if문으로 감싸 타입을 확정합니다.
                 if (localStream) {
                     if (config.role === "MENTOR") {
-                        // 멘토는 비디오와 오디오 모두 송출
                         await produceAudio(localStream, sendTransport);
                         await produceVideo(localStream, sendTransport);
                         console.log("✅ Mentor tracks produced");
                     } else if (isOneToOne) {
-                        // 1:1 멘티인 경우 오디오만 송출
                         await produceAudio(localStream, sendTransport);
                         console.log("✅ Mentee audio track produced (1:1)");
                     }
-                } else {
-                    // 1:N 멘티의 경우 localStream이 없으므로 송출 로직을 건너뜁니다.
-                    console.log("ℹ️ 1:N Mentee mode: Skipping production");
                 }
 
+                // 4. 기존 Producer 확인 및 수신
                 const { data: producerIds } = await new Promise<{ data: any[] }>((resolve, reject) => {
-                    config.socket?.emit(
-                        "signal",
-                        {
-                            requestId: `list-producers-${Date.now()}`,
-                            action: "listProducers",
-                            data: {}
-                        },
-                        (response: any) => {
-                            if (response?.ok) resolve(response);
-                            else reject(new Error(response?.error));
-                        }
-                    );
+                    config.socket?.emit("signal", {
+                        requestId: `list-producers-${Date.now()}`,
+                        action: "listProducers",
+                        data: {}
+                    }, (response: any) => {
+                        if (response?.ok) resolve(response);
+                        else reject(new Error(response?.error));
+                    });
                 });
 
                 if (producerIds && producerIds.length > 0) {
-                    console.log("📥 Found existing producers:", producerIds);
                     for (const p of producerIds) {
                         const pid = typeof p === 'string' ? p : p.producerId;
                         const pkind = typeof p === 'string' ? undefined : p.kind;
@@ -522,25 +522,17 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
             }
         };
 
-        const retryInit = () => {
-            void init();
-        };
-
-        if (config.socket) {
-            config.socket.on("connect", retryInit);
-            config.socket.on("reconnect", retryInit);
-        }
+        // ❌ 기존에 소켓 재연결 시 강제로 init()을 호출하던 
+        // socket.on("connect", retryInit) 부분은 완전히 삭제합니다. 
+        // 이제 isJoined 상태 변경에 의해 React가 자연스럽게 순서를 보장하며 재실행합니다.
 
         init();
 
         return () => {
             isMountedRef.current = false;
-            if (config.socket) {
-                config.socket.off("connect", retryInit);
-                config.socket.off("reconnect", retryInit);
-            }
         };
-    }, [config.socket, config.peerId, config.role, isReady, initLocalStream, initDevice, createSendTransport, createRecvTransport, produceAudio, produceVideo, localStream]);
+        // 💡 의존성 배열에 config.isJoined 필수 추가
+    }, [config.socket, config.peerId, config.isJoined, config.role, isReady, initLocalStream, initDevice, createSendTransport, createRecvTransport, produceAudio, produceVideo, localStream]);
 
     // 카메라/마이크 토글
     const setCameraOn = useCallback(

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -101,7 +101,14 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
                     requestId: `get-rtp-caps-${Date.now()}`,
                     action: "getRtpCapabilities",
                     data: {},
-                }, (res: any) => res?.ok ? resolve(res) : reject(new Error(res?.error)));
+                }, (res: any) => {
+                    console.log("📩 RTP Capabilities 서버 응답:", res);
+                    if (res?.ok) {
+                        resolve(res);
+                    } else {
+                        reject(new Error(res?.error || `서버 에러 발생: ${JSON.stringify(res)}`));
+                    }
+                });
             });
 
             console.log("🚀 Loading MediaSoup device...");
@@ -113,7 +120,7 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
             return device;
         } catch (err) {
             const errorMsg = err instanceof Error ? err.message : "Device 초기화 실패";
-            console.error("❌ Device init error:", errorMsg);
+            console.error("❌ Device init error:", err);
             if (isMountedRef.current) {
                 setError(errorMsg);
             }

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -120,10 +120,19 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
             deviceRef.current = device;
             return device;
         } catch (err) {
-            const errorMsg = err instanceof Error ? err.message : "Device 초기화 실패";
-            console.error("❌ Device init error:", JSON.stringify(err, Object.getOwnPropertyNames(err)));
+            const error = err as any;
+
+            console.error(`[❌ Device init error 발생!`);
+
+            // 직렬화하지 않고 객체 날것 그대로 콘솔에 출력 (화살표를 눌러 내부를 볼 수 있음)
+            console.error("1. Raw Error Object:", error);
+
+            // 프로토타입 체인을 무시하고 명시적으로 속성 추출
+            console.error("2. Error Details -> Name:", error?.name, " | Message:", error?.message);
+            console.error("3. Error Stack:", error?.stack);
+
             if (isMountedRef.current) {
-                setError(errorMsg);
+                setError(error?.message || "Device 초기화 실패");
             }
             throw err;
         }

--- a/services/media-server/Dockerfile
+++ b/services/media-server/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /app
 
 # mediasoup prebuilt 실패 시 로컬 빌드를 위한 의존성
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip make g++ pkg-config openssl ca-certificates \
+    && apt-get install -y --no-install-recommends python3 python3-pip make g++ pkg-config ffmpeg openssl ca-certificates \
     && ln -sf /usr/bin/python3 /usr/bin/python \
     && rm -rf /var/lib/apt/lists/*
 
@@ -27,7 +27,7 @@ WORKDIR /app/services/media-server
 FROM node:22-bookworm-slim
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends openssl ca-certificates ffmpeg && rm -rf /var/lib/apt/lists/*
 
 ENV TZ=Asia/Seoul
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/services/media-server/src/streaming/mediaSoupOrchestrator.js
+++ b/services/media-server/src/streaming/mediaSoupOrchestrator.js
@@ -136,8 +136,8 @@ export class MediaSoupOrchestrator {
             throw new Error(`Peer ${peerId}은 이미 방에 존재합니다.`);
         }
 
-        if (role === 'mentor') {
-            const mentorExists = [...room.peers.values()].some((peer) => peer.role === 'mentor');
+        if (role === 'MENTOR') {
+            const mentorExists = [...room.peers.values()].some((peer) => peer.role === 'MENTOR');
 
             if (mentorExists) {
                 throw new Error('이 멘토링은 이미 멘토가 있습니다.');
@@ -145,20 +145,20 @@ export class MediaSoupOrchestrator {
         }
 
         if (!room.isGroup) {
-            if (role !== 'mentor' && role !== 'mentee' && role !== 'tts-bot') {
+            if (role !== 'MENTOR' && role !== 'MENTEE' && role !== 'TTS-BOT') {
                 throw new Error('1:1 멘토링에서는 mentor/mentee/tts-bot role만 사용할 수 있습니다.');
             }
 
-            if (role === 'mentee') {
-                const menteeExists = [...room.peers.values()].some((peer) => peer.role === 'mentee');
+            if (role === 'MENTEE') {
+                const menteeExists = [...room.peers.values()].some((peer) => peer.role === 'MENTEE');
 
                 if (menteeExists) {
                     throw new Error('1:1 멘토링에는 멘티 1명만 참여할 수 있습니다.');
                 }
             }
 
-            if (role === 'tts-bot') {
-                const ttsExists = [...room.peers.values()].some((peer) => peer.role === 'tts-bot');
+            if (role === 'TTS-BOT') {
+                const ttsExists = [...room.peers.values()].some((peer) => peer.role === 'TTS-BOT');
 
                 if (ttsExists) {
                     throw new Error('1:1 멘토링에는 tts-bot 1개만 연결할 수 있습니다.');
@@ -249,7 +249,7 @@ export class MediaSoupOrchestrator {
             throw new Error('멘토링 Room이나 Peer를 찾을 수 없습니다.');
         }
 
-        if (peer.role === 'mentee' && room.isGroup) {
+        if (peer.role === 'MENTEE' && room.isGroup) {
             throw new Error('멘티는 1:N 멘토링에서 미디어를 송출할 수 없습니다.');
         }
 
@@ -257,7 +257,7 @@ export class MediaSoupOrchestrator {
             throw new Error('1:1 멘토링은 오디오만 송출할 수 있습니다.');
         }
 
-        if (peer.role === 'tts-bot' && kind !== 'audio') {
+        if (peer.role === 'TTS-BOT' && kind !== 'audio') {
             throw new Error('tts-bot role은 오디오 미디어만 송출할 수 있습니다.');
         }
 
@@ -267,19 +267,19 @@ export class MediaSoupOrchestrator {
         peer.producers.set(producer.id, producer);
 
         if (kind === 'audio') {
-            if (peer.role === 'mentor') {
+            if (peer.role === 'MENTOR') {
                 this.audioPipeline.attachMentorAudioProducer(mentoringId, producer.id);
             }
 
-            if (peer.role === 'mentee') {
+            if (peer.role === 'MENTEE') {
                 this.audioPipeline.attachMenteeAudioProducer(mentoringId, producer.id);
             }
 
-            if (peer.role === 'tts-bot') {
+            if (peer.role === 'TTS-BOT') {
                 this.audioPipeline.attachTtsAudioProducer(mentoringId, producer.id);
             }
 
-            const shouldForward = peer.role === 'mentor' || (!room.isGroup && peer.role === 'mentee');
+            const shouldForward = peer.role === 'MENTOR' || (!room.isGroup && peer.role === 'MENTEE');
             if (shouldForward && peer.userId != null) {
                 this.rtpForwarder.start({
                     router: room.router,

--- a/services/media-server/src/streaming/rtpForwarder.js
+++ b/services/media-server/src/streaming/rtpForwarder.js
@@ -82,6 +82,10 @@ export class RtpForwarder {
             'pipe:1',
         ]);
 
+        ffmpeg.on('error', (err) => {
+            console.error('[RtpForwarder] FFmpeg 실행 실패:', err);
+        });
+
         const state = {
             plainTransport, consumer, ffmpeg, sdpPath, port,
             pcmBuffer: Buffer.alloc(0),

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -137,12 +137,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
 
                         socketContext.set(socket.id, { mentoringId, peerId, role, userId });
 
-                        sendReply(socket, requestId, {
-                            peerId,
-                            ...joinResult,
-                            audioPipeline: audioPipeline.getRoomSnapshot(mentoringId)
-                        });
-
                         notifyPeers(
                             mentoringId,
                             'peer-joined',
@@ -166,7 +160,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             throw new Error('멘토링 세션이 존재하지 않습니다.');
                         }
 
-                        sendReply(socket, requestId, room.router.rtpCapabilities);
                         result = room.router.rtpCapabilities;
                         break;
                     }
@@ -183,7 +176,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             direction: data.direction ?? 'recv'
                         });
 
-                        sendReply(socket, requestId, transport);
                         result = transport;
                         break;
                     }
@@ -201,7 +193,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             dtlsParameters: data.dtlsParameters
                         });
 
-                        sendReply(socket, requestId, { connected: true });
                         result = { connected: true };
                         break;
                     }
@@ -220,8 +211,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             rtpParameters: data.rtpParameters,
                             appData: data.appData
                         });
-
-                        sendReply(socket, requestId, produced);
 
                         notifyPeers(
                             context.mentoringId,
@@ -263,7 +252,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             rtpCapabilities: data.rtpCapabilities
                         });
 
-                        sendReply(socket, requestId, consumed);
                         result = consumed;
                         break;
                     }
@@ -280,7 +268,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             consumerId: data.consumerId
                         });
 
-                        sendReply(socket, requestId, { resumed: true });
                         result = { resumed: true };
                         break;
                     }
@@ -296,7 +283,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             context.peerId
                         );
 
-                        sendReply(socket, requestId, producerIds);
                         result = producerIds;
                         break;
                     }
@@ -313,10 +299,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             metadata: data.metadata ?? null
                         });
 
-                        sendReply(socket, requestId, {
-                            queued: true,
-                            message: 'TTS request queued; attach a tts-bot audio producer to inject actual synthesized audio'
-                        });
                         result = {
                             queued: true,
                             message: 'TTS request queued; attach a tts-bot audio producer to inject actual synthesized audio'
@@ -344,7 +326,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         );
 
                         socketContext.delete(socket.id);
-                        sendReply(socket, requestId, { left: true });
                         result = { left: true };
                         break;
                     }

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -149,6 +149,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         break;
                     }
                     case 'getRtpCapabilities': {
+                        console.log('getRtpCapabilities called');
                         const context = socketContext.get(socket.id);
 
                         if (!context) {
@@ -161,6 +162,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         }
 
                         result = JSON.parse(JSON.stringify(room.router.rtpCapabilities));
+                        console.log('Returning RTP Capabilities:', result);
                         break;
                     }
                     case 'createWebRtcTransport': {
@@ -340,11 +342,12 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 }
             } catch (error) {
                 console.error('Signaling error:', error);
+                const errorMessage = error instanceof Error ? error.message : String(error);
 
                 if (typeof callback === 'function') {
-                    callback({ ok: false, error: error?.message ?? 'Unhandled signaling error' });
+                    callback({ ok: false, error: errorMessage });
                 } else {
-                    sendError(socket, requestId, error);
+                    sendError(socket, requestId, { message: errorMessage });
                 }
             }
         });

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -96,8 +96,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 let result;
                 switch (action) {
                     case 'joinMentoring': {
-                        console.log('joinMentoring called');
-
                         try {
                             const mentoringId = Number(data.mentoringId);
                             const role = data.role ?? 'MENTEE';
@@ -153,7 +151,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                                 },
                                 peerId
                             );
-                            console.log('joinMentoring successful');
                             break;
                         } catch (error) {
                             console.error('joinMentoring error:', error);
@@ -165,7 +162,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         }
                     }
                     case 'getRtpCapabilities': {
-                        console.log('getRtpCapabilities called');
                         const context = socketContext.get(socket.id);
 
                         if (!context) {
@@ -178,7 +174,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         }
 
                         result = JSON.parse(JSON.stringify(room.router.rtpCapabilities));
-                        console.log('Returning RTP Capabilities');
                         break;
                     }
                     case 'createWebRtcTransport': {
@@ -352,7 +347,6 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 }
 
                 if (typeof callback === 'function') {
-                    console.log('response for callback:', { ok: true, data: result });
                     callback({ ok: true, data: result });
                 } else {
                     sendReply(socket, requestId, result);

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -60,7 +60,11 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
             methods: ['GET', 'POST'],
             credentials: true
         },
-        transports: ['websocket', 'polling']
+        transports: ['websocket', 'polling'],
+        connectionStateRecovery: {
+            maxDisconnectionDuration: 2 * 60 * 1000, // 2분
+            skipMiddlewares: true
+        }
     });
 
     const socketContext = new Map();

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -92,7 +92,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 switch (action) {
                     case 'joinMentoring': {
                         const mentoringId = Number(data.mentoringId);
-                        const role = data.role ?? 'mentee';
+                        const role = data.role ?? 'MENTEE';
                         const peerId = data.userId ?? socket.id;
 
                         if (!Number.isFinite(mentoringId)) {
@@ -107,7 +107,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
 
                         const userId = resolveUserIdFromSocket(socket, data);
 
-                        if (role === 'mentor') {
+                        if (role === 'MENTOR') {
                             if (userId === null) {
                                 throw new Error('멘토 권한이 필요합니다.');
                             }

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -162,7 +162,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         }
 
                         result = JSON.parse(JSON.stringify(room.router.rtpCapabilities));
-                        console.log('Returning RTP Capabilities:', result);
+                        console.log('Returning RTP Capabilities');
                         break;
                     }
                     case 'createWebRtcTransport': {
@@ -336,6 +336,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 }
 
                 if (typeof callback === 'function') {
+                    console.log('response for callback:', { ok: true, data: result });
                     callback({ ok: true, data: result });
                 } else {
                     sendReply(socket, requestId, result);

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -96,61 +96,73 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                 let result;
                 switch (action) {
                     case 'joinMentoring': {
-                        const mentoringId = Number(data.mentoringId);
-                        const role = data.role ?? 'MENTEE';
-                        const peerId = data.userId ?? socket.id;
+                        console.log('joinMentoring called');
 
-                        if (!Number.isFinite(mentoringId)) {
-                            throw new Error('유효하지 않은 멘토링 ID입니다.');
-                        }
+                        try {
+                            const mentoringId = Number(data.mentoringId);
+                            const role = data.role ?? 'MENTEE';
+                            const peerId = data.userId ?? socket.id;
 
-                        const mentoring = await mentoringRepository.getMentoringById(mentoringId);
-
-                        if (!mentoring || mentoring.status !== 'ON_AIR') {
-                            throw new Error('멘토링 세션이 진행 중이 아닙니다.');
-                        }
-
-                        const userId = resolveUserIdFromSocket(socket, data);
-
-                        if (role === 'MENTOR') {
-                            if (userId === null) {
-                                throw new Error('멘토 권한이 필요합니다.');
+                            if (!Number.isFinite(mentoringId)) {
+                                throw new Error('유효하지 않은 멘토링 ID입니다.');
                             }
 
-                            await mentoringRepository.assertMentorUser(userId);
+                            const mentoring = await mentoringRepository.getMentoringById(mentoringId);
 
-                            if (Number(mentoring.userId) !== Number(userId)) {
-                                throw new Error('멘토링 세션에 참여할 권한이 없습니다.');
+                            if (!mentoring || mentoring.status !== 'ON_AIR') {
+                                throw new Error('멘토링 세션이 진행 중이 아닙니다.');
                             }
-                        }
 
-                        const joinResult = await mediaOrchestrator.addPeer({
-                            mentoringId,
-                            peerId,
-                            role,
-                            socket,
-                            isGroup: mentoring.isGroup,
-                            userId,
-                        });
+                            const userId = resolveUserIdFromSocket(socket, data);
 
-                        result = {
-                            peerId,
-                            ...joinResult,
-                            audioPipeline: audioPipeline.getRoomSnapshot(mentoringId)
-                        };
+                            if (role === 'MENTOR') {
+                                if (userId === null) {
+                                    throw new Error('멘토 권한이 필요합니다.');
+                                }
 
-                        socketContext.set(socket.id, { mentoringId, peerId, role, userId });
+                                await mentoringRepository.assertMentorUser(userId);
 
-                        notifyPeers(
-                            mentoringId,
-                            'peer-joined',
-                            {
+                                if (Number(mentoring.userId) !== Number(userId)) {
+                                    throw new Error('멘토링 세션에 참여할 권한이 없습니다.');
+                                }
+                            }
+
+                            const joinResult = await mediaOrchestrator.addPeer({
+                                mentoringId,
                                 peerId,
-                                role
-                            },
-                            peerId
-                        );
-                        break;
+                                role,
+                                socket,
+                                isGroup: mentoring.isGroup,
+                                userId,
+                            });
+
+                            result = {
+                                peerId,
+                                ...joinResult,
+                                audioPipeline: audioPipeline.getRoomSnapshot(mentoringId)
+                            };
+
+                            socketContext.set(socket.id, { mentoringId, peerId, role, userId });
+
+                            notifyPeers(
+                                mentoringId,
+                                'peer-joined',
+                                {
+                                    peerId,
+                                    role
+                                },
+                                peerId
+                            );
+                            console.log('joinMentoring successful');
+                            break;
+                        } catch (error) {
+                            console.error('joinMentoring error:', error);
+                            if (typeof callback === 'function') {
+                                callback({ ok: false, error: error.message });
+                                return;
+                            }
+                            break;
+                        }
                     }
                     case 'getRtpCapabilities': {
                         console.log('getRtpCapabilities called');

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -89,6 +89,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
             const { requestId, action, data = {} } = message;
 
             try {
+                let result;
                 switch (action) {
                     case 'joinMentoring': {
                         const mentoringId = Number(data.mentoringId);
@@ -128,6 +129,12 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             userId,
                         });
 
+                        result = {
+                            peerId,
+                            ...joinResult,
+                            audioPipeline: audioPipeline.getRoomSnapshot(mentoringId)
+                        };
+
                         socketContext.set(socket.id, { mentoringId, peerId, role, userId });
 
                         sendReply(socket, requestId, {
@@ -160,6 +167,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         }
 
                         sendReply(socket, requestId, room.router.rtpCapabilities);
+                        result = room.router.rtpCapabilities;
                         break;
                     }
                     case 'createWebRtcTransport': {
@@ -332,8 +340,20 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                     default:
                         throw new Error(`알 수 없는 signaling 액션: ${action}`);
                 }
+
+                if (typeof ack === 'function') {
+                    ack({ ok: true, data: result });
+                } else {
+                    sendReply(socket, requestId, result);
+                }
             } catch (error) {
-                sendError(socket, requestId, error);
+                console.error('Signaling error:', error);
+
+                if (typeof ack === 'function') {
+                    ack({ ok: false, error: error?.message ?? 'Unhandled signaling error' });
+                } else {
+                    sendError(socket, requestId, error);
+                }
             }
         });
 

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -160,7 +160,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             throw new Error('멘토링 세션이 존재하지 않습니다.');
                         }
 
-                        result = room.router.rtpCapabilities;
+                        result = JSON.parse(JSON.stringify(room.router.rtpCapabilities));
                         break;
                     }
                     case 'createWebRtcTransport': {

--- a/services/media-server/src/streaming/signalingServer.js
+++ b/services/media-server/src/streaming/signalingServer.js
@@ -85,9 +85,9 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
     }
 
     io.on('connection', (socket) => {
-        socket.on('signal', async (message = {}) => {
+        socket.on('signal', async (message = {}, callback) => {
             const { requestId, action, data = {} } = message;
-
+            console.log(`Received signaling message: ${action}`);
             try {
                 let result;
                 switch (action) {
@@ -184,6 +184,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         });
 
                         sendReply(socket, requestId, transport);
+                        result = transport;
                         break;
                     }
                     case 'connectWebRtcTransport': {
@@ -201,6 +202,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         });
 
                         sendReply(socket, requestId, { connected: true });
+                        result = { connected: true };
                         break;
                     }
                     case 'produce': {
@@ -232,6 +234,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             },
                             context.peerId
                         );
+                        result = produced;
                         break;
                     }
                     case 'consume': {
@@ -261,6 +264,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         });
 
                         sendReply(socket, requestId, consumed);
+                        result = consumed;
                         break;
                     }
                     case 'resumeConsumer': {
@@ -277,6 +281,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         });
 
                         sendReply(socket, requestId, { resumed: true });
+                        result = { resumed: true };
                         break;
                     }
                     case 'listProducers': {
@@ -292,6 +297,7 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                         );
 
                         sendReply(socket, requestId, producerIds);
+                        result = producerIds;
                         break;
                     }
                     case 'ttsEnqueue': {
@@ -311,6 +317,10 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
                             queued: true,
                             message: 'TTS request queued; attach a tts-bot audio producer to inject actual synthesized audio'
                         });
+                        result = {
+                            queued: true,
+                            message: 'TTS request queued; attach a tts-bot audio producer to inject actual synthesized audio'
+                        };
                         break;
                     }
                     case 'leaveMentoring': {
@@ -335,22 +345,23 @@ export function createSignalingServer({ httpServer, mediaOrchestrator, mentoring
 
                         socketContext.delete(socket.id);
                         sendReply(socket, requestId, { left: true });
+                        result = { left: true };
                         break;
                     }
                     default:
                         throw new Error(`알 수 없는 signaling 액션: ${action}`);
                 }
 
-                if (typeof ack === 'function') {
-                    ack({ ok: true, data: result });
+                if (typeof callback === 'function') {
+                    callback({ ok: true, data: result });
                 } else {
                     sendReply(socket, requestId, result);
                 }
             } catch (error) {
                 console.error('Signaling error:', error);
 
-                if (typeof ack === 'function') {
-                    ack({ ok: false, error: error?.message ?? 'Unhandled signaling error' });
+                if (typeof callback === 'function') {
+                    callback({ ok: false, error: error?.message ?? 'Unhandled signaling error' });
                 } else {
                     sendError(socket, requestId, error);
                 }


### PR DESCRIPTION
# 연관된 이슈

#86 

## 작업 내용

멘토링 세션 내 영상과 음성 실시간으로 송출되도록 수정하였습니다.
멘토링 종료 시 자동 퇴장 기능 및 일대일 멘토링에서 멘티의 나가기 버튼 등을 추가했습니다.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

실시간 송수신 테스트에 배포 환경이 필요해서 커밋-배포-테스트를 여러번 하다보니 커밋이 많이 쌓였습니다..
그냥 머지와 스쿼시앤머지(브랜치 기록이 안 남고 전체 커밋이 main 브랜치에 하나의 커밋으로 압축됨) 중에 뭐가 나을까요?