### PR TITLE
fix(question-service): resolve mounted kc electra model path

### DIFF
--- a/services/question-service/scripts/question-detection/question_detection_inference.py
+++ b/services/question-service/scripts/question-detection/question_detection_inference.py
@@ -51,12 +51,22 @@ def resolve_kc_electra_dir(model_dir: Path) -> Path:
     return model_dir
 
 
-def load_kc_electra_pipeline(model_dir: Path):
-    model_dir = resolve_kc_electra_dir(model_dir)
-    config = json.loads((model_dir / "inference_config.json").read_text(encoding="utf-8-sig"))
+def resolve_kc_electra_model_dir(model_dir: Path, config: dict[str, Any]) -> Path:
+    bundled_model_dir = model_dir / "model"
+    if bundled_model_dir.exists():
+        return bundled_model_dir
+
     local_model_dir = Path(config["local_model_dir"])
     if not local_model_dir.is_absolute():
         local_model_dir = (REPO_ROOT / local_model_dir).resolve()
+
+    return local_model_dir
+
+
+def load_kc_electra_pipeline(model_dir: Path):
+    model_dir = resolve_kc_electra_dir(model_dir)
+    config = json.loads((model_dir / "inference_config.json").read_text(encoding="utf-8-sig"))
+    local_model_dir = resolve_kc_electra_model_dir(model_dir, config)
 
     tokenizer = AutoTokenizer.from_pretrained(str(local_model_dir))
     model = AutoModelForSequenceClassification.from_pretrained(str(local_model_dir))


### PR DESCRIPTION
## 연관된 이슈
#111 

## 작업 내용

배포 환경에서 KC-ELECTRA 모델 로드 시 Windows 로컬 경로를 참조하던 문제를 수정했습니다.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

배포 환경에서 question-model-api가 EC2 모델 마운트 경로를 정상적으로 참조하는지 확인 부탁드립니다.