### PR TITLE
feat(question): connect chat questions to ranking queue

### DIFF
--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -21,6 +21,13 @@ interface ChatMessage {
     content: string;
 }
 
+interface AiRecommendation {
+    questionId?: string | number;
+    content: string;
+    score?: number;
+    reason?: string;
+}
+
 // ============================================================================
 // [Wrapper 컴포넌트] 로딩 화면 & 방 입장 기록(History) 생성 게이트웨이
 // ============================================================================
@@ -113,6 +120,9 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
     const [chatInput, setChatInput] = useState("");
     const [isAiOpen, setIsAiOpen] = useState(false);
     const [isAutoplayBlocked, setIsAutoplayBlocked] = useState(false);
+    const [aiRecommendations, setAiRecommendations] = useState<AiRecommendation[]>([]);
+    const [isAiRecommendationsLoading, setIsAiRecommendationsLoading] = useState(false);
+    const [aiRecommendationError, setAiRecommendationError] = useState<string | null>(null);
 
     const [chatSocket, setChatSocket] = useState<Socket | null>(null);
     const [chats, setChats] = useState<ChatMessage[]>([]);
@@ -207,6 +217,31 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
     useEffect(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
     }, [chats]);
+
+    useEffect(() => {
+        if (!isAiOpen || !mentoringId) return;
+
+        const fetchAiRecommendations = async () => {
+            try {
+                setIsAiRecommendationsLoading(true);
+                setAiRecommendationError(null);
+
+                const response = await apiClient.post("/api/questions/recommendations", {
+                    sessionId: mentoringId,
+                    count: 3,
+                });
+
+                setAiRecommendations((response.data?.questions ?? []) as AiRecommendation[]);
+            } catch (err) {
+                console.error("AI 질문 추천 조회 실패:", err);
+                setAiRecommendationError("추천 질문을 불러오지 못했습니다.");
+            } finally {
+                setIsAiRecommendationsLoading(false);
+            }
+        };
+
+        fetchAiRecommendations();
+    }, [isAiOpen, mentoringId]);
 
     // 멘토가 라이브 멘토링을 종료하면 멘티 자동 이동
     useEffect(() => {
@@ -418,13 +453,21 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                             </button>
 
                             <div className={`w-full bg-[#222222] border border-gray-700/50 rounded-2xl shadow-lg transition-all duration-300 ease-in-out overflow-hidden flex flex-col ${isAiOpen ? "max-h-64 opacity-100 p-4 mb-3" : "max-h-0 opacity-0 p-0 m-0 border-transparent"}`}>
-                                <ul className="space-y-3">
-                                    {["1. 신입 개발자로서 가장 중요하게 생각하시는 역량이 무엇인가요?", "2. 향후 커리어 방향을 어떻게 잡아야 할까요?", "3. 이력서에서 보완해야 할 점이 있다면 무엇일까요?"].map((item, idx) => (
-                                        <li key={idx} onClick={() => handleSuggestionClick(item)} className="text-sm text-gray-300 hover:text-white cursor-pointer transition-colors line-clamp-1 p-2 rounded-lg hover:bg-gray-700/30 active:bg-gray-700/50">
-                                            {item}
-                                        </li>
-                                    ))}
-                                </ul>
+                                {isAiRecommendationsLoading ? (
+                                    <div className="text-sm text-gray-400 p-2">추천 질문을 불러오는 중입니다...</div>
+                                ) : aiRecommendationError ? (
+                                    <div className="text-sm text-red-300 p-2">{aiRecommendationError}</div>
+                                ) : aiRecommendations.length === 0 ? (
+                                    <div className="text-sm text-gray-400 p-2">아직 추천할 질문이 없습니다.</div>
+                                ) : (
+                                    <ul className="space-y-3">
+                                        {aiRecommendations.map((item, idx) => (
+                                            <li key={item.questionId ?? idx} onClick={() => handleSuggestionClick(item.content)} className="text-sm text-gray-300 hover:text-white cursor-pointer transition-colors line-clamp-1 p-2 rounded-lg hover:bg-gray-700/30 active:bg-gray-700/50">
+                                                {idx + 1}. {item.content}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
                             </div>
                         </>
                     )}

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -1,21 +1,23 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-import { io, Socket } from "socket.io-client";
+import { io } from "socket.io-client";
 import { PhoneOff, Users, Volume2, Settings, Mic, MicOff, Video, VideoOff, MessageSquare, Lock, AlertCircle } from "lucide-react";
 
+import apiClient from "@/lib/apiClient";
 import { useMentoringSession } from "@/hooks/useMentoringSession";
 import { useWebRtcSession } from "@/hooks/useWebRtcSession";
 
 interface Question {
-    id: number;
+    questionId: string;
     type: "free" | "paid";
     isPrivate: boolean;
     author: string;
-    avatar: string;
     content: string;
+    status: "BEFORE" | "ANSWERING" | "COMPLETED";
+    priorityScore?: number;
 }
 
 interface ChatMessage {
@@ -24,6 +26,18 @@ interface ChatMessage {
     author: string;
     senderId: string;
     content: string;
+}
+
+interface QuestionQueueResponseItem {
+    questionId: string | number;
+    isPaid: boolean;
+    isPrivate: boolean;
+    content: string;
+    status: Question["status"];
+    priorityScore?: number;
+    user?: {
+        nickname?: string | null;
+    };
 }
 
 export default function MentorLivePage() {
@@ -41,8 +55,10 @@ export default function MentorLivePage() {
     const [isExitPopupOpen, setIsExitPopupOpen] = useState(false);
     const [isReading, setIsReading] = useState(false);
     const [currentIdx, setCurrentIdx] = useState(0);
+    const [questionQueue, setQuestionQueue] = useState<Question[]>([]);
+    const [isQuestionQueueLoading, setIsQuestionQueueLoading] = useState(false);
+    const [questionQueueError, setQuestionQueueError] = useState<string | null>(null);
 
-    const [chatSocket, setChatSocket] = useState<Socket | null>(null);
     const [chats, setChats] = useState<ChatMessage[]>([]);
     const [onlineUserCount, setOnlineUserCount] = useState<number>(0);
 
@@ -58,12 +74,50 @@ export default function MentorLivePage() {
             mentoringType: "GROUP"
         });
 
-    const questionQueue: Question[] = [
-        { id: 1, type: "paid", isPrivate: true, author: "김세종", avatar: "👨‍💼", content: '"How do you negotiate equity in a Series B startup without losing the offer?"' },
-        { id: 2, type: "free", isPrivate: false, author: "이유진", avatar: "👩‍💼", content: '"Can you share some tips on building a tech portfolio from scratch?"' }
-    ];
+    const currentQuestion = questionQueue[currentIdx] ?? {
+        questionId: "",
+        type: "free" as const,
+        isPrivate: false,
+        author: isQuestionQueueLoading ? "로딩 중" : "대기 중",
+        content: questionQueueError ?? (isQuestionQueueLoading ? "질문 큐를 불러오는 중입니다." : "아직 대기 중인 질문이 없습니다."),
+        status: "BEFORE" as const,
+    };
+    const hasCurrentQuestion = Boolean(currentQuestion.questionId);
+    const currentQuestionInitial = currentQuestion.author.trim().charAt(0) || "?";
 
-    const currentQuestion = questionQueue[currentIdx];
+    const fetchQuestionQueue = useCallback(async () => {
+        if (!mentoringId) return;
+
+        try {
+            setIsQuestionQueueLoading(true);
+            setQuestionQueueError(null);
+
+            const response = await apiClient.get("/api/questions", {
+                params: {
+                    mentoringId,
+                    status: "BEFORE",
+                },
+            });
+
+            const mappedQuestions = ((response.data?.questions ?? []) as QuestionQueueResponseItem[]).map((question) => ({
+                questionId: String(question.questionId),
+                type: question.isPaid ? "paid" : "free",
+                isPrivate: Boolean(question.isPrivate),
+                author: question.user?.nickname ?? "익명 멘티",
+                content: question.content,
+                status: question.status,
+                priorityScore: question.priorityScore,
+            })) as Question[];
+
+            setQuestionQueue(mappedQuestions);
+            setCurrentIdx((prev) => Math.min(prev, Math.max(mappedQuestions.length - 1, 0)));
+        } catch (err) {
+            console.error("질문 큐 조회 실패:", err);
+            setQuestionQueueError("질문 큐를 불러오지 못했습니다.");
+        } finally {
+            setIsQuestionQueueLoading(false);
+        }
+    }, [mentoringId]);
 
     useEffect(() => {
         const storedRole = localStorage.getItem("role")?.toUpperCase();
@@ -117,19 +171,24 @@ export default function MentorLivePage() {
                 senderId: String(m.userId),
                 content: m.content.replace("[유료] ", ""),
             }]);
+            if (m.question) {
+                fetchQuestionQueue();
+            }
         });
 
         newSocket.on("user_joined", (data: any) => setOnlineUserCount(data.userCount));
         newSocket.on("user_left", (data: any) => setOnlineUserCount(data.userCount));
         newSocket.on("online_users", (data: any) => setOnlineUserCount(data.userCount));
 
-        setChatSocket(newSocket);
-
         return () => {
             newSocket.emit("leave_chat", { mentoringId, userId: String(userId), userName });
             newSocket.disconnect();
         };
-    }, [mentoringId, userId, userName]);
+    }, [fetchQuestionQueue, mentoringId, userId, userName]);
+
+    useEffect(() => {
+        fetchQuestionQueue();
+    }, [fetchQuestionQueue]);
 
     useEffect(() => {
         if (isChatOpen) {
@@ -145,8 +204,34 @@ export default function MentorLivePage() {
     }, [localStream, isCameraOn]);
 
     const handleNextQuestion = () => {
+        if (questionQueue.length === 0) return;
         setCurrentIdx((prev) => (prev + 1) % questionQueue.length);
         setIsReading(false);
+    };
+
+    const handleStartQuestion = async () => {
+        if (!currentQuestion.questionId) return;
+
+        try {
+            await apiClient.patch(`/api/questions/${currentQuestion.questionId}/answering`);
+            setIsReading(true);
+        } catch (err) {
+            console.error("질문 읽기 시작 실패:", err);
+            alert("질문 상태를 답변 중으로 변경하지 못했습니다.");
+        }
+    };
+
+    const handleCompleteQuestion = async () => {
+        if (!currentQuestion.questionId) return;
+
+        try {
+            await apiClient.patch(`/api/questions/${currentQuestion.questionId}/completed`);
+            setIsReading(false);
+            await fetchQuestionQueue();
+        } catch (err) {
+            console.error("질문 답변 완료 실패:", err);
+            alert("질문 답변 완료 처리에 실패했습니다.");
+        }
     };
 
     // 멘토링 세션 완전 종료 처리
@@ -218,8 +303,13 @@ export default function MentorLivePage() {
                         <div className="flex flex-col gap-3 flex-1">
                             <div className="flex items-center justify-between w-full">
                                 <div className="flex items-center gap-2">
-                                    <div className="w-8 h-8 bg-black/10 rounded-full flex items-center justify-center text-sm">{currentQuestion.avatar}</div>
+                                    <div className="w-8 h-8 bg-black/10 rounded-full flex items-center justify-center text-sm">{currentQuestionInitial}</div>
                                     <span className="font-bold text-[14px]">{currentQuestion.author}</span>
+                                    {typeof currentQuestion.priorityScore === "number" && (
+                                        <span className="text-[10px] font-extrabold bg-black/10 px-2 py-1 rounded-lg">
+                                            우선순위 {currentQuestion.priorityScore.toFixed(1)}
+                                        </span>
+                                    )}
                                 </div>
                                 {currentQuestion.isPrivate && (
                                     <div className="flex items-center gap-1 bg-red-600 text-white text-[10px] font-extrabold px-2 py-1 rounded-lg">
@@ -230,11 +320,11 @@ export default function MentorLivePage() {
                             <p className="font-extrabold text-[16px] leading-snug">{currentQuestion.content}</p>
                         </div>
                         <div className="flex flex-col gap-2 shrink-0 justify-center">
-                            <button onClick={() => setIsReading(true)} className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}>
+                            <button disabled={!hasCurrentQuestion} onClick={handleStartQuestion} className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all disabled:opacity-50 disabled:cursor-not-allowed ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}>
                                 <Volume2 className={`w-3.5 h-3.5 mr-1.5 ${isReading ? 'animate-pulse' : ''}`} />
                                 {isReading ? '읽는 중...' : '질문 읽기'}
                             </button>
-                            <button onClick={handleNextQuestion} className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0]">답변 완료</button>
+                            <button disabled={!hasCurrentQuestion} onClick={handleCompleteQuestion} className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0] disabled:opacity-50 disabled:cursor-not-allowed">답변 완료</button>
                         </div>
                     </div>
 
@@ -256,11 +346,12 @@ export default function MentorLivePage() {
                         </div>
                         <div className="relative w-full flex items-center justify-between px-3 pb-3 gap-2 z-10">
                             <div className="flex gap-2">
-                                <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">다음 질문</button>
-                                <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">답변 완료</button>
+                                <button disabled={questionQueue.length === 0} onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full disabled:opacity-50 disabled:cursor-not-allowed">다음 질문</button>
+                                <button disabled={!hasCurrentQuestion} onClick={handleCompleteQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full disabled:opacity-50 disabled:cursor-not-allowed">답변 완료</button>
                                 <button
-                                    onClick={() => setIsReading(true)}
-                                    className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full text-center active:scale-95 transition-transform"
+                                    disabled={!hasCurrentQuestion}
+                                    onClick={handleStartQuestion}
+                                    className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full text-center active:scale-95 transition-transform disabled:opacity-50 disabled:cursor-not-allowed"
                                 >
                                     질문 다시 읽기
                                 </button>

--- a/services/chat-service/src/database/chatRepository.js
+++ b/services/chat-service/src/database/chatRepository.js
@@ -1,6 +1,354 @@
 import { PrismaClient } from '@carpoolink/database';
 
 const prisma = new PrismaClient();
+const DEFAULT_QUESTION_SERVICE_URL = 'http://localhost:4003';
+
+function getQuestionServiceUrl() {
+    return (process.env.QUESTION_SERVICE_URL || DEFAULT_QUESTION_SERVICE_URL).replace(/\/+$/, '');
+}
+
+function getQuestionDetectionTimeoutMs() {
+    const parsedValue = Number.parseInt(process.env.QUESTION_DETECTION_REQUEST_TIMEOUT_MS ?? '5000', 10);
+    return Number.isFinite(parsedValue) ? parsedValue : 5000;
+}
+
+function getQuestionRankingTimeoutMs() {
+    const parsedValue = Number.parseInt(process.env.QUESTION_RANKING_REQUEST_TIMEOUT_MS ?? '15000', 10);
+    return Number.isFinite(parsedValue) ? parsedValue : 15000;
+}
+
+function asTextList(value) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .map(item => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean);
+}
+
+function readInfoList(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return [];
+    }
+
+    for (const key of keys) {
+        if (Array.isArray(info[key])) {
+            return asTextList(info[key]);
+        }
+    }
+
+    return [];
+}
+
+function readInfoText(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return '';
+    }
+
+    for (const key of keys) {
+        const value = typeof info[key] === 'string' ? info[key].trim() : '';
+        if (value) {
+            return value;
+        }
+    }
+
+    return '';
+}
+
+function textFromScriptContent(content) {
+    if (typeof content === 'string') {
+        return content.trim();
+    }
+
+    if (!content || typeof content !== 'object') {
+        return '';
+    }
+
+    if (Array.isArray(content)) {
+        return asTextList(content.map(item => {
+            if (typeof item === 'string') return item;
+            if (item && typeof item === 'object') return item.text ?? item.content ?? item.script ?? '';
+            return '';
+        })).join('\n');
+    }
+
+    return asTextList([
+        content.text,
+        content.content,
+        content.script,
+        content.summary,
+    ]).join('\n');
+}
+
+function buildMentorContext(mentoring) {
+    const mentorUser = mentoring.hostMentor;
+    const mentorProfile = mentorUser?.mentorProfile;
+    const mentorInfo = mentorProfile?.info;
+    const fieldNames = mentorProfile?.fields?.map(field => field.fieldName) ?? [];
+    const expertise = [...new Set([
+        ...fieldNames,
+        ...readInfoList(mentorInfo, ['expertise', 'skills', 'fields']),
+    ])];
+    const role = readInfoText(mentorInfo, ['role', 'job', 'position', 'title']) || mentorUser?.role || '';
+    const bio = mentorProfile?.bio ?? '';
+
+    return {
+        mentorProfileText: [
+            mentorUser?.nickname,
+            role,
+            expertise.join(', '),
+            bio,
+        ].filter(Boolean).join(' | '),
+        mentorExpertiseEvidence: [
+            ...expertise,
+            bio,
+        ].filter(Boolean),
+    };
+}
+
+function buildMenteeProfileText(mentoring) {
+    return (mentoring.participants ?? [])
+        .map(participant => {
+            const user = participant.user;
+            if (!user || user.role !== 'MENTEE') {
+                return '';
+            }
+
+            return [
+                user.nickname,
+                user.role,
+                user.menteeProfile?.surveyResult?.title,
+            ].filter(Boolean).join(' | ');
+        })
+        .filter(Boolean)
+        .join('\n');
+}
+
+function buildRankingPayload({ mentoring, questions }) {
+    const scripts = mentoring.scripts ?? [];
+    const scriptTexts = scripts
+        .map(script => textFromScriptContent(script.content))
+        .filter(Boolean);
+    const answeredQuestions = (mentoring.questions ?? [])
+        .filter(question => question.status === 'COMPLETED')
+        .map(question => question.content);
+    const recentMentorUtterances = (mentoring.chats ?? [])
+        .filter(chat => chat.userId === mentoring.userId)
+        .slice(-5)
+        .map(chat => chat.content);
+    const { mentorProfileText, mentorExpertiseEvidence } = buildMentorContext(mentoring);
+
+    return {
+        questions: questions.map(question => ({
+            id: String(question.questionId),
+            text: question.content,
+            isPaid: question.isPaid,
+            createdAt: question.createdAt,
+            userId: String(question.userId),
+        })),
+        sessionTopic: mentoring.title,
+        previousScriptSections: scriptTexts.slice(0, -1),
+        currentScriptSection: scriptTexts.at(-1) ?? '',
+        answeredQuestions,
+        queuedQuestions: questions.map(question => question.content),
+        recentMentorUtterances,
+        menteeProfile: buildMenteeProfileText(mentoring),
+        mentorProfile: mentorProfileText,
+        mentorExpertiseEvidence,
+        mentorPastScripts: scriptTexts,
+    };
+}
+
+export function parseQuestionFlagsFromChatContent(content) {
+    const rawContent = String(content ?? '').trim();
+    const paidPrefixes = ['[유료]', '[PAID]', '[paid]', '[?좊즺]'];
+    const privatePrefixes = ['[비공개]', '[PRIVATE]', '[private]'];
+
+    let normalizedContent = rawContent;
+    const isPaid = paidPrefixes.some((prefix) => {
+        if (normalizedContent.startsWith(prefix)) {
+            normalizedContent = normalizedContent.slice(prefix.length).trim();
+            return true;
+        }
+        return false;
+    });
+    const isPrivate = privatePrefixes.some((prefix) => {
+        if (normalizedContent.startsWith(prefix)) {
+            normalizedContent = normalizedContent.slice(prefix.length).trim();
+            return true;
+        }
+        return false;
+    });
+
+    return {
+        content: normalizedContent || rawContent,
+        isPaid,
+        isPrivate,
+    };
+}
+
+export async function predictQuestionText(text, { fetchImpl = globalThis.fetch } = {}) {
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('fetch is not available for question detection.');
+    }
+
+    const timeoutMs = getQuestionDetectionTimeoutMs();
+    const signal = typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(timeoutMs)
+        : undefined;
+
+    const response = await fetchImpl(`${getQuestionServiceUrl()}/api/question-detection/predict`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ text }),
+        signal,
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+        throw new Error(body?.message || body?.error || 'question detection request failed');
+    }
+
+    return body;
+}
+
+export async function requestQuestionRanking(payload, { fetchImpl = globalThis.fetch } = {}) {
+    if (typeof fetchImpl !== 'function') {
+        throw new Error('fetch is not available for question ranking.');
+    }
+
+    const timeoutMs = getQuestionRankingTimeoutMs();
+    const signal = typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function'
+        ? AbortSignal.timeout(timeoutMs)
+        : undefined;
+
+    const response = await fetchImpl(`${getQuestionServiceUrl()}/api/questions/rank-batch`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+        signal,
+    });
+
+    const body = await response.json().catch(() => null);
+    if (!response.ok) {
+        throw new Error(body?.message || body?.error || 'question ranking request failed');
+    }
+
+    return body;
+}
+
+export async function rankQuestionQueueForMentoring(mentoringId, options = {}) {
+    const mentoring = await prisma.mentoring.findUnique({
+        where: { mentoringId },
+        include: {
+            hostMentor: {
+                include: {
+                    mentorProfile: {
+                        include: { fields: true },
+                    },
+                },
+            },
+            participants: {
+                include: {
+                    user: {
+                        include: {
+                            menteeProfile: {
+                                include: { surveyResult: true },
+                            },
+                        },
+                    },
+                },
+            },
+            scripts: {
+                orderBy: { createdAt: 'asc' },
+                take: 5,
+            },
+            questions: {
+                where: {
+                    OR: [
+                        { status: 'BEFORE' },
+                        { status: 'COMPLETED' },
+                    ],
+                },
+                orderBy: { createdAt: 'asc' },
+            },
+            chats: {
+                orderBy: { createdAt: 'asc' },
+                take: 50,
+            },
+        },
+    });
+
+    if (!mentoring) {
+        return null;
+    }
+
+    const queuedQuestions = mentoring.questions.filter(question => question.status === 'BEFORE');
+    if (queuedQuestions.length === 0) {
+        return {
+            updatedCount: 0,
+            rankedQuestions: [],
+        };
+    }
+
+    const result = await requestQuestionRanking(
+        buildRankingPayload({
+            mentoring,
+            questions: queuedQuestions,
+        }),
+        options,
+    );
+    const scoreByQuestionId = new Map(
+        (result.rankedQuestions ?? []).map(question => [String(question.id), Number(question.priorityScore)]),
+    );
+    const updates = queuedQuestions
+        .map(question => ({
+            questionId: question.questionId,
+            priorityScore: scoreByQuestionId.get(String(question.questionId)),
+        }))
+        .filter(update => Number.isFinite(update.priorityScore));
+
+    if (updates.length > 0) {
+        await prisma.$transaction(updates.map(update => prisma.question.update({
+            where: { questionId: update.questionId },
+            data: { priorityScore: update.priorityScore },
+        })));
+    }
+
+    return {
+        updatedCount: updates.length,
+        ...result,
+    };
+}
+
+export async function saveQuestionFromChatMessage(chatMessage, options = {}) {
+    const { content, isPaid, isPrivate } = parseQuestionFlagsFromChatContent(chatMessage.content);
+    const prediction = await predictQuestionText(content, options);
+
+    if (!prediction?.is_question) {
+        return {
+            saved: false,
+            prediction,
+        };
+    }
+
+    const question = await prisma.question.create({
+        data: {
+            content,
+            isPaid,
+            isPrivate,
+            userId: chatMessage.userId,
+            mentoringId: chatMessage.mentoringId,
+        },
+    });
+
+    return {
+        saved: true,
+        prediction,
+        question,
+    };
+}
 
 /**
  * 채팅 메시지 저장

--- a/services/chat-service/src/socket/socketHandler.js
+++ b/services/chat-service/src/socket/socketHandler.js
@@ -1,5 +1,7 @@
 import {
     saveChatMessage,
+    saveQuestionFromChatMessage,
+    rankQuestionQueueForMentoring,
     getMentoringStatus,
     verifyChatJoinAccess,
 } from '../database/chatRepository.js';
@@ -270,6 +272,22 @@ export async function handleConnection(socket, io) {
                 content,
             });
 
+            let questionResult = null;
+            try {
+                questionResult = await saveQuestionFromChatMessage(chatMessage);
+            } catch (error) {
+                console.error('[Question] Failed to detect/save chat question:', error);
+            }
+
+            let rankingResult = null;
+            if (questionResult?.saved) {
+                try {
+                    rankingResult = await rankQuestionQueueForMentoring(BigInt(state.mentoringId));
+                } catch (error) {
+                    console.error('[Question] Failed to rank question queue:', error);
+                }
+            }
+
             // 실시간 브로드캐스트
             io.to(roomName).emit('new_message', {
                 mentoringChatId: chatMessage.mentoringChatId.toString(),
@@ -278,6 +296,20 @@ export async function handleConnection(socket, io) {
                 userName: state.userName,
                 content,
                 createdAt: chatMessage.createdAt,
+                question: questionResult?.saved
+                    ? {
+                        questionId: questionResult.question.questionId.toString(),
+                        isPaid: questionResult.question.isPaid,
+                        isPrivate: questionResult.question.isPrivate,
+                        status: questionResult.question.status,
+                    }
+                    : null,
+                ranking: rankingResult
+                    ? {
+                        updatedCount: rankingResult.updatedCount,
+                        clustering: rankingResult.clustering ?? null,
+                    }
+                    : null,
             });
         } catch (error) {
             console.error('Error in send_message:', error);

--- a/services/core-api/src/lib/questionRecommendationProxy.js
+++ b/services/core-api/src/lib/questionRecommendationProxy.js
@@ -202,3 +202,32 @@ export async function requestQuestionRecommendations(payload, options = {}) {
 
     return responseBody;
 }
+
+export async function requestQuestionRanking(payload, options = {}) {
+    const baseUrl = options.baseUrl ?? getQuestionServiceUrl();
+    const fetchImpl = options.fetchImpl ?? fetch;
+    const response = await fetchImpl(`${baseUrl}/api/questions/rank-batch`, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+    });
+
+    let responseBody = null;
+    try {
+        responseBody = await response.json();
+    } catch {
+        responseBody = null;
+    }
+
+    if (!response.ok) {
+        throw new QuestionRecommendationProxyError(
+            responseBody?.message ?? 'failed to rank questions',
+            response.status,
+            responseBody?.code ?? responseBody?.error ?? 'QUESTION_RANKING_SERVICE_FAILED',
+        );
+    }
+
+    return responseBody;
+}

--- a/services/core-api/src/lib/questionRecommendationProxy.test.js
+++ b/services/core-api/src/lib/questionRecommendationProxy.test.js
@@ -5,6 +5,7 @@ import {
     parseSessionId,
     QuestionRecommendationProxyError,
     requestQuestionRecommendations,
+    requestQuestionRanking,
     selectMenteeParticipant,
 } from './questionRecommendationProxy.js';
 
@@ -168,4 +169,39 @@ test('propagates question-service errors', async () => {
             && error.status === 502
             && error.code === 'QUESTION_RECOMMENDATION_GENERATION_FAILED',
     );
+});
+
+test('forwards ranking request to question-service', async () => {
+    const calls = [];
+    const result = await requestQuestionRanking(
+        {
+            questions: [
+                { id: '1', text: 'What should I ask first?', isPaid: false },
+            ],
+        },
+        {
+            baseUrl: 'http://question-service',
+            fetchImpl: async (url, options) => {
+                calls.push({ url, options });
+                return {
+                    ok: true,
+                    json: async () => ({
+                        service: 'question-service',
+                        rankedQuestions: [
+                            { id: '1', priorityScore: 0.75 },
+                        ],
+                    }),
+                };
+            },
+        },
+    );
+
+    assert.equal(calls[0].url, 'http://question-service/api/questions/rank-batch');
+    assert.equal(calls[0].options.method, 'POST');
+    assert.deepEqual(JSON.parse(calls[0].options.body), {
+        questions: [
+            { id: '1', text: 'What should I ask first?', isPaid: false },
+        ],
+    });
+    assert.equal(result.rankedQuestions[0].priorityScore, 0.75);
 });

--- a/services/core-api/src/routes/questions.js
+++ b/services/core-api/src/routes/questions.js
@@ -7,23 +7,520 @@ import {
     parseSessionId,
     QuestionRecommendationProxyError,
     requestQuestionRecommendations,
+    requestQuestionRanking,
 } from '../lib/questionRecommendationProxy.js';
 
 const router = Router();
 
-function isInvalidContext(value) {
-    return typeof value !== 'string' || !value.trim();
+function parseQueueStatus(value) {
+    const normalized = String(value ?? 'BEFORE').toUpperCase();
+    if (normalized === 'BEFORE' || normalized === 'ANSWERING' || normalized === 'COMPLETED') {
+        return normalized;
+    }
+
+    return 'BEFORE';
 }
 
-router.post('/recommendations', requireUser, async (req, res, next) => {
+function parseQuestionId(value) {
     try {
-        if (isInvalidContext(req.body?.context)) {
+        if (value === undefined || value === null || value === '') {
+            return null;
+        }
+
+        return BigInt(value);
+    } catch {
+        return null;
+    }
+}
+
+function asTextList(value) {
+    if (!Array.isArray(value)) {
+        return [];
+    }
+
+    return value
+        .map(item => (typeof item === 'string' ? item.trim() : ''))
+        .filter(Boolean);
+}
+
+function readInfoList(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return [];
+    }
+
+    for (const key of keys) {
+        if (Array.isArray(info[key])) {
+            return asTextList(info[key]);
+        }
+    }
+
+    return [];
+}
+
+function readInfoText(info, keys) {
+    if (!info || typeof info !== 'object') {
+        return '';
+    }
+
+    for (const key of keys) {
+        const value = typeof info[key] === 'string' ? info[key].trim() : '';
+        if (value) {
+            return value;
+        }
+    }
+
+    return '';
+}
+
+function textFromScriptContent(content) {
+    if (typeof content === 'string') {
+        return content.trim();
+    }
+
+    if (!content || typeof content !== 'object') {
+        return '';
+    }
+
+    if (Array.isArray(content)) {
+        return asTextList(content.map(item => {
+            if (typeof item === 'string') return item;
+            if (item && typeof item === 'object') return item.text ?? item.content ?? item.script ?? '';
+            return '';
+        })).join('\n');
+    }
+
+    return asTextList([
+        content.text,
+        content.content,
+        content.script,
+        content.summary,
+    ]).join('\n');
+}
+
+function buildMentorContext(mentoring) {
+    const mentorUser = mentoring.hostMentor;
+    const mentorProfile = mentorUser?.mentorProfile;
+    const mentorInfo = mentorProfile?.info;
+    const fieldNames = mentorProfile?.fields?.map(field => field.fieldName) ?? [];
+    const expertise = [...new Set([
+        ...fieldNames,
+        ...readInfoList(mentorInfo, ['expertise', 'skills', 'fields']),
+    ])];
+    const role = readInfoText(mentorInfo, ['role', 'job', 'position', 'title']) || mentorUser?.role || '';
+    const bio = mentorProfile?.bio ?? '';
+
+    return {
+        mentorProfileText: [
+            mentorUser?.nickname,
+            role,
+            expertise.join(', '),
+            bio,
+        ].filter(Boolean).join(' | '),
+        mentorExpertiseEvidence: [
+            ...expertise,
+            bio,
+        ].filter(Boolean),
+    };
+}
+
+function buildMenteeProfileText(mentoring) {
+    return (mentoring.participants ?? [])
+        .map(participant => {
+            const user = participant.user;
+            if (!user || user.role !== 'MENTEE') {
+                return '';
+            }
+
+            return [
+                user.nickname,
+                user.role,
+                user.menteeProfile?.surveyResult?.title,
+            ].filter(Boolean).join(' | ');
+        })
+        .filter(Boolean)
+        .join('\n');
+}
+
+function buildRankingPayload({ mentoring, questions }) {
+    const scripts = mentoring.scripts ?? [];
+    const scriptTexts = scripts
+        .map(script => textFromScriptContent(script.content))
+        .filter(Boolean);
+    const answeredQuestions = (mentoring.questions ?? [])
+        .filter(question => question.status === 'COMPLETED')
+        .map(question => question.content);
+    const recentMentorUtterances = (mentoring.chats ?? [])
+        .filter(chat => chat.userId === mentoring.userId)
+        .slice(-5)
+        .map(chat => chat.content);
+    const { mentorProfileText, mentorExpertiseEvidence } = buildMentorContext(mentoring);
+
+    return {
+        questions: questions.map(question => ({
+            id: String(question.questionId),
+            text: question.content,
+            isPaid: question.isPaid,
+            createdAt: question.createdAt,
+            userId: String(question.userId),
+        })),
+        sessionTopic: mentoring.title,
+        previousScriptSections: scriptTexts.slice(0, -1),
+        currentScriptSection: scriptTexts.at(-1) ?? '',
+        answeredQuestions,
+        queuedQuestions: questions.map(question => question.content),
+        recentMentorUtterances,
+        menteeProfile: buildMenteeProfileText(mentoring),
+        mentorProfile: mentorProfileText,
+        mentorExpertiseEvidence,
+        mentorPastScripts: scriptTexts,
+    };
+}
+
+function buildRecommendationRequestBody({ body, mentoring }) {
+    const scripts = mentoring.scripts ?? [];
+    const scriptTexts = scripts
+        .map(script => textFromScriptContent(script.content))
+        .filter(Boolean);
+    const chats = mentoring.chats ?? [];
+    const questions = mentoring.questions ?? [];
+    const answeredQuestions = questions
+        .filter(question => question.status === 'COMPLETED')
+        .map(question => question.content);
+    const queuedQuestions = questions
+        .filter(question => question.status === 'BEFORE' || question.status === 'ANSWERING')
+        .map(question => question.content);
+    const recentMentorUtterances = chats
+        .filter(chat => chat.userId === mentoring.userId)
+        .slice(-5)
+        .map(chat => chat.content);
+    const recentChatContext = chats
+        .slice(-8)
+        .map(chat => `${chat.user?.nickname ?? 'user'}: ${chat.content}`)
+        .join('\n');
+    const explicitContext = typeof body?.context === 'string' ? body.context.trim() : '';
+    const dbContext = [
+        `Session topic: ${mentoring.title}`,
+        scriptTexts.at(-1) ? `Current script section:\n${scriptTexts.at(-1)}` : '',
+        recentChatContext ? `Recent chat:\n${recentChatContext}` : '',
+        queuedQuestions.length > 0 ? `Queued questions:\n${queuedQuestions.join('\n')}` : '',
+    ].filter(Boolean).join('\n\n');
+    const answerabilityContext = body?.answerabilityContext && typeof body.answerabilityContext === 'object'
+        ? body.answerabilityContext
+        : {};
+
+    return {
+        ...body,
+        context: explicitContext || dbContext || mentoring.title,
+        topic: body?.topic || mentoring.title,
+        answerabilityContext: {
+            ...answerabilityContext,
+            previousScriptSections: answerabilityContext.previousScriptSections ?? scriptTexts.slice(0, -1),
+            currentScriptSection: answerabilityContext.currentScriptSection ?? scriptTexts.at(-1) ?? '',
+            recentMentorUtterances: answerabilityContext.recentMentorUtterances ?? recentMentorUtterances,
+            answeredQuestions: answerabilityContext.answeredQuestions ?? answeredQuestions,
+            queuedQuestions: answerabilityContext.queuedQuestions ?? queuedQuestions,
+        },
+    };
+}
+
+function truncateRecommendationContent(content) {
+    const value = typeof content === 'string' ? content.trim() : '';
+    return value.length > 150 ? value.slice(0, 150) : value;
+}
+
+async function updateQuestionStatusForHost(req, res, next, status) {
+    try {
+        const questionId = parseQuestionId(req.params.questionId);
+        if (questionId === null) {
             return res.status(400).json({
-                code: 'QUESTION_RECOMMENDATION_INVALID_INPUT',
-                message: 'context is required',
+                code: 'QUESTION_INVALID_ID',
+                message: 'valid questionId is required',
             });
         }
 
+        const question = await prisma.question.findFirst({
+            where: {
+                questionId,
+                mentoring: {
+                    userId: req.user.userId,
+                },
+            },
+            include: {
+                user: {
+                    select: {
+                        userId: true,
+                        nickname: true,
+                    },
+                },
+            },
+        });
+
+        if (!question) {
+            return res.status(404).json({
+                code: 'QUESTION_NOT_FOUND',
+                message: 'question not found or access denied',
+            });
+        }
+
+        if (question.status === 'COMPLETED' && status === 'ANSWERING') {
+            return res.status(409).json({
+                code: 'QUESTION_ALREADY_COMPLETED',
+                message: 'completed question cannot be moved back to answering',
+            });
+        }
+
+        const updatedQuestion = await prisma.question.update({
+            where: { questionId },
+            data: { status },
+            include: {
+                user: {
+                    select: {
+                        userId: true,
+                        nickname: true,
+                    },
+                },
+            },
+        });
+
+        return res.json(serialize({
+            question: {
+                questionId: updatedQuestion.questionId,
+                content: updatedQuestion.content,
+                isPaid: updatedQuestion.isPaid,
+                isPrivate: updatedQuestion.isPrivate,
+                priorityScore: updatedQuestion.priorityScore,
+                status: updatedQuestion.status,
+                createdAt: updatedQuestion.createdAt,
+                user: {
+                    userId: updatedQuestion.user.userId,
+                    nickname: updatedQuestion.user.nickname,
+                },
+            },
+        }));
+    } catch (error) {
+        next(error);
+    }
+}
+
+router.get('/', requireUser, async (req, res, next) => {
+    try {
+        const mentoringId = parseSessionId(req.query.mentoringId ?? req.query.sessionId);
+        const status = parseQueueStatus(req.query.status);
+
+        const mentoring = await prisma.mentoring.findFirst({
+            where: {
+                mentoringId,
+                OR: [
+                    { userId: req.user.userId },
+                    {
+                        participants: {
+                            some: { userId: req.user.userId },
+                        },
+                    },
+                ],
+            },
+            select: { mentoringId: true },
+        });
+
+        if (!mentoring) {
+            return res.status(404).json({
+                code: 'QUESTION_QUEUE_SESSION_NOT_FOUND',
+                message: 'mentoring session not found or access denied',
+            });
+        }
+
+        const questions = await prisma.question.findMany({
+            where: {
+                mentoringId,
+                status,
+            },
+            include: {
+                user: {
+                    select: {
+                        userId: true,
+                        nickname: true,
+                    },
+                },
+            },
+            orderBy: [
+                { isPaid: 'desc' },
+                { priorityScore: 'desc' },
+                { createdAt: 'asc' },
+                { questionId: 'asc' },
+            ],
+        });
+
+        return res.json(serialize({
+            questions: questions.map((question) => ({
+                questionId: question.questionId,
+                content: question.content,
+                isPaid: question.isPaid,
+                isPrivate: question.isPrivate,
+                priorityScore: question.priorityScore,
+                status: question.status,
+                createdAt: question.createdAt,
+                user: {
+                    userId: question.user.userId,
+                    nickname: question.user.nickname,
+                },
+            })),
+        }));
+    } catch (error) {
+        if (error instanceof QuestionRecommendationProxyError) {
+            return res.status(error.status).json({
+                code: 'QUESTION_QUEUE_INVALID_REQUEST',
+                message: error.message,
+            });
+        }
+
+        next(error);
+    }
+});
+
+router.patch('/:questionId/answering', requireUser, (req, res, next) => {
+    return updateQuestionStatusForHost(req, res, next, 'ANSWERING');
+});
+
+router.patch('/:questionId/completed', requireUser, (req, res, next) => {
+    return updateQuestionStatusForHost(req, res, next, 'COMPLETED');
+});
+
+router.post('/rank-queue', requireUser, async (req, res, next) => {
+    try {
+        const mentoringId = parseSessionId(req.body?.mentoringId ?? req.body?.sessionId);
+        const mentoring = await prisma.mentoring.findFirst({
+            where: {
+                mentoringId,
+                userId: req.user.userId,
+            },
+            include: {
+                hostMentor: {
+                    include: {
+                        mentorProfile: {
+                            include: { fields: true },
+                        },
+                    },
+                },
+                participants: {
+                    include: {
+                        user: {
+                            include: {
+                                menteeProfile: {
+                                    include: { surveyResult: true },
+                                },
+                            },
+                        },
+                    },
+                },
+                scripts: {
+                    orderBy: { createdAt: 'asc' },
+                    take: 5,
+                },
+                questions: {
+                    where: {
+                        OR: [
+                            { status: 'BEFORE' },
+                            { status: 'COMPLETED' },
+                        ],
+                    },
+                    orderBy: { createdAt: 'asc' },
+                    include: {
+                        user: {
+                            select: {
+                                userId: true,
+                                nickname: true,
+                            },
+                        },
+                    },
+                },
+                chats: {
+                    include: {
+                        user: {
+                            select: {
+                                nickname: true,
+                            },
+                        },
+                    },
+                    orderBy: { createdAt: 'asc' },
+                    take: 50,
+                },
+            },
+        });
+
+        if (!mentoring) {
+            return res.status(404).json({
+                code: 'QUESTION_RANKING_SESSION_NOT_FOUND',
+                message: 'mentoring session not found or access denied',
+            });
+        }
+
+        const queuedQuestions = mentoring.questions.filter(question => question.status === 'BEFORE');
+        if (queuedQuestions.length === 0) {
+            return res.json(serialize({
+                updatedCount: 0,
+                questions: [],
+            }));
+        }
+
+        const result = await requestQuestionRanking(buildRankingPayload({
+            mentoring,
+            questions: queuedQuestions,
+        }));
+
+        const scoreByQuestionId = new Map(
+            (result.rankedQuestions ?? []).map(question => [String(question.id), Number(question.priorityScore)]),
+        );
+
+        const updates = queuedQuestions
+            .map(question => ({
+                questionId: question.questionId,
+                priorityScore: scoreByQuestionId.get(String(question.questionId)),
+            }))
+            .filter(update => Number.isFinite(update.priorityScore));
+
+        await prisma.$transaction(updates.map(update => prisma.question.update({
+            where: { questionId: update.questionId },
+            data: { priorityScore: update.priorityScore },
+        })));
+        const queuedQuestionById = new Map(
+            queuedQuestions.map(question => [String(question.questionId), question]),
+        );
+
+        return res.json(serialize({
+            updatedCount: updates.length,
+            questions: (result.rankedQuestions ?? []).map(question => ({
+                questionId: question.id,
+                content: queuedQuestionById.get(String(question.id))?.content ?? question.text,
+                isPaid: queuedQuestionById.get(String(question.id))?.isPaid ?? question.isPaid,
+                isPrivate: queuedQuestionById.get(String(question.id))?.isPrivate ?? false,
+                status: queuedQuestionById.get(String(question.id))?.status ?? 'BEFORE',
+                createdAt: queuedQuestionById.get(String(question.id))?.createdAt ?? null,
+                user: queuedQuestionById.get(String(question.id))?.user ?? null,
+                priorityScore: question.priorityScore,
+                answerabilityScore: question.answerabilityScore,
+                priorityTier: question.priorityTier,
+                priorityGroup: question.priorityGroup,
+                clusterId: question.clusterId,
+                clusterSize: question.clusterSize,
+                similarQuestionIds: question.similarQuestionIds ?? [],
+                scores: question.scores ?? null,
+            })),
+            clustering: result.clustering ?? null,
+        }));
+    } catch (error) {
+        if (error instanceof QuestionRecommendationProxyError) {
+            return res.status(error.status).json({
+                code: error.code,
+                message: error.message,
+            });
+        }
+
+        next(error);
+    }
+});
+
+router.post('/recommendations', requireUser, async (req, res, next) => {
+    try {
         const mentoringId = parseSessionId(req.body?.sessionId);
         const mentoring = await prisma.mentoring.findFirst({
             where: {
@@ -56,6 +553,25 @@ router.post('/recommendations', requireUser, async (req, res, next) => {
                         },
                     },
                 },
+                scripts: {
+                    orderBy: { createdAt: 'asc' },
+                    take: 5,
+                },
+                questions: {
+                    orderBy: { createdAt: 'asc' },
+                    take: 50,
+                },
+                chats: {
+                    include: {
+                        user: {
+                            select: {
+                                nickname: true,
+                            },
+                        },
+                    },
+                    orderBy: { createdAt: 'asc' },
+                    take: 50,
+                },
             },
         });
 
@@ -67,14 +583,31 @@ router.post('/recommendations', requireUser, async (req, res, next) => {
         }
 
         const payload = buildQuestionRecommendationPayload({
-            body: req.body,
+            body: buildRecommendationRequestBody({
+                body: req.body ?? {},
+                mentoring,
+            }),
             mentoring,
             currentUserId: req.user.userId,
         });
         const result = await requestQuestionRecommendations(payload);
+        const recommendations = result.questions ?? [];
+
+        const rows = recommendations
+            .map(question => ({
+                mentoringId,
+                content: truncateRecommendationContent(question.content),
+            }))
+            .filter(row => row.content);
+
+        if (rows.length > 0) {
+            await prisma.aiRecommendation.createMany({
+                data: rows,
+            });
+        }
 
         return res.json(serialize({
-            questions: result.questions ?? [],
+            questions: recommendations,
         }));
     } catch (error) {
         if (error instanceof QuestionRecommendationProxyError) {


### PR DESCRIPTION
## 연관된 이슈

#107

## 작업 내용

채팅으로 들어온 메시지를 question-service와 연결해 질문 감지, DB 저장, 질문 큐 ranking까지 이어지도록 구성했습니다.

- chat-service에서 채팅 저장 후 질문 감지 및 질문 저장 처리
- 질문 저장 성공 시 question-service ranking API 호출 후 priorityScore 갱신
- core-api에서 DB의 멘토링/멘토/멘티/스크립트/채팅/질문 정보를 question-service 요청 context로 전달
- 멘토 화면 질문 큐를 mock 데이터에서 DB 조회 기반으로 변경
- 멘티 화면 AI 질문 추천을 실제 추천 API와 연결

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

다음 흐름이 의도대로 연결됐는지 중점적으로 봐주세요.

- 채팅 수집 -> question detection -> question DB 저장 -> question ranking -> 멘토 질문 큐 반영
- 특히 chat-service에서 질문 저장 후 ranking을 호출하는 방식과, core-api에서 question-service로 넘기는 DB context 구성이 적절한지 확인 부탁드립니다.

## 주의사항

- question-service가 실행 중이어야 질문 감지/ranking/추천이 정상 동작합니다.
- QUESTION_SERVICE_URL 환경변수가 없으면 기본값으로 http://localhost:4003을 사용합니다.
- 멘토 질문 큐는 BEFORE 상태 질문만 조회합니다.
- 채팅 저장은 성공했지만 question-service 호출이 실패하면, 채팅 자체는 남고 질문 저장/ranking만 누락될 수 있습니다.

## 테스트 방법

1. core-api, chat-service, question-service, demo-web을 실행합니다.
2. 멘티 계정으로 라이브 멘토링 방에 입장합니다.
3. 멘토 계정으로 같은 라이브 멘토링 방에 입장합니다.
4. 멘티 채팅창에서 질문 형태의 메시지를 보냅니다.
5. 예: 신입 개발자로 포트폴리오를 어떻게 구성하면 좋을까요?
6. DB의 questions 테이블에 해당 채팅 기반 질문이 저장되는지 확인합니다.
7. 저장된 질문의 priorityScore가 ranking 결과로 갱신되는지 확인합니다.
8. 멘토 화면 상단 질문 큐에 방금 저장된 질문이 표시되는지 확인합니다.
9. 멘토 화면에서 질문 읽기, 답변 완료, 다음 질문 버튼이 정상 동작하는지 확인합니다. 
10. 멘티 화면에서 AI 질문 추천을 열고 추천 질문이 표시되는지 확인합니다.