### PR TITLE
Refactor/111 qusetion model fastapi

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,6 @@
 !package-lock.json
 !services/**
 !packages/**
+services/**/node_modules/
+services/model/question_detection.zip
+services/question-service/outputs/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,12 @@ jobs:
             question-service:
               - 'services/question-service/**'
               - 'packages/**'
+            question-model-api:
+              - 'services/question-service/python_api/**'
+              - 'services/question-service/scripts/**'
+              - 'services/question-service/requirements.txt'
+              - 'services/question-service/Dockerfile.model-api'
+              - 'services/model/question_detection.dvc'
             stt-service:
               - 'services/stt-service/**'
               - 'packages/**'
@@ -49,7 +55,7 @@ jobs:
         id: force-all
         if: github.event_name == 'workflow_dispatch'
         run: |
-          echo 'changes=["core-api", "chat-service", "media-server", "question-service", "stt-service"]' >> $GITHUB_OUTPUT
+          echo 'changes=["core-api", "chat-service", "media-server", "question-model-api", "question-service", "stt-service"]' >> $GITHUB_OUTPUT
   
   buildAndPush:
     name: Build and Push ${{ matrix.service }}
@@ -90,11 +96,20 @@ jobs:
             type=raw,value=${{ github.sha }}
             type=raw,value=latest
 
+      - name: Resolve Dockerfile
+        id: dockerfile
+        run: |
+          if [ "${{ matrix.service }}" = "question-model-api" ]; then
+            echo "path=./services/question-service/Dockerfile.model-api" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=./services/${{ matrix.service }}/Dockerfile" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
           context: .
-          file: ./services/${{ matrix.service }}/Dockerfile
+          file: ${{ steps.dockerfile.outputs.path }}
           push: true
           platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
@@ -218,7 +233,24 @@ jobs:
                     -p 4003:4003 \
                     --network carpoolink-network \
                     --env-file /app/.env \
+                    -e QUESTION_MODEL_API_URL=http://carpoolink-question-model-api:8000 \
                     ghcr.io/${{ env.REPO_OWNER }}/question-service:${{ github.sha }}
+                  ;;
+                "question-model-api")
+                  if [ ! -d /app/services/model/question_detection ]; then
+                    echo "Missing /app/services/model/question_detection on EC2."
+                    echo "Upload or restore the DVC model artifacts before deploying question-model-api."
+                    exit 1
+                  fi
+                  docker run --restart always \
+                    -d --name carpoolink-question-model-api \
+                    --network carpoolink-network \
+                    --env-file /app/.env \
+                    -e QUESTION_PRELOAD_KC_ELECTRA=true \
+                    -e QUESTION_TFIDF_ARTIFACT_DIR=/app/services/model/question_detection/tfidf_lr_rule_filter_off \
+                    -e QUESTION_KC_ELECTRA_DIR=/app/services/model/question_detection/kc_electra_question_detector \
+                    -v /app/services/model/question_detection:/app/services/model/question_detection:ro \
+                    ghcr.io/${{ env.REPO_OWNER }}/question-model-api:${{ github.sha }}
                   ;;
                 "stt-service")
                   docker run --restart always \

--- a/docs/guides/question-model-api-deployment.md
+++ b/docs/guides/question-model-api-deployment.md
@@ -1,0 +1,127 @@
+# Question Model API Deployment
+
+This guide explains how to run and deploy the Python model API used by
+`question-service`.
+
+## Local Development
+
+Start the FastAPI model API:
+
+```powershell
+npm.cmd run dev:question:model
+```
+
+In another terminal, route the Node question-service through the model API:
+
+```powershell
+$env:QUESTION_MODEL_API_URL="http://127.0.0.1:8000"
+npm.cmd run dev:question
+```
+
+Test question detection through the Node service:
+
+```powershell
+Invoke-RestMethod `
+  -Uri "http://127.0.0.1:4003/api/question-detection/predict" `
+  -Method Post `
+  -ContentType "application/json; charset=utf-8" `
+  -Body '{"text":"이 부분 다시 설명해주실 수 있나요?"}'
+```
+
+Test question clustering through the Node service:
+
+```powershell
+Invoke-RestMethod `
+  -Uri "http://127.0.0.1:4003/api/question-clustering/cluster" `
+  -Method Post `
+  -ContentType "application/json; charset=utf-8" `
+  -Body '{"questions":[{"id":"q1","text":"이 부분 다시 설명해주실 수 있나요?"},{"id":"q2","text":"이 부분을 다시 설명해 주세요"}],"similarityMode":"rule","threshold":0.5}'
+```
+
+## Docker Compose
+
+The compose stack includes:
+
+- `question-model-api`: FastAPI service on port `8000`.
+- `question-service`: Node service on port `4003`, configured with
+  `QUESTION_MODEL_API_URL=http://question-model-api:8000`.
+
+Run only the question services:
+
+```powershell
+docker compose -f infra/compose/docker-compose.yml up -d --build question-model-api question-service
+```
+
+If local ports `4003` or `8000` are already in use, override the host ports:
+
+```powershell
+$env:QUESTION_SERVICE_HOST_PORT="4015"
+$env:QUESTION_MODEL_API_HOST_PORT="8015"
+docker compose -f infra/compose/docker-compose.yml up -d --build question-model-api question-service
+```
+
+Check health:
+
+```powershell
+Invoke-RestMethod -Uri "http://127.0.0.1:8000/health" -Method Get
+Invoke-RestMethod -Uri "http://127.0.0.1:4003/health" -Method Get
+```
+
+When using override ports, replace `8000` and `4003` with the configured host
+ports.
+
+## Deployment Notes
+
+- Keep `question-model-api` and `question-service` as separate services.
+- On EC2, model artifacts must exist at `/app/services/model/question_detection`
+  before deploying `question-model-api`.
+- Do not ship `services/model/question_detection.zip` in the Docker build
+  context; it is excluded by `.dockerignore`.
+- Production deployment sets `QUESTION_PRELOAD_KC_ELECTRA=true` so the neural
+  model loads during container startup. This avoids first-request latency and
+  fails fast if the model artifacts are missing.
+- For production, expose `question-service` publicly and keep
+  `question-model-api` private on the internal service network.
+
+## GitHub Actions Deployment
+
+The existing workflow deploys through AWS SSM to the running EC2 instance tagged:
+
+```text
+Name = carpoolink-server
+```
+
+For the first model API rollout, run the workflow manually:
+
+1. Open GitHub Actions.
+2. Select `Deploy Carpoolink Services`.
+3. Click `Run workflow`.
+4. Use the `main` branch.
+
+The workflow builds and pushes `question-model-api` to GHCR, then deploys it on
+the same Docker network as `question-service`. The Node service receives:
+
+```text
+QUESTION_MODEL_API_URL=http://carpoolink-question-model-api:8000
+```
+
+If the workflow fails with a missing model artifact message, restore or upload
+the DVC model directory to the EC2 path:
+
+```text
+/app/services/model/question_detection
+```
+
+The model directory is tracked by DVC. On the EC2 host, restore it from the
+project root with:
+
+```bash
+pip install "dvc[s3]"
+dvc pull services/model/question_detection.dvc
+```
+
+The configured DVC remote is:
+
+```text
+s3://capstone2026-carpoolink-dvc-kro
+```

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -25,8 +25,8 @@ services:
   # Core API (Port 4000)
   core-api:
     build:
-      context: ./services/core-api
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: services/core-api/Dockerfile
     container_name: carpoolink-core-api
     environment:
       NODE_ENV: ${NODE_ENV:-development}
@@ -39,8 +39,8 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ../../services/core-api:/app
-      - /app/node_modules
+      - ../../services/core-api:/app/services/core-api
+      - /app/services/core-api/node_modules
     networks:
       - carpoolink-network
     command: npm run dev
@@ -48,8 +48,8 @@ services:
   # Chat Service (Port 4001)
   chat-service:
     build:
-      context: ./services/chat-service
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: services/chat-service/Dockerfile
     container_name: carpoolink-chat-service
     environment:
       NODE_ENV: ${NODE_ENV:-development}
@@ -63,8 +63,8 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ../../services/chat-service:/app
-      - /app/node_modules
+      - ../../services/chat-service:/app/services/chat-service
+      - /app/services/chat-service/node_modules
     networks:
       - carpoolink-network
     command: npm run dev
@@ -72,8 +72,8 @@ services:
   # Media Server (Port 4002)
   media-server:
     build:
-      context: ./services/media-server
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: services/media-server/Dockerfile
     container_name: carpoolink-media-server
     environment:
       NODE_ENV: ${NODE_ENV:-development}
@@ -87,8 +87,8 @@ services:
       postgres:
         condition: service_healthy
     volumes:
-      - ../../services/media-server:/app
-      - /app/node_modules
+      - ../../services/media-server:/app/services/media-server
+      - /app/services/media-server/node_modules
     networks:
       - carpoolink-network
     command: npm run dev
@@ -96,27 +96,58 @@ services:
   # Question Service (Port 4003)
   question-service:
     build:
-      context: ./services/question-service
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: services/question-service/Dockerfile
     container_name: carpoolink-question-service
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       QUESTION_SERVICE_PORT: 4003
+      QUESTION_MODEL_API_URL: http://question-model-api:8000
       TZ: Asia/Seoul
     ports:
-      - "4003:4003"
+      - "${QUESTION_SERVICE_HOST_PORT:-4003}:4003"
+    depends_on:
+      question-model-api:
+        condition: service_healthy
     volumes:
-      - ../../services/question-service:/app
-      - /app/node_modules
+      - ../../services/question-service:/app/services/question-service
+      - /app/services/question-service/node_modules
     networks:
       - carpoolink-network
     command: npm run dev
 
+  # Question Model API (Port 8000)
+  question-model-api:
+    build:
+      context: ../..
+      dockerfile: services/question-service/Dockerfile.model-api
+    container_name: carpoolink-question-model-api
+    environment:
+      QUESTION_PRELOAD_KC_ELECTRA: ${QUESTION_PRELOAD_KC_ELECTRA:-true}
+      QUESTION_CLUSTERING_THRESHOLD: ${QUESTION_CLUSTERING_THRESHOLD:-0.72}
+      QUESTION_CLUSTERING_SIMILARITY_MODE: ${QUESTION_CLUSTERING_SIMILARITY_MODE:-hybrid}
+      QUESTION_CLUSTERING_EMBEDDING_MODEL: ${QUESTION_CLUSTERING_EMBEDDING_MODEL:-distiluse}
+      TZ: Asia/Seoul
+    ports:
+      - "${QUESTION_MODEL_API_HOST_PORT:-8000}:8000"
+    volumes:
+      - ../../services/question-service/python_api:/app/services/question-service/python_api
+      - ../../services/question-service/scripts:/app/services/question-service/scripts
+      - ../../services/model/question_detection:/app/services/model/question_detection:ro
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json, urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health', timeout=5).read()"]
+      interval: 15s
+      timeout: 10s
+      retries: 10
+      start_period: 90s
+    networks:
+      - carpoolink-network
+
   # STT Service (Port 4004)
   stt-service:
     build:
-      context: ./services/stt-service
-      dockerfile: Dockerfile
+      context: ../..
+      dockerfile: services/stt-service/Dockerfile
     container_name: carpoolink-stt-service
     environment:
       NODE_ENV: ${NODE_ENV:-development}
@@ -126,8 +157,8 @@ services:
     ports:
       - "4004:4004"
     volumes:
-      - ../../services/stt-service:/app
-      - /app/node_modules
+      - ../../services/stt-service:/app/services/stt-service
+      - /app/services/stt-service/node_modules
     networks:
       - carpoolink-network
     command: npm run dev

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "dev:media": "npm run dev -w services/media-server",
     "dev:chat": "npm run dev -w services/chat-service",
     "dev:question": "npm run dev -w services/question-service",
+    "dev:question:model": "npm run dev:model -w services/question-service",
     "dev:stt": "npm run dev -w services/stt-service",
     "benchmark:question": "..\\venv\\Scripts\\python.exe services/question-service/scripts/question-detection/benchmark_question_detection.py",
     "test": "npm run test -ws --if-present"

--- a/services/question-service/Dockerfile.model-api
+++ b/services/question-service/Dockerfile.model-api
@@ -1,0 +1,24 @@
+FROM python:3.12-slim
+
+WORKDIR /app
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app/services/question-service/scripts/question-detection:/app/services/question-service/scripts/question-clustering \
+    QUESTION_TFIDF_ARTIFACT_DIR=/app/services/model/question_detection/tfidf_lr_rule_filter_off \
+    QUESTION_KC_ELECTRA_DIR=/app/services/model/question_detection/kc_electra_question_detector
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY services/question-service/requirements.txt /tmp/question-service-requirements.txt
+RUN pip install --no-cache-dir -r /tmp/question-service-requirements.txt
+
+COPY services/question-service/scripts /app/services/question-service/scripts
+COPY services/question-service/python_api /app/services/question-service/python_api
+
+WORKDIR /app/services/question-service
+
+EXPOSE 8000
+
+CMD ["python", "-X", "utf8", "-m", "fastapi", "run", "python_api/app.py", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/question-service/README.md
+++ b/services/question-service/README.md
@@ -16,6 +16,46 @@ $env:QUESTION_SERVICE_PYTHON="..\venv\Scripts\python.exe"
 npm run dev -w services/question-service
 ```
 
+## Python model API
+
+The question detection model can also run as a long-lived FastAPI process so
+the Python model artifacts are loaded once and reused across requests. The same
+model API also exposes question clustering.
+
+Install the Python dependencies:
+
+```powershell
+..\venv\Scripts\python.exe -m pip install -r services\question-service\requirements.txt
+```
+
+Run the model API:
+
+```powershell
+npm.cmd run dev:question:model
+```
+
+You can also run the same app directly with Uvicorn:
+
+```powershell
+Set-Location services\question-service
+..\..\..\venv\Scripts\python.exe -m uvicorn python_api.app:app --host 127.0.0.1 --port 8000
+```
+
+Set `QUESTION_PRELOAD_KC_ELECTRA=true` to load KC-ELECTRA during startup instead
+of lazily on the first request routed to the neural model.
+
+To route the Node question-service through the model API, start the model API
+first, then run the Node service with:
+
+```powershell
+Set-Location C:\Users\admin\Desktop\Capstone_design_2026\Capstone\carpoolink
+$env:QUESTION_MODEL_API_URL="http://127.0.0.1:8000"
+npm.cmd run dev:question
+```
+
+With Docker Compose, `question-service` is wired to the internal
+`question-model-api` service automatically.
+
 ## API
 
 ### `POST /api/question-detection/predict`
@@ -51,6 +91,7 @@ Response fields include `cluster_count`, `clusters`, and per-question
 ## Environment Variables
 
 - `QUESTION_SERVICE_PORT`: HTTP port. Defaults to `4003`.
+- `QUESTION_MODEL_API_URL`: FastAPI model API base URL. When set, question detection and clustering use HTTP instead of spawning Python subprocesses.
 - `QUESTION_SERVICE_PYTHON`: Python executable path for inference and clustering.
 - `QUESTION_DETECTION_SCRIPT_PATH`: override hybrid detection script path.
 - `QUESTION_TFIDF_ARTIFACT_DIR`: TF-IDF artifact directory.

--- a/services/question-service/package.json
+++ b/services/question-service/package.json
@@ -7,6 +7,8 @@
     "scripts": {
         "start": "node src/server.js",
         "dev": "nodemon src/server.js",
+        "dev:model": "..\\..\\..\\venv\\Scripts\\python.exe -X utf8 -m fastapi dev python_api\\app.py --host 127.0.0.1 --port 8000",
+        "start:model": "python -X utf8 -m fastapi run python_api\\app.py --host 0.0.0.0 --port 8000",
         "test": "node --test \"src/**/*.test.js\""
     },
     "dependencies": {

--- a/services/question-service/python_api/app.py
+++ b/services/question-service/python_api/app.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import os
+import sys
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+
+APP_DIR = Path(__file__).resolve().parent
+SERVICE_ROOT = APP_DIR.parent
+REPO_ROOT = SERVICE_ROOT.parent.parent
+QUESTION_DETECTION_SCRIPT_DIR = SERVICE_ROOT / "scripts" / "question-detection"
+QUESTION_CLUSTERING_SCRIPT_DIR = SERVICE_ROOT / "scripts" / "question-clustering"
+
+sys.path.insert(0, str(QUESTION_DETECTION_SCRIPT_DIR))
+sys.path.insert(0, str(QUESTION_CLUSTERING_SCRIPT_DIR))
+
+from question_detection_inference import (  # noqa: E402
+    HybridQuestionDetector,
+    HybridQuestionDetectorConfig,
+)
+from question_clustering_inference import (  # noqa: E402
+    QuestionClusterer,
+    QuestionClusteringConfig,
+)
+
+
+DEFAULT_TFIDF_ARTIFACT_DIR = REPO_ROOT / "services" / "model" / "question_detection" / "tfidf_lr_rule_filter_off"
+DEFAULT_KC_ELECTRA_DIR = REPO_ROOT / "services" / "model" / "question_detection" / "kc_electra_question_detector"
+
+
+class QuestionDetectionRequest(BaseModel):
+    text: str = Field(..., description="Chat text to classify as a question or non-question.")
+
+
+class QuestionClusteringRequest(BaseModel):
+    questions: list[Any]
+    threshold: float | None = None
+    similarityMode: str | None = None
+    similarity_mode: str | None = None
+    embeddingModel: str | None = None
+    embedding_model: str | None = None
+
+
+class HealthResponse(BaseModel):
+    service: str
+    status: str
+    detector_loaded: bool
+    clusterer_loaded: bool
+
+
+detector: HybridQuestionDetector | None = None
+clusterer: QuestionClusterer | None = None
+
+
+def env_bool(name: str, default: bool = False) -> bool:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+    return raw_value.lower() in {"1", "true", "yes", "y", "on"}
+
+
+def env_float(name: str, default: float) -> float:
+    raw_value = os.getenv(name)
+    if raw_value is None:
+        return default
+
+    try:
+        return float(raw_value)
+    except ValueError:
+        return default
+
+
+def build_detector_config() -> HybridQuestionDetectorConfig:
+    tfidf_artifact_dir = Path(os.getenv("QUESTION_TFIDF_ARTIFACT_DIR", str(DEFAULT_TFIDF_ARTIFACT_DIR)))
+    kc_electra_dir = Path(os.getenv("QUESTION_KC_ELECTRA_DIR", str(DEFAULT_KC_ELECTRA_DIR)))
+
+    return HybridQuestionDetectorConfig(
+        tfidf_artifact_dir=tfidf_artifact_dir,
+        kc_electra_dir=kc_electra_dir,
+        tfidf_low_confidence=env_float("QUESTION_TFIDF_LOW_CONFIDENCE", 0.15),
+        tfidf_high_confidence=env_float("QUESTION_TFIDF_HIGH_CONFIDENCE", 0.85),
+        tfidf_margin=env_float("QUESTION_TFIDF_MARGIN", 0.10),
+        always_use_kc_electra_on_rule_question=env_bool(
+            "QUESTION_ALWAYS_USE_KC_ELECTRA_ON_RULE_QUESTION",
+            False,
+        ),
+    )
+
+
+def build_clustering_config() -> QuestionClusteringConfig:
+    return QuestionClusteringConfig(
+        threshold=env_float("QUESTION_CLUSTERING_THRESHOLD", 0.72),
+        similarity_mode=os.getenv("QUESTION_CLUSTERING_SIMILARITY_MODE", "hybrid"),
+        embedding_model=os.getenv("QUESTION_CLUSTERING_EMBEDDING_MODEL", "distiluse"),
+    )
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global detector, clusterer
+    config = build_detector_config()
+    detector = HybridQuestionDetector(
+        config,
+        preload_kc_electra=env_bool("QUESTION_PRELOAD_KC_ELECTRA", False),
+    )
+    clusterer = QuestionClusterer()
+    yield
+    detector = None
+    clusterer = None
+
+
+app = FastAPI(
+    title="Carpoolink Question Model API",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.get("/health", response_model=HealthResponse)
+def health() -> HealthResponse:
+    return HealthResponse(
+        service="question-model-api",
+        status="ok",
+        detector_loaded=detector is not None,
+        clusterer_loaded=clusterer is not None,
+    )
+
+
+@app.post("/question-detection/predict")
+def predict_question(request: QuestionDetectionRequest) -> dict[str, Any]:
+    if detector is None:
+        raise HTTPException(status_code=503, detail="Question detector is not loaded.")
+
+    return detector.predict(request.text)
+
+
+@app.post("/question-clustering/cluster")
+def cluster_questions(request: QuestionClusteringRequest) -> dict[str, Any]:
+    if clusterer is None:
+        raise HTTPException(status_code=503, detail="Question clusterer is not loaded.")
+
+    payload = request.model_dump(exclude_none=True)
+    if request.similarityMode is not None:
+        payload["similarity_mode"] = request.similarityMode
+    if request.embeddingModel is not None:
+        payload["embedding_model"] = request.embeddingModel
+
+    try:
+        return clusterer.cluster(payload, build_clustering_config())
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error)) from error

--- a/services/question-service/requirements.txt
+++ b/services/question-service/requirements.txt
@@ -1,5 +1,6 @@
 pandas
 scikit-learn
+fastapi[standard]
 torch
 transformers
 datasets

--- a/services/question-service/scripts/question-clustering/question_clustering_inference.py
+++ b/services/question-service/scripts/question-clustering/question_clustering_inference.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import math
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import pandas as pd
+
+from question_cluster_similarity import EmbeddingSimilarityEngine
+from question_clustering_core import build_clusters
+
+
+@dataclass(frozen=True)
+class QuestionClusteringConfig:
+    threshold: float = 0.72
+    similarity_mode: str = "hybrid"
+    embedding_model: str = "distiluse"
+
+
+def normalize_questions(payload: dict[str, Any]) -> pd.DataFrame:
+    questions = payload.get("questions")
+    if not isinstance(questions, list):
+        raise ValueError("`questions` must be a list.")
+
+    rows = []
+    for index, item in enumerate(questions, start=1):
+        if isinstance(item, str):
+            rows.append({"question_id": f"q_{index}", "text": item})
+            continue
+
+        if isinstance(item, dict):
+            text = item.get("text")
+            if not isinstance(text, str):
+                raise ValueError("Each question object must include a string `text` field.")
+
+            question_id = item.get("question_id") or item.get("id") or f"q_{index}"
+            rows.append({"question_id": str(question_id), "text": text})
+            continue
+
+        raise ValueError("Each question must be either a string or an object.")
+
+    return pd.DataFrame(rows)
+
+
+def serialize_clusters(clusters) -> list[dict[str, Any]]:
+    return [
+        {
+            "cluster_id": cluster.cluster_id,
+            "representative_question_id": cluster.representative_question_id,
+            "representative_question": cluster.representative_question,
+            "representative_canonical_text": cluster.representative_canonical_text,
+            "representative_score": cluster.representative_score,
+            "best_match_score": round(cluster.best_match_score, 4),
+            "member_count": len(cluster.member_questions),
+            "member_questions": [asdict(member) for member in cluster.member_questions],
+        }
+        for cluster in clusters
+    ]
+
+
+def clean_json_value(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {key: clean_json_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [clean_json_value(item) for item in value]
+    return value
+
+
+class QuestionClusterer:
+    def __init__(self) -> None:
+        self.embedding_engines: dict[str, EmbeddingSimilarityEngine] = {}
+
+    def get_embedding_engine(self, embedding_model: str) -> EmbeddingSimilarityEngine:
+        if embedding_model not in self.embedding_engines:
+            self.embedding_engines[embedding_model] = EmbeddingSimilarityEngine(embedding_model)
+        return self.embedding_engines[embedding_model]
+
+    def cluster(self, payload: dict[str, Any], config: QuestionClusteringConfig) -> dict[str, Any]:
+        df = normalize_questions(payload)
+        threshold = float(payload.get("threshold", config.threshold))
+        similarity_mode = str(payload.get("similarity_mode", config.similarity_mode))
+        embedding_model = str(payload.get("embedding_model", config.embedding_model))
+
+        if similarity_mode not in {"rule", "hybrid", "embedding"}:
+            raise ValueError("`similarity_mode` must be one of: rule, hybrid, embedding.")
+
+        embedding_engine = None
+        if similarity_mode in {"hybrid", "embedding"}:
+            embedding_engine = self.get_embedding_engine(embedding_model)
+
+        clusters, assignment_df = build_clusters(
+            df=df,
+            text_column="text",
+            question_id_column="question_id",
+            threshold=threshold,
+            similarity_mode=similarity_mode,
+            embedding_engine=embedding_engine,
+        )
+
+        return {
+            "question_count": int(len(assignment_df)),
+            "cluster_count": int(len(clusters)),
+            "threshold": threshold,
+            "similarity_mode": similarity_mode,
+            "embedding_model": embedding_model if embedding_engine is not None else None,
+            "clusters": serialize_clusters(clusters),
+            "assignments": clean_json_value(assignment_df.to_dict(orient="records")),
+        }

--- a/services/question-service/scripts/question-clustering/run_question_clustering_api.py
+++ b/services/question-service/scripts/question-clustering/run_question_clustering_api.py
@@ -2,15 +2,11 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import sys
-from dataclasses import asdict
 from typing import Any
 
-import pandas as pd
-
-from question_cluster_similarity import EMBEDDING_MODEL_ALIASES, EmbeddingSimilarityEngine
-from question_clustering_core import build_clusters
+from question_cluster_similarity import EMBEDDING_MODEL_ALIASES
+from question_clustering_inference import QuestionClusterer, QuestionClusteringConfig
 
 
 def parse_args() -> argparse.Namespace:
@@ -48,91 +44,15 @@ def load_request_payload() -> dict[str, Any]:
     return payload
 
 
-def normalize_questions(payload: dict[str, Any]) -> pd.DataFrame:
-    questions = payload.get("questions")
-    if not isinstance(questions, list):
-        raise ValueError("`questions` must be a list.")
-
-    rows = []
-    for index, item in enumerate(questions, start=1):
-        if isinstance(item, str):
-            rows.append({"question_id": f"q_{index}", "text": item})
-            continue
-
-        if isinstance(item, dict):
-            text = item.get("text")
-            if not isinstance(text, str):
-                raise ValueError("Each question object must include a string `text` field.")
-
-            question_id = item.get("question_id") or item.get("id") or f"q_{index}"
-            rows.append({"question_id": str(question_id), "text": text})
-            continue
-
-        raise ValueError("Each question must be either a string or an object.")
-
-    return pd.DataFrame(rows)
-
-
-def serialize_clusters(clusters) -> list[dict[str, Any]]:
-    return [
-        {
-            "cluster_id": cluster.cluster_id,
-            "representative_question_id": cluster.representative_question_id,
-            "representative_question": cluster.representative_question,
-            "representative_canonical_text": cluster.representative_canonical_text,
-            "representative_score": cluster.representative_score,
-            "best_match_score": round(cluster.best_match_score, 4),
-            "member_count": len(cluster.member_questions),
-            "member_questions": [asdict(member) for member in cluster.member_questions],
-        }
-        for cluster in clusters
-    ]
-
-
-def clean_json_value(value: Any) -> Any:
-    if isinstance(value, float) and not math.isfinite(value):
-        return None
-    if isinstance(value, dict):
-        return {key: clean_json_value(item) for key, item in value.items()}
-    if isinstance(value, list):
-        return [clean_json_value(item) for item in value]
-    return value
-
-
 def main() -> None:
     args = parse_args()
     payload = load_request_payload()
-    df = normalize_questions(payload)
-
-    threshold = float(payload.get("threshold", args.threshold))
-    similarity_mode = str(payload.get("similarity_mode", args.similarity_mode))
-    embedding_model = str(payload.get("embedding_model", args.embedding_model))
-
-    if similarity_mode not in {"rule", "hybrid", "embedding"}:
-        raise ValueError("`similarity_mode` must be one of: rule, hybrid, embedding.")
-
-    embedding_engine = None
-    if similarity_mode in {"hybrid", "embedding"}:
-        embedding_engine = EmbeddingSimilarityEngine(embedding_model)
-
-    clusters, assignment_df = build_clusters(
-        df=df,
-        text_column="text",
-        question_id_column="question_id",
-        threshold=threshold,
-        similarity_mode=similarity_mode,
-        embedding_engine=embedding_engine,
+    config = QuestionClusteringConfig(
+        threshold=args.threshold,
+        similarity_mode=args.similarity_mode,
+        embedding_model=args.embedding_model,
     )
-
-    response = {
-        "question_count": int(len(assignment_df)),
-        "cluster_count": int(len(clusters)),
-        "threshold": threshold,
-        "similarity_mode": similarity_mode,
-        "embedding_model": embedding_model if embedding_engine is not None else None,
-        "clusters": serialize_clusters(clusters),
-        "assignments": clean_json_value(assignment_df.to_dict(orient="records")),
-    }
+    response = QuestionClusterer().cluster(payload, config)
     sys.stdout.buffer.write(
         json.dumps(response, ensure_ascii=False, allow_nan=False).encode("utf-8")
     )

--- a/services/question-service/scripts/question-detection/question_detection_inference.py
+++ b/services/question-service/scripts/question-detection/question_detection_inference.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import pickle
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
+
+from preprocess_question_detection_for_tfidf import normalize_for_tfidf
+from question_detection_rules import classify_question_by_rules, extract_rule_features
+
+
+SAFE_NEGATIVE_RULE_REASONS = {
+    "rule_empty_text",
+    "rule_short_reaction",
+    "rule_statement_ending",
+}
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+SCRIPTS_ROOT = SCRIPT_DIR.parent
+SERVICE_ROOT = SCRIPTS_ROOT.parent
+REPO_ROOT = SERVICE_ROOT.parent.parent
+
+
+@dataclass(frozen=True)
+class HybridQuestionDetectorConfig:
+    tfidf_artifact_dir: Path
+    kc_electra_dir: Path
+    tfidf_low_confidence: float = 0.15
+    tfidf_high_confidence: float = 0.85
+    tfidf_margin: float = 0.10
+    always_use_kc_electra_on_rule_question: bool = False
+
+
+def load_tfidf_artifact(artifact_dir: Path) -> dict[str, Any]:
+    artifact_path = artifact_dir / "question_detector_artifact.pkl"
+    with artifact_path.open("rb") as file:
+        return pickle.load(file)
+
+
+def resolve_kc_electra_dir(model_dir: Path) -> Path:
+    if model_dir.exists():
+        return model_dir
+
+    smoke_dir = Path(f"{model_dir}_smoke")
+    if smoke_dir.exists():
+        return smoke_dir
+
+    return model_dir
+
+
+def load_kc_electra_pipeline(model_dir: Path):
+    model_dir = resolve_kc_electra_dir(model_dir)
+    config = json.loads((model_dir / "inference_config.json").read_text(encoding="utf-8-sig"))
+    local_model_dir = Path(config["local_model_dir"])
+    if not local_model_dir.is_absolute():
+        local_model_dir = (REPO_ROOT / local_model_dir).resolve()
+
+    tokenizer = AutoTokenizer.from_pretrained(str(local_model_dir))
+    model = AutoModelForSequenceClassification.from_pretrained(str(local_model_dir))
+    clf = pipeline(
+        "text-classification",
+        model=model,
+        tokenizer=tokenizer,
+        return_all_scores=True,
+        truncation=True,
+    )
+    return clf, config
+
+
+def run_tfidf_inference(text: str, tfidf_artifact: dict[str, Any]) -> float:
+    model = tfidf_artifact["model"]
+    prob = model.predict_proba([text])[0, 1]
+    return float(prob)
+
+
+def route_to_kc_electra(
+    *,
+    tfidf_score: float,
+    tfidf_threshold: float,
+    rule_label: int | None,
+    rule_reason: str,
+    config: HybridQuestionDetectorConfig,
+) -> tuple[bool, str]:
+    if rule_label == 1 and not config.always_use_kc_electra_on_rule_question:
+        return False, "rule_direct_positive"
+
+    if rule_label == 0 and rule_reason in SAFE_NEGATIVE_RULE_REASONS:
+        return False, "rule_direct_negative"
+
+    if tfidf_score <= config.tfidf_low_confidence:
+        return False, "tfidf_low_confidence_negative"
+
+    if tfidf_score >= config.tfidf_high_confidence:
+        return False, "tfidf_high_confidence_positive"
+
+    if abs(tfidf_score - tfidf_threshold) <= config.tfidf_margin:
+        return True, "near_tfidf_threshold"
+
+    if rule_label == 1 and config.always_use_kc_electra_on_rule_question:
+        return True, "rule_question_requires_confirmation"
+
+    if rule_label is None:
+        return True, "rule_uncertain"
+
+    return False, "tfidf_direct_decision"
+
+
+def run_kc_electra_inference(text: str, clf, threshold: float) -> tuple[int, float, str]:
+    outputs = clf(text)
+    if outputs and isinstance(outputs, list) and outputs and isinstance(outputs[0], dict):
+        scores = outputs
+    else:
+        scores = outputs[0]
+    label_to_score = {item["label"]: float(item["score"]) for item in scores}
+
+    positive_score = None
+    for label_key in ["LABEL_1", "1", "question"]:
+        if label_key in label_to_score:
+            positive_score = label_to_score[label_key]
+            break
+
+    if positive_score is None:
+        positive_score = max(scores, key=lambda item: item["score"])["score"]
+
+    pred = int(positive_score >= threshold)
+    return pred, float(positive_score), "kc_electra"
+
+
+class HybridQuestionDetector:
+    def __init__(self, config: HybridQuestionDetectorConfig, *, preload_kc_electra: bool = False) -> None:
+        self.config = config
+        self.tfidf_artifact = load_tfidf_artifact(config.tfidf_artifact_dir)
+        self.kc_pipeline = None
+        self.kc_config = None
+
+        if preload_kc_electra:
+            self.load_kc_electra()
+
+    def load_kc_electra(self) -> None:
+        if self.kc_pipeline is None or self.kc_config is None:
+            self.kc_pipeline, self.kc_config = load_kc_electra_pipeline(self.config.kc_electra_dir)
+
+    def predict(self, raw_text: str) -> dict[str, Any]:
+        preprocessed_text = normalize_for_tfidf(raw_text)
+        rule_label, rule_reason = classify_question_by_rules(raw_text)
+        rule_features = extract_rule_features(raw_text)
+
+        tfidf_threshold = float(self.tfidf_artifact["best_threshold"])
+        tfidf_score = run_tfidf_inference(preprocessed_text, self.tfidf_artifact)
+
+        should_use_kc_electra, route_reason = route_to_kc_electra(
+            tfidf_score=tfidf_score,
+            tfidf_threshold=tfidf_threshold,
+            rule_label=rule_label,
+            rule_reason=rule_reason,
+            config=self.config,
+        )
+
+        final_pred = None
+        final_score = tfidf_score
+        decision_source = "tfidf"
+        kc_electra_score = None
+        kc_electra_threshold = None
+
+        if rule_label == 1 and not should_use_kc_electra and route_reason == "rule_direct_positive":
+            final_pred = 1
+            final_score = 1.0
+            decision_source = route_reason
+        elif rule_label == 0 and not should_use_kc_electra and route_reason == "rule_direct_negative":
+            final_pred = 0
+            final_score = 0.0
+            decision_source = route_reason
+        elif should_use_kc_electra:
+            self.load_kc_electra()
+            kc_electra_threshold = float(self.kc_config["best_threshold"])
+            final_pred, kc_electra_score, decision_source = run_kc_electra_inference(
+                text=preprocessed_text,
+                clf=self.kc_pipeline,
+                threshold=kc_electra_threshold,
+            )
+            final_score = kc_electra_score
+        else:
+            final_pred = int(tfidf_score >= tfidf_threshold)
+            decision_source = route_reason
+
+        return {
+            "text": raw_text,
+            "text_preprocessed": preprocessed_text,
+            "is_question": bool(final_pred),
+            "score": round(float(final_score), 6),
+            "decision_source": decision_source,
+            "route_reason": route_reason,
+            "rule_label": rule_label,
+            "rule_reason": rule_reason,
+            "rule_features": rule_features,
+            "tfidf_score": round(float(tfidf_score), 6),
+            "tfidf_threshold": round(float(tfidf_threshold), 6),
+            "kc_electra_score": None if kc_electra_score is None else round(float(kc_electra_score), 6),
+            "kc_electra_threshold": None if kc_electra_threshold is None else round(float(kc_electra_threshold), 6),
+            "used_kc_electra": should_use_kc_electra,
+        }
+
+
+def predict_question(raw_text: str, config: HybridQuestionDetectorConfig) -> dict[str, Any]:
+    return HybridQuestionDetector(config).predict(raw_text)

--- a/services/question-service/scripts/question-detection/run_hybrid_question_pipeline.py
+++ b/services/question-service/scripts/question-detection/run_hybrid_question_pipeline.py
@@ -2,26 +2,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import pickle
 from pathlib import Path
 
-import numpy as np
-from transformers import AutoModelForSequenceClassification, AutoTokenizer, pipeline
-
-from preprocess_question_detection_for_tfidf import normalize_for_tfidf
-from question_detection_rules import classify_question_by_rules, extract_rule_features
-
-
-SAFE_NEGATIVE_RULE_REASONS = {
-    "rule_empty_text",
-    "rule_short_reaction",
-    "rule_statement_ending",
-}
-
-SCRIPT_DIR = Path(__file__).resolve().parent
-SCRIPTS_ROOT = SCRIPT_DIR.parent
-SERVICE_ROOT = SCRIPTS_ROOT.parent
-REPO_ROOT = SERVICE_ROOT.parent.parent
+from question_detection_inference import (
+    HybridQuestionDetector,
+    HybridQuestionDetectorConfig,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -72,164 +58,18 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def load_tfidf_artifact(artifact_dir: Path) -> dict:
-    artifact_path = artifact_dir / "question_detector_artifact.pkl"
-    with artifact_path.open("rb") as file:
-        return pickle.load(file)
-
-
-def resolve_kc_electra_dir(model_dir: Path) -> Path:
-    if model_dir.exists():
-        return model_dir
-
-    smoke_dir = Path(f"{model_dir}_smoke")
-    if smoke_dir.exists():
-        return smoke_dir
-
-    return model_dir
-
-
-def load_kc_electra_pipeline(model_dir: Path):
-    model_dir = resolve_kc_electra_dir(model_dir)
-    config = json.loads((model_dir / "inference_config.json").read_text(encoding="utf-8-sig"))
-    local_model_dir = Path(config["local_model_dir"])
-    if not local_model_dir.is_absolute():
-        local_model_dir = (REPO_ROOT / local_model_dir).resolve()
-    tokenizer = AutoTokenizer.from_pretrained(str(local_model_dir))
-    model = AutoModelForSequenceClassification.from_pretrained(str(local_model_dir))
-    clf = pipeline(
-        "text-classification",
-        model=model,
-        tokenizer=tokenizer,
-        return_all_scores=True,
-        truncation=True,
-    )
-    return clf, config
-
-
-def run_tfidf_inference(text: str, tfidf_artifact: dict) -> float:
-    model = tfidf_artifact["model"]
-    prob = model.predict_proba([text])[0, 1]
-    return float(prob)
-
-
-def route_to_kc_electra(
-    text: str,
-    tfidf_score: float,
-    tfidf_threshold: float,
-    rule_label: int | None,
-    rule_reason: str,
-    args: argparse.Namespace,
-) -> tuple[bool, str]:
-    if rule_label == 1 and not args.always_use_kc_electra_on_rule_question:
-        return False, "rule_direct_positive"
-
-    if rule_label == 0 and rule_reason in SAFE_NEGATIVE_RULE_REASONS:
-        return False, "rule_direct_negative"
-
-    if tfidf_score <= args.tfidf_low_confidence:
-        return False, "tfidf_low_confidence_negative"
-
-    if tfidf_score >= args.tfidf_high_confidence:
-        return False, "tfidf_high_confidence_positive"
-
-    if abs(tfidf_score - tfidf_threshold) <= args.tfidf_margin:
-        return True, "near_tfidf_threshold"
-
-    if rule_label == 1 and args.always_use_kc_electra_on_rule_question:
-        return True, "rule_question_requires_confirmation"
-
-    if rule_label is None:
-        return True, "rule_uncertain"
-
-    return False, "tfidf_direct_decision"
-
-
-def run_kc_electra_inference(text: str, clf, threshold: float) -> tuple[int, float, str]:
-    outputs = clf(text)
-    if outputs and isinstance(outputs, list) and outputs and isinstance(outputs[0], dict):
-        scores = outputs
-    else:
-        scores = outputs[0]
-    label_to_score = {item["label"]: float(item["score"]) for item in scores}
-
-    positive_score = None
-    for label_key in ["LABEL_1", "1", "question"]:
-        if label_key in label_to_score:
-            positive_score = label_to_score[label_key]
-            break
-
-    if positive_score is None:
-        positive_score = max(scores, key=lambda item: item["score"])["score"]
-
-    pred = int(positive_score >= threshold)
-    return pred, float(positive_score), "kc_electra"
-
-
 def main() -> None:
     args = parse_args()
-
-    raw_text = args.text
-    preprocessed_text = normalize_for_tfidf(raw_text)
-    rule_label, rule_reason = classify_question_by_rules(raw_text)
-    rule_features = extract_rule_features(raw_text)
-
-    tfidf_artifact = load_tfidf_artifact(Path(args.tfidf_artifact_dir))
-    tfidf_threshold = float(tfidf_artifact["best_threshold"])
-    tfidf_score = run_tfidf_inference(preprocessed_text, tfidf_artifact)
-
-    should_use_kc_electra, route_reason = route_to_kc_electra(
-        text=preprocessed_text,
-        tfidf_score=tfidf_score,
-        tfidf_threshold=tfidf_threshold,
-        rule_label=rule_label,
-        rule_reason=rule_reason,
-        args=args,
+    config = HybridQuestionDetectorConfig(
+        tfidf_artifact_dir=Path(args.tfidf_artifact_dir),
+        kc_electra_dir=Path(args.kc_electra_dir),
+        tfidf_low_confidence=args.tfidf_low_confidence,
+        tfidf_high_confidence=args.tfidf_high_confidence,
+        tfidf_margin=args.tfidf_margin,
+        always_use_kc_electra_on_rule_question=args.always_use_kc_electra_on_rule_question,
     )
-
-    final_pred = None
-    final_score = tfidf_score
-    decision_source = "tfidf"
-    kc_electra_score = None
-    kc_electra_threshold = None
-
-    if rule_label == 1 and not should_use_kc_electra and route_reason == "rule_direct_positive":
-        final_pred = 1
-        final_score = 1.0
-        decision_source = route_reason
-    elif rule_label == 0 and not should_use_kc_electra and route_reason == "rule_direct_negative":
-        final_pred = 0
-        final_score = 0.0
-        decision_source = route_reason
-    elif should_use_kc_electra:
-        kc_pipeline, kc_config = load_kc_electra_pipeline(Path(args.kc_electra_dir))
-        kc_electra_threshold = float(kc_config["best_threshold"])
-        final_pred, kc_electra_score, decision_source = run_kc_electra_inference(
-            text=preprocessed_text,
-            clf=kc_pipeline,
-            threshold=kc_electra_threshold,
-        )
-        final_score = kc_electra_score
-    else:
-        final_pred = int(tfidf_score >= tfidf_threshold)
-        decision_source = route_reason
-
-    result = {
-        "text": raw_text,
-        "text_preprocessed": preprocessed_text,
-        "is_question": bool(final_pred),
-        "score": round(float(final_score), 6),
-        "decision_source": decision_source,
-        "route_reason": route_reason,
-        "rule_label": rule_label,
-        "rule_reason": rule_reason,
-        "rule_features": rule_features,
-        "tfidf_score": round(float(tfidf_score), 6),
-        "tfidf_threshold": round(float(tfidf_threshold), 6),
-        "kc_electra_score": None if kc_electra_score is None else round(float(kc_electra_score), 6),
-        "kc_electra_threshold": None if kc_electra_threshold is None else round(float(kc_electra_threshold), 6),
-        "used_kc_electra": should_use_kc_electra,
-    }
+    detector = HybridQuestionDetector(config)
+    result = detector.predict(args.text)
 
     print(json.dumps(result, ensure_ascii=False, indent=2))
 

--- a/services/question-service/src/lib/questionClusterClient.js
+++ b/services/question-service/src/lib/questionClusterClient.js
@@ -41,6 +41,11 @@ function getDefaultEmbeddingModel() {
     return process.env.QUESTION_CLUSTERING_EMBEDDING_MODEL || 'distiluse';
 }
 
+function getModelApiUrl() {
+    const rawValue = process.env.QUESTION_MODEL_API_URL;
+    return rawValue && rawValue.trim() ? rawValue.trim().replace(/\/+$/, '') : null;
+}
+
 function runPythonJson(scriptPayload) {
     return new Promise((resolve, reject) => {
         const child = spawn(getPythonExecutable(), [getScriptPath()], {
@@ -109,10 +114,37 @@ export async function clusterQuestions({
     similarityMode = getDefaultSimilarityMode(),
     embeddingModel = getDefaultEmbeddingModel(),
 }) {
-    return runPythonJson({
+    const scriptPayload = {
         questions,
         threshold,
         similarity_mode: similarityMode,
         embedding_model: embeddingModel,
+    };
+
+    const modelApiUrl = getModelApiUrl();
+    if (modelApiUrl) {
+        return clusterQuestionsViaModelApi(scriptPayload, modelApiUrl);
+    }
+
+    return runPythonJson(scriptPayload);
+}
+
+async function clusterQuestionsViaModelApi(scriptPayload, modelApiUrl) {
+    const response = await fetch(`${modelApiUrl}/question-clustering/cluster`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: JSON.stringify(scriptPayload),
+        signal: AbortSignal.timeout(getExecutionTimeoutMs()),
     });
+
+    if (!response.ok) {
+        const responseBody = await response.text();
+        throw new Error(
+            `Question clustering model API failed with status ${response.status}: ${responseBody}`,
+        );
+    }
+
+    return response.json();
 }

--- a/services/question-service/src/lib/questionClusterClient.test.js
+++ b/services/question-service/src/lib/questionClusterClient.test.js
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { clusterQuestions } from './questionClusterClient.js';
+
+const originalFetch = globalThis.fetch;
+const originalQuestionModelApiUrl = process.env.QUESTION_MODEL_API_URL;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalQuestionModelApiUrl === undefined) {
+        delete process.env.QUESTION_MODEL_API_URL;
+    } else {
+        process.env.QUESTION_MODEL_API_URL = originalQuestionModelApiUrl;
+    }
+});
+
+test('clusters questions through the configured model API', async () => {
+    const requests = [];
+    process.env.QUESTION_MODEL_API_URL = 'http://localhost:8000/';
+    globalThis.fetch = async (url, options) => {
+        requests.push({ url, options });
+        return Response.json({
+            question_count: 2,
+            cluster_count: 1,
+            clusters: [],
+            assignments: [],
+        });
+    };
+
+    const result = await clusterQuestions({
+        questions: [{ id: 'q1', text: '다시 설명해주실 수 있나요?' }],
+        threshold: 0.7,
+        similarityMode: 'rule',
+        embeddingModel: 'distiluse',
+    });
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, 'http://localhost:8000/question-clustering/cluster');
+    assert.deepEqual(JSON.parse(requests[0].options.body), {
+        questions: [{ id: 'q1', text: '다시 설명해주실 수 있나요?' }],
+        threshold: 0.7,
+        similarity_mode: 'rule',
+        embedding_model: 'distiluse',
+    });
+    assert.equal(result.cluster_count, 1);
+});
+
+test('raises a useful error when the clustering model API rejects a request', async () => {
+    process.env.QUESTION_MODEL_API_URL = 'http://localhost:8000';
+    globalThis.fetch = async () => new Response('bad request', { status: 400 });
+
+    await assert.rejects(
+        clusterQuestions({ questions: [], similarityMode: 'rule' }),
+        /Question clustering model API failed with status 400: bad request/,
+    );
+});

--- a/services/question-service/src/lib/questionDetectorClient.js
+++ b/services/question-service/src/lib/questionDetectorClient.js
@@ -59,11 +59,45 @@ function getExecutionTimeoutMs() {
     return Number.isFinite(parsedValue) ? parsedValue : 30000;
 }
 
+function getModelApiUrl() {
+    const rawValue = process.env.QUESTION_MODEL_API_URL;
+    return rawValue && rawValue.trim() ? rawValue.trim().replace(/\/+$/, '') : null;
+}
+
 function shouldForceKcElectraOnRuleQuestion() {
     return process.env.QUESTION_ALWAYS_USE_KC_ELECTRA_ON_RULE_QUESTION === 'true';
 }
 
 export async function predictQuestion(text) {
+    const modelApiUrl = getModelApiUrl();
+    if (modelApiUrl) {
+        return predictQuestionViaModelApi(text, modelApiUrl);
+    }
+
+    return predictQuestionViaPythonCli(text);
+}
+
+async function predictQuestionViaModelApi(text, modelApiUrl) {
+    const response = await fetch(`${modelApiUrl}/question-detection/predict`, {
+        method: 'POST',
+        headers: {
+            'content-type': 'application/json',
+        },
+        body: JSON.stringify({ text }),
+        signal: AbortSignal.timeout(getExecutionTimeoutMs()),
+    });
+
+    if (!response.ok) {
+        const responseBody = await response.text();
+        throw new Error(
+            `Question model API failed with status ${response.status}: ${responseBody}`,
+        );
+    }
+
+    return response.json();
+}
+
+async function predictQuestionViaPythonCli(text) {
     const command = getPythonExecutable();
     const args = [
         getScriptPath(),

--- a/services/question-service/src/lib/questionDetectorClient.test.js
+++ b/services/question-service/src/lib/questionDetectorClient.test.js
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { predictQuestion } from './questionDetectorClient.js';
+
+const originalFetch = globalThis.fetch;
+const originalQuestionModelApiUrl = process.env.QUESTION_MODEL_API_URL;
+
+test.afterEach(() => {
+    globalThis.fetch = originalFetch;
+    if (originalQuestionModelApiUrl === undefined) {
+        delete process.env.QUESTION_MODEL_API_URL;
+    } else {
+        process.env.QUESTION_MODEL_API_URL = originalQuestionModelApiUrl;
+    }
+});
+
+test('predicts questions through the configured model API', async () => {
+    const requests = [];
+    process.env.QUESTION_MODEL_API_URL = 'http://localhost:8000/';
+    globalThis.fetch = async (url, options) => {
+        requests.push({ url, options });
+        return Response.json({
+            text: '이 부분 다시 설명해주실 수 있나요?',
+            is_question: true,
+            score: 1,
+        });
+    };
+
+    const result = await predictQuestion('이 부분 다시 설명해주실 수 있나요?');
+
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].url, 'http://localhost:8000/question-detection/predict');
+    assert.equal(requests[0].options.method, 'POST');
+    assert.deepEqual(JSON.parse(requests[0].options.body), {
+        text: '이 부분 다시 설명해주실 수 있나요?',
+    });
+    assert.equal(result.is_question, true);
+});
+
+test('raises a useful error when the model API rejects a request', async () => {
+    process.env.QUESTION_MODEL_API_URL = 'http://localhost:8000';
+    globalThis.fetch = async () => new Response('model unavailable', { status: 503 });
+
+    await assert.rejects(
+        predictQuestion('테스트 문장입니다'),
+        /Question model API failed with status 503: model unavailable/,
+    );
+});


### PR DESCRIPTION
##연관된 이슈
#111

##작업 내용

- question-service의 질문 감지/클러스터링 Python 모델 로직을 FastAPI 기반 model API로 분리했습니다.
- Node question-service는 QUESTION_MODEL_API_URL 설정 시 FastAPI model API를 호출하고, 설정이 없으면 기존 Python subprocess 방식을 유지합니다.
- Docker Compose와 GitHub Actions 배포 설정에 question-model-api 서비스를 추가했습니다. 배포 환경에서는 KC-ELECTRA를 서버 시작 시 preload하도록 설정했습니다.

##체크 리스트

- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

##리뷰 요구사항

- [ ] question-service와 question-model-api 분리 구조가 적절한지 확인 부탁드립니다.
- [ ] question-model-api는 EC2의 /app/services/model/question_detection 모델 아티팩트를 필요로 합니다.
- [ ] GitHub Actions 배포 시 question-model-api가 먼저 실행되고, question-service가 QUESTION_MODEL_API_URL=http://carpoolink-question-model-api:8000 으로 연결되는 구조가 적절한지 확인 부탁드립니다.
- [ ] 모델 API는 외부에 직접 노출하지 않고 내부 Docker network에서만 question-service가 호출하는 방향입니다