### PR TITLE
[question-service] 질문 탐지 api 프론트엔드 연결

### DIFF
--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -19,6 +19,8 @@ interface ChatMessage {
     author: string;
     senderId: string;
     content: string;
+    isQuestion?: boolean;
+    questionId?: string | null;
 }
 
 // ============================================================================
@@ -50,7 +52,7 @@ export default function LiveMentoringPage() {
                 setUserId(parsedUserId);
 
                 try {
-                    await apiClient.post(`/api/mentorings/${mentoringId}/join`);
+                    await apiClient.post(`/mentorings/${mentoringId}/join`);
 
                     // 성공 시 진짜 방 화면으로 전환
                     setIsReady(true);
@@ -186,6 +188,8 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                 author: m.user?.nickname || m.userName || "익명멘티",
                 senderId: String(m.userId),
                 content: m.content.replace("[유료] ", ""),
+                isQuestion: m.isQuestion, 
+                questionId: m.questionId,
             }]);
         });
 
@@ -399,18 +403,38 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                                     className="w-9 h-9 rounded-full object-cover shrink-0 bg-gray-800 border-2 border-[#FFCC00]"
                                 />
 
-                                <div className="flex flex-col items-start">
+                                {/* 💡 넓이를 차지하도록 w-full 추가 */}
+                                <div className="flex flex-col items-start w-full">
                                     <div className="flex items-center gap-2 mb-1">
                                         <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                        
+                                        {/* 기존 유료 질문 배지 */}
                                         {chat.type === 'paid' && (
                                             <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded tracking-wide">
                                                 유료 질문
                                             </span>
                                         )}
+                                        
+                                        {/* 💡 [추가] 일반 질문 배지 (유료가 아니면서 isQuestion이 true일 때) */}
+                                        {chat.isQuestion && chat.type !== 'paid' && (
+                                            <span className="bg-blue-600 text-white text-[10px] font-extrabold px-1.5 py-0.5 rounded flex items-center gap-1 shadow-sm">
+                                                💡 질문
+                                            </span>
+                                        )}
                                     </div>
-                                    <p className={`text-[15px] break-all leading-relaxed ${chat.type === 'paid' ? 'text-[#FFCC00]' : 'text-gray-100'}`}>
+                                    
+                                    {/* 💡 [수정] 질문 여부에 따른 말풍선 조건부 스타일링 */}
+                                    <div 
+                                        className={`text-[15px] break-all leading-relaxed ${
+                                            chat.type === 'paid' 
+                                                ? 'text-[#FFCC00]' // 유료 질문 텍스트 스타일
+                                                : chat.isQuestion 
+                                                    ? 'bg-blue-900/30 border border-blue-500/50 text-blue-50 px-3 py-2 rounded-2xl rounded-tl-sm w-fit max-w-[90%]' // 🎯 일반 질문 말풍선
+                                                    : 'text-gray-100' // 일반 채팅 텍스트 스타일
+                                        }`}
+                                    >
                                         {chat.content}
-                                    </p>
+                                    </div>
                                 </div>
                             </div>
                         );

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -177,6 +177,8 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                 author: m.user?.nickname || m.userName || "익명멘티",
                 senderId: String(m.userId),
                 content: m.content.replace("[유료] ", ""),
+                isQuestion: m.isQuestion,
+                questionId: m.questionId,
             })) as ChatMessage[];
             setChats(mapped);
         });
@@ -386,59 +388,39 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
             </div>
 
             <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-5 z-10 custom-scrollbar">
-                {chats.length === 0 ? (
+                {/* 유료 질문을 제외한 순수 채팅 개수만 체크 */}
+                {chats.filter((chat) => chat.type !== 'paid').length === 0 ? (
                     <div className="h-full flex items-center justify-center text-gray-500 text-sm">
                         채팅 내역이 없습니다. 첫 인사를 남겨보세요!
                     </div>
                 ) : (
-                    chats.map((chat) => {
-                        const isMentor = sessionData?.host?.userId && String(chat.senderId) === String(sessionData.host.userId);
-                        const profileImage = isMentor ? "/images/mentor_profile.jpg" : "/images/mentee_profile.jpg";
+                    chats
+                        // 유료 질문은 화면에 아예 렌더링하지 않음.
+                        .filter((chat) => chat.type !== 'paid')
+                        .map((chat) => {
+                            const isMentor = sessionData?.host?.userId && String(chat.senderId) === String(sessionData.host.userId);
+                            const profileImage = isMentor ? "/images/mentor_profile.jpg" : "/images/mentee_profile.jpg";
 
-                        return (
-                            <div key={chat.id} className="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
-                                <img
-                                    src={profileImage}
-                                    alt={isMentor ? "멘토 프로필" : "멘티 프로필"}
-                                    className="w-9 h-9 rounded-full object-cover shrink-0 bg-gray-800 border-2 border-[#FFCC00]"
-                                />
+                            return (
+                                <div key={chat.id} className="flex gap-3 animate-in fade-in slide-in-from-bottom-2 duration-300">
+                                    <img
+                                        src={profileImage}
+                                        alt={isMentor ? "멘토 프로필" : "멘티 프로필"}
+                                        className="w-9 h-9 rounded-full object-cover shrink-0 bg-gray-800 border-2 border-[#FFCC00]"
+                                    />
 
-                                {/* 💡 넓이를 차지하도록 w-full 추가 */}
-                                <div className="flex flex-col items-start w-full">
-                                    <div className="flex items-center gap-2 mb-1">
-                                        <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                    <div className="flex flex-col items-start w-full">
+                                        <div className="flex items-center gap-2 mb-1">
+                                            <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                        </div>
                                         
-                                        {/* 기존 유료 질문 배지 */}
-                                        {chat.type === 'paid' && (
-                                            <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded tracking-wide">
-                                                유료 질문
-                                            </span>
-                                        )}
-                                        
-                                        {/* 💡 [추가] 일반 질문 배지 (유료가 아니면서 isQuestion이 true일 때) */}
-                                        {chat.isQuestion && chat.type !== 'paid' && (
-                                            <span className="bg-blue-600 text-white text-[10px] font-extrabold px-1.5 py-0.5 rounded flex items-center gap-1 shadow-sm">
-                                                💡 질문
-                                            </span>
-                                        )}
-                                    </div>
-                                    
-                                    {/* 💡 [수정] 질문 여부에 따른 말풍선 조건부 스타일링 */}
-                                    <div 
-                                        className={`text-[15px] break-all leading-relaxed ${
-                                            chat.type === 'paid' 
-                                                ? 'text-[#FFCC00]' // 유료 질문 텍스트 스타일
-                                                : chat.isQuestion 
-                                                    ? 'bg-blue-900/30 border border-blue-500/50 text-blue-50 px-3 py-2 rounded-2xl rounded-tl-sm w-fit max-w-[90%]' // 🎯 일반 질문 말풍선
-                                                    : 'text-gray-100' // 일반 채팅 텍스트 스타일
-                                        }`}
-                                    >
-                                        {chat.content}
+                                        <div className="text-[15px] break-all leading-relaxed text-gray-100">
+                                            {chat.content}
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
-                        );
-                    })
+                            );
+                        })
                 )}
                 <div ref={messagesEndRef} />
             </div>

--- a/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentee/[id]/page.tsx
@@ -3,15 +3,22 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import Link from "next/link";
 import { useParams } from "next/navigation";
-
-// 💡 프로젝트 환경에 맞게 apiClient 경로를 확인해주세요. (예: "@/lib/apiClient" 또는 "@/api/client")
 import apiClient from "@/lib/apiClient";
 
 import { io, Socket } from "socket.io-client";
-import { Users, Send, Sparkles, Star, X, ChevronUp, ChevronDown, AlertCircle, Play } from "lucide-react";
+import { Users, Send, Sparkles, Star, X, ChevronUp, ChevronDown, AlertCircle, Play, Lock } from "lucide-react";
 
 import { useMentoringSession } from "@/hooks/useMentoringSession";
 import { useWebRtcSession } from "@/hooks/useWebRtcSession";
+
+interface Question {
+    id: number;
+    isPaid: boolean;
+    isPrivate: boolean;
+    author: string;
+    avatar: string;
+    content: string;
+}
 
 interface ChatMessage {
     id: string | number;
@@ -121,6 +128,7 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
     const [chats, setChats] = useState<ChatMessage[]>([]);
     const [onlineUserCount, setOnlineUserCount] = useState<number>(0);
     const [isChatClosed, setIsChatClosed] = useState(false);
+    const [currentAnsweringQuestion, setCurrentAnsweringQuestion] = useState<Question | null>(null);
 
     const { sessionData, isLoading, error, isConnected, peerId, socket: rtcSocket } =
         useMentoringSession({ role, userId });
@@ -168,6 +176,35 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
 
         socket.on("connect_error", (err) => {
             console.error("❌ [채팅] 소켓 연결 실패! 상세 원인:", err.message);
+        });
+
+        // 멘토가 질문 읽기를 눌렀을 때 (상태 -> ANSWERING)
+        socket.on('question:acknowledged', (data: any) => {
+            const q = data?.question;
+            if (q) {
+                setCurrentAnsweringQuestion({
+                    id: Number(q.questionId),
+                    isPaid: q.isPaid || false,
+                    isPrivate: q.isPrivate || false,
+                    author: q.user?.nickname || '익명멘티',
+                    avatar: q.isPaid ? "💎" : "👤",
+                    content: q.content,
+                });
+            }
+        });
+
+        // 멘토가 답변 완료를 눌렀을 때 (상태 -> COMPLETED)
+        socket.on('question:completed', (data: any) => {
+            const q = data?.question;
+            if (q) {
+                setCurrentAnsweringQuestion((prev) => {
+                    // 완료된 질문이 현재 화면에 떠있는 질문과 같으면 화면에서 내립니다.
+                    if (prev && prev.id === Number(q.questionId)) {
+                        return null;
+                    }
+                    return prev;
+                });
+            }
         });
 
         socket.on("message_history", (messages: any[]) => {
@@ -333,7 +370,22 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
             </header>
 
             <div className="px-4 shrink-0 z-10 flex flex-col gap-3">
-                <div className="w-full aspect-[16/9] bg-gray-800 rounded-2xl relative overflow-hidden flex items-center justify-center">
+                {/* 현재 답변 중인 질문이 있고, '공개(isPrivate: false)'일 때만 질문 카드를 렌더링합니다. */}
+                {currentAnsweringQuestion && !currentAnsweringQuestion.isPrivate && (
+                    <div className={`w-full rounded-[20px] p-4 shrink-0 shadow-lg flex justify-between gap-3 animate-in slide-in-from-top-4 fade-in duration-300 ${currentAnsweringQuestion.isPaid ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-[#F0F0F0] text-[#1A1A1A]'}`}>
+                        <div className="flex flex-col gap-2 flex-1">
+                            <div className="flex items-center gap-2">
+                                <div className="w-7 h-7 bg-black/10 rounded-full flex items-center justify-center text-xs">
+                                    {currentAnsweringQuestion.avatar}
+                                </div>
+                                <span className="font-bold text-[13px]">{currentAnsweringQuestion.author}</span>
+                            </div>
+                            <p className="font-bold text-[15px] leading-snug">{currentAnsweringQuestion.content}</p>
+                        </div>
+                    </div>
+                )}
+
+                <div className="w-full aspect-[16/9] bg-gray-800 rounded-2xl relative overflow-hidden flex items-center justify-center shadow-xl border border-gray-800/50">
                     {remoteStreams.size > 0 ? (
                         <>
                             {Array.from(remoteStreams.entries()).map(([id, stream]) => (
@@ -367,10 +419,21 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
                             <div className="text-gray-400 text-sm animate-pulse">멘토의 영상을 기다리는 중...</div>
                         </div>
                     )}
+                    
                     <div className="absolute inset-x-0 bottom-0 h-1/3 bg-gradient-to-t from-black/60 to-transparent pointer-events-none"></div>
-                    <div className="absolute top-4 bg-red-600 text-white text-[11px] font-bold px-4 py-1.5 rounded-full shadow-lg z-10">
-                        비공개 질문 답변중
-                    </div>
+                    
+                    {/* 비디오 내부 상단 뱃지(질문 읽기 상태일 때만 노출, 비공개/공개 색상 구분) */}
+                    {currentAnsweringQuestion && (
+                        <div className={`absolute top-4 text-[11px] font-bold px-4 py-1.5 rounded-full backdrop-blur-md shadow-md animate-in fade-in duration-300 ${
+                            currentAnsweringQuestion.isPrivate 
+                                ? 'bg-red-600 text-white' 
+                                : 'bg-[#FFCC00] text-[#1A1A1A]'
+                        }`}>
+                            <span className="text-xs font-bold tracking-wide">
+                                {currentAnsweringQuestion.isPrivate ? '비공개 질문 답변 중' : '공개 질문 답변 중'}
+                            </span>
+                        </div>
+                    )}
                 </div>
             </div>
 
@@ -388,14 +451,14 @@ function LiveMentoringContent({ mentoringId, role, userId, userName }: { mentori
             </div>
 
             <div className="flex-1 overflow-y-auto px-4 pb-4 space-y-5 z-10 custom-scrollbar">
-                {/* 유료 질문을 제외한 순수 채팅 개수만 체크 */}
+                {/* 유료 질문을 걸러낸 순수 채팅 개수만 체크 */}
                 {chats.filter((chat) => chat.type !== 'paid').length === 0 ? (
                     <div className="h-full flex items-center justify-center text-gray-500 text-sm">
                         채팅 내역이 없습니다. 첫 인사를 남겨보세요!
                     </div>
                 ) : (
                     chats
-                        // 유료 질문은 화면에 아예 렌더링하지 않음.
+                        // 유료 질문은 채팅창 화면에 아예 렌더링하지 않음
                         .filter((chat) => chat.type !== 'paid')
                         .map((chat) => {
                             const isMentor = sessionData?.host?.userId && String(chat.senderId) === String(sessionData.host.userId);
@@ -520,10 +583,10 @@ const MediaRenderer = memo(function MediaRenderer({ stream, onBlocked }: { strea
     const isVideo = stream.getVideoTracks().length > 0;
     const hasAudio = stream.getAudioTracks().length > 0;
 
-    // 1. 💡 스트림 설정 및 재생 관리 Effect
+    // 1. 스트림 설정 및 재생 관리 Effect
     useEffect(() => {
         if (mediaRef.current && stream) {
-            // 🚨 [핵심] 이미 엘리먼트에 같은 스트림이 주입되어 있다면 아무것도 하지 않습니다.
+            // 이미 엘리먼트에 같은 스트림이 주입되어 있다면 아무것도 하지 않습니다.
             // srcObject를 매번 새로 대입하면 비디오 파이프라인이 초기화되면서 깜빡임이 발생합니다.
             if (mediaRef.current.srcObject !== stream) {
                 mediaRef.current.srcObject = stream;
@@ -537,7 +600,7 @@ const MediaRenderer = memo(function MediaRenderer({ stream, onBlocked }: { strea
         }
     }, [stream, onBlocked]); // 이펙트 재실행 시 srcObject를 null로 밀어버리는 코드를 제거함
 
-    // 2. 💡 진짜 컴포넌트가 '언마운트' 될 때만 미디어 자원을 깔끔하게 해제하는 별도 Effect
+    // 2. 진짜 컴포넌트가 '언마운트' 될 때만 미디어 자원을 깔끔하게 해제하는 별도 Effect
     useEffect(() => {
         return () => {
             if (mediaRef.current) {

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -479,7 +479,11 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                             ) : (
                                 chats.map((chat) => (
                                     <div key={chat.id} className="flex gap-3">
-                                        <div className="w-9 h-9 rounded-full bg-gray-800 border-2 border-[#FFCC00] shrink-0" />
+                                        <img 
+                                            src="/images/mentee_profile.jpg" 
+                                            alt={`${chat.author} 프로필`}
+                                            className="w-9 h-9 rounded-full border-2 border-[#FFCC00] shrink-0 object-cover bg-gray-800" 
+                                        />
                                         {/* 넓이를 차지하도록 w-full 추가 */}
                                         <div className="flex flex-col items-start w-full"> 
                                             <div className="flex items-center gap-2 mb-1">

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -25,6 +25,8 @@ interface ChatMessage {
     author: string;
     senderId: string;
     content: string;
+    isQuestion?: boolean;
+    questionId?: string | null;
 }
 
 // 1. 게이트웨이 컴포넌트: 정보가 준비될 때까지 로딩만 보여줌
@@ -213,6 +215,8 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 author: m.user?.nickname || m.userName || "익명멘티",
                 senderId: String(m.userId),
                 content: m.content.replace("[유료] ", ""),
+                isQuestion: m.isQuestion,
+                questionId: m.questionId,
             }]);
         });
 
@@ -410,6 +414,8 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 {isChatOpen && (
                     <div className="flex-1 flex flex-col mt-4 animate-in fade-in slide-in-from-bottom-8 duration-500 overflow-hidden">
                         <div className="flex-1 overflow-y-auto space-y-4 custom-scrollbar pb-6 pr-2">
+                            
+                            {/* 💡 수정됨: 채팅이 0개일 때 빈 화면 표시, 아닐 때 채팅 목록 렌더링 */}
                             {chats.length === 0 ? (
                                 <div className="h-full flex items-center justify-center text-gray-500 text-sm">
                                     아직 대화 내용이 없습니다.
@@ -418,14 +424,38 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                                 chats.map((chat) => (
                                     <div key={chat.id} className="flex gap-3">
                                         <div className="w-9 h-9 rounded-full bg-gray-800 border-2 border-[#FFCC00] shrink-0" />
-                                        <div className="flex flex-col items-start">
+                                        {/* 넓이를 차지하도록 w-full 추가 */}
+                                        <div className="flex flex-col items-start w-full"> 
                                             <div className="flex items-center gap-2 mb-1">
                                                 <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
-                                                {chat.type === 'paid' && <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded">유료 질문</span>}
+                                                
+                                                {/* 기존 유료 질문 배지 */}
+                                                {chat.type === 'paid' && (
+                                                    <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded">
+                                                        유료 질문
+                                                    </span>
+                                                )}
+                                                
+                                                {/* 💡 [추가] 일반 질문 배지 (유료가 아니면서 isQuestion이 true일 때) */}
+                                                {chat.isQuestion && chat.type !== 'paid' && (
+                                                    <span className="bg-blue-600 text-white text-[10px] font-extrabold px-1.5 py-0.5 rounded flex items-center gap-1 shadow-sm">
+                                                        💡 질문
+                                                    </span>
+                                                )}
                                             </div>
-                                            <p className={`text-[15px] leading-relaxed break-all ${chat.type === 'paid' ? 'text-[#FFCC00]' : 'text-gray-100'}`}>
+                                            
+                                            {/* 💡 [수정] 질문 여부에 따른 말풍선 조건부 스타일링 */}
+                                            <div 
+                                                className={`text-[15px] leading-relaxed break-all ${
+                                                    chat.type === 'paid' 
+                                                        ? 'text-[#FFCC00]' // 유료 질문 텍스트 스타일
+                                                        : chat.isQuestion 
+                                                            ? 'bg-blue-900/30 border border-blue-500/50 text-blue-50 px-3 py-2 rounded-2xl rounded-tl-sm w-fit max-w-[90%]' // 🎯 질문 말풍선 (다크 테마 호환 파란색)
+                                                            : 'text-gray-100' // 일반 채팅 텍스트 스타일
+                                                }`}
+                                            >
                                                 {chat.content}
-                                            </p>
+                                            </div>
                                         </div>
                                     </div>
                                 ))

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -246,6 +246,8 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 author: m.user?.nickname || m.userName || "익명멘티",
                 senderId: String(m.userId),
                 content: m.content.replace("[유료] ", ""),
+                isQuestion: m.isQuestion, 
+                questionId: m.questionId,
             })) as ChatMessage[];
             setChats(mapped);
         });
@@ -471,54 +473,33 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                     <div className="flex-1 flex flex-col mt-4 animate-in fade-in slide-in-from-bottom-8 duration-500 overflow-hidden">
                         <div className="flex-1 overflow-y-auto space-y-4 custom-scrollbar pb-6 pr-2">
                             
-                            {/* 💡 수정됨: 채팅이 0개일 때 빈 화면 표시, 아닐 때 채팅 목록 렌더링 */}
-                            {chats.length === 0 ? (
+                            {/* 유료 질문을 제외한 순수 채팅 개수만 체크 */}
+                            {chats.filter((chat) => chat.type !== 'paid').length === 0 ? (
                                 <div className="h-full flex items-center justify-center text-gray-500 text-sm">
                                     아직 대화 내용이 없습니다.
                                 </div>
                             ) : (
-                                chats.map((chat) => (
-                                    <div key={chat.id} className="flex gap-3">
-                                        <img 
-                                            src="/images/mentee_profile.jpg" 
-                                            alt={`${chat.author} 프로필`}
-                                            className="w-9 h-9 rounded-full border-2 border-[#FFCC00] shrink-0 object-cover bg-gray-800" 
-                                        />
-                                        {/* 넓이를 차지하도록 w-full 추가 */}
-                                        <div className="flex flex-col items-start w-full"> 
-                                            <div className="flex items-center gap-2 mb-1">
-                                                <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                chats
+                                    // 유료 질문은 채팅창 화면에 아예 렌더링하지 않음.
+                                    .filter((chat) => chat.type !== 'paid')
+                                    .map((chat) => (
+                                        <div key={chat.id} className="flex gap-3">
+                                            <img 
+                                                src="/images/mentee_profile.jpg" 
+                                                alt={`${chat.author} 프로필`}
+                                                className="w-9 h-9 rounded-full border-2 border-[#FFCC00] shrink-0 object-cover bg-gray-800" 
+                                            />
+                                            <div className="flex flex-col items-start w-full"> 
+                                                <div className="flex items-center gap-2 mb-1">
+                                                    <span className="text-sm font-semibold text-gray-400">{chat.author}</span>
+                                                </div>
                                                 
-                                                {/* 기존 유료 질문 배지 */}
-                                                {chat.type === 'paid' && (
-                                                    <span className="bg-[#FFCC00] text-[#1A1A1A] text-[10px] font-extrabold px-1.5 py-0.5 rounded">
-                                                        유료 질문
-                                                    </span>
-                                                )}
-                                                
-                                                {/* 💡 [추가] 일반 질문 배지 (유료가 아니면서 isQuestion이 true일 때) */}
-                                                {chat.isQuestion && chat.type !== 'paid' && (
-                                                    <span className="bg-blue-600 text-white text-[10px] font-extrabold px-1.5 py-0.5 rounded flex items-center gap-1 shadow-sm">
-                                                        💡 질문
-                                                    </span>
-                                                )}
-                                            </div>
-                                            
-                                            {/* 💡 [수정] 질문 여부에 따른 말풍선 조건부 스타일링 */}
-                                            <div 
-                                                className={`text-[15px] leading-relaxed break-all ${
-                                                    chat.type === 'paid' 
-                                                        ? 'text-[#FFCC00]' // 유료 질문 텍스트 스타일
-                                                        : chat.isQuestion 
-                                                            ? 'bg-blue-900/30 border border-blue-500/50 text-blue-50 px-3 py-2 rounded-2xl rounded-tl-sm w-fit max-w-[90%]' // 🎯 질문 말풍선 (다크 테마 호환 파란색)
-                                                            : 'text-gray-100' // 일반 채팅 텍스트 스타일
-                                                }`}
-                                            >
-                                                {chat.content}
+                                                <div className="text-[15px] leading-relaxed break-all text-gray-100">
+                                                    {chat.content}
+                                                </div>
                                             </div>
                                         </div>
-                                    </div>
-                                ))
+                                    ))
                             )}
                             <div ref={messagesEndRef} />
                         </div>

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -8,7 +8,6 @@ import { PhoneOff, Users, Volume2, Settings, Mic, MicOff, Video, VideoOff, Messa
 
 import { useMentoringSession } from "@/hooks/useMentoringSession";
 import { useWebRtcSession } from "@/hooks/useWebRtcSession";
-// core-api 호출용 클라이언트
 import apiClient from "@/lib/apiClient";
 
 interface Question {
@@ -18,6 +17,8 @@ interface Question {
     author: string;
     avatar: string;
     content: string;
+    status?: string;
+    answerer?: { userId: number; nickname: string } | null;
 }
 
 interface ChatMessage {
@@ -62,7 +63,7 @@ export default function MentorLivePage() {
         );
     }
 
-    // 💡 정보가 확정된 후, 실제 소켓 로직이 있는 Content 컴포넌트 실행
+    // 정보가 확정된 후, 실제 소켓 로직이 있는 Content 컴포넌트 실행
     return <MentorLiveContent mentoringId={mentoringId} role={role} userId={userId} userName={userName} />;
 }
 
@@ -79,8 +80,9 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
     const [isReading, setIsReading] = useState(false);
     const [questions, setQuestions] = useState<Question[]>([]);
     const [isLoadingQuestions, setIsLoadingQuestions] = useState(false);
+    const [completedIds, setCompletedIds] = useState<number[]>([]);
 
-    // 💡 이제 이 훅들은 컴포넌트가 마운트될 때 단 한 번, 올바른 userId로 실행됩니다.
+    // 이제 이 훅들은 컴포넌트가 마운트될 때 단 한 번, 올바른 userId로 실행됩니다.
     const mentoringOptions = useMemo(() => ({ role, userId }), [role, userId]);
     const { sessionData, isConnected, peerId, socket, endMentoring, isLoading, error } = useMentoringSession(mentoringOptions);
 
@@ -95,26 +97,27 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
 
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } = useWebRtcSession(webRtcConfig);
 
-// [질문 목록 로드 - 초기 DB 데이터 반영]
+    // [질문 목록 로드 - 초기 DB 데이터 반영]
     useEffect(() => {
         const fetchQuestions = async () => {
             if (!mentoringId) return;
             setIsLoadingQuestions(true);
             try {
-                const response = await apiClient.get(`/api/mentorings/${mentoringId}/questions`, {
-                    params: { status: "BEFORE" }
-                });
+                const response = await apiClient.get(`/api/mentorings/${mentoringId}/questions`);
                 if (response.data?.questions) {
-                    // 팀원의 API 응답 데이터를 본인의 데이터 구조(type, avatar 등)와 호환되도록 매핑
-                    const mappedQuestions = response.data.questions.map((q: any) => ({
-                        id: q.questionId,
-                        type: q.isPaid ? "paid" : "free",
-                        isPaid: q.isPaid || false, // 💡 [추가 1] 타입스크립트 에러 해결
-                        isPrivate: q.isPrivate || false,
-                        author: q.user?.nickname || "익명멘티",
-                        avatar: q.isPaid ? "💎" : "👤",
-                        content: q.content,
-                    }));
+                    const mappedQuestions = response.data.questions
+                        .filter((q: any) => q.status !== 'COMPLETED') // 프론트에서 완료된 질문만 필터링
+                        .map((q: any) => ({
+                            id: q.questionId,
+                            type: q.isPaid ? "paid" : "free",
+                            isPaid: q.isPaid || false,
+                            isPrivate: q.isPrivate || false,
+                            author: q.user?.nickname || "익명멘티",
+                            avatar: q.isPaid ? "💎" : "👤",
+                            content: q.content,
+                            status: q.status,
+                            answerer: q.answerer 
+                        }));
                     setQuestions(mappedQuestions);
                 }
             } catch (err: any) {
@@ -127,38 +130,20 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         fetchQuestions();
     }, [mentoringId]);
 
-    // 💡 [하이브리드 큐 생성] DB의 기존 질문들과 실시간 채팅창의 질문들을 중복 없이 결합합니다.
+    // [질문 큐 생성] 검증된 questions 상태(DB + 질문 소켓 이벤트)만 사용하여 정렬.
     const questionQueue = useMemo(() => {
-        // 1. 실시간 채팅 목록에서 질문들만 필터링하여 매핑
-        const chatQuestions = chats
-            .filter((chat) => chat.isQuestion || chat.type === 'paid')
-            .map((chat) => ({
-                id: chat.questionId || chat.id,
-                type: chat.type,
-                isPaid: chat.type === 'paid', // 💡 [추가 2] 타입스크립트 에러 해결
-                isPrivate: chat.isPrivate || false,
-                author: chat.author,
-                avatar: chat.type === 'paid' ? "💎" : "👤",
-                content: chat.content
-            }));
+        const completedStringIds = completedIds.map(id => String(id));
 
-        // 2. 초기 DB 질문 리스트(questions)를 기반으로 두고, 실시간 질문 중 중복되지 않은 것만 큐에 추가
-        const unified = [...questions];
-        chatQuestions.forEach((cq) => {
-            const isDuplicate = unified.some((q) => String(q.id) === String(cq.id));
-            if (!isDuplicate) {
-                unified.push(cq);
-            }
-        });
-        // 3. 유료 질문 우선 정렬 로직
-        // 결합된 배열(unified)을 유료와 무료로 분리.
-        const paidQuestions = unified.filter(q => q.isPaid);
-        const freeQuestions = unified.filter(q => !q.isPaid);
+        // 1. 이미 완료 처리된 질문 ID는 한 번 더 확실하게 필터링합니다.
+        const activeQuestions = questions.filter(q => !completedStringIds.includes(String(q.id)));
 
-        // 유료 질문들을 무조건 배열의 맨 앞으로 보내고, 그 뒤에 무료 질문들을 붙임.
-        // 각각의 배열 내에서는 FIFO 유지.
+        // 2. 유료 질문 최우선 정렬 로직
+        const paidQuestions = activeQuestions.filter(q => q.isPaid);
+        const freeQuestions = activeQuestions.filter(q => !q.isPaid);
+
+        // 3. 유료 질문이 무조건 앞에 오고, 일반 질문이 뒤에 오도록 합쳐서 반환.
         return [...paidQuestions, ...freeQuestions];
-    }, [questions, chats]);
+    }, [questions, completedIds]);
 
     // 현재 인덱스에 해당하는 질문 가져오기 (결합된 완성형 큐 사용)
     const currentQuestion = questionQueue[currentIdx];
@@ -168,16 +153,10 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         if (questionQueue.length === 0) {
             setCurrentIdx(0);
         } else if (currentIdx >= questionQueue.length) {
-            // 모든 질문을 다 본 상태(currentIdx === questionQueue.length)를 허용.
-            // 새치기 등으로 인해 인덱스가 전체 길이를 '초과'했을 때만 마지막 인덱스로 보정.
-            setCurrentIdx(questionQueue.length);
+            // 길이를 초과할 경우 안전하게 마지막 질문 카드를 가리키도록 보정 (-1 추가)
+            setCurrentIdx(questionQueue.length - 1);
         }
     }, [questionQueue.length, currentIdx]);
-
-    // page.tsx의 컴포넌트 내부 적절한 위치에 추가해서 로그를 확인해보세요.
-    useEffect(() => {
-        console.log("현재 들어온 전체 채팅 목록:", chats);
-    }, [chats]);
 
     // [채팅 소켓 설정]
     useEffect(() => {
@@ -227,13 +206,15 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
             }
         });
 
+        // [채팅 소켓 설정 useEffect 내부의 완료 이벤트 리스너]
         newSocket.on('question:completed', (data: any) => {
             try {
                 const q = data?.question;
                 if (!q) return;
-
                 const removeId = Number(q.questionId);
 
+                // 완료 목록에 누적하여 큐에서 완전히 제외되도록 처리
+                setCompletedIds((prev) => [...prev, removeId]);
                 setQuestions((prev) => prev.filter(p => p.id !== removeId));
             } catch (e) {
                 console.error('question:completed 처리 중 에러', e);
@@ -291,33 +272,59 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         }
     }, [chats, isChatOpen]);
 
-    // 💡 [수정 2] 다음 질문/답변 완료 버튼 로직 수정
+    // 다음 질문/답변 완료 버튼 로직
     const handleNextQuestion = () => {
-    // 💡 실시간 하이브리드 큐(questionQueue)의 범위를 벗어나지 않도록 안전하게 인덱스 증가
+    // questionQueue의 범위를 벗어나지 않도록 안전하게 인덱스 증가
         if (currentIdx < questionQueue.length) {
             setCurrentIdx((prev) => prev + 1); // 인덱스를 올려 다음 질문으로 이동 (끝에 도달 시 빈 카드 노출)
             setIsReading(false); // 새로운 질문을 읽기 위해 기존 읽기 상태 초기화
         }
     };
 
+    // [1] 답변 시작 시점 (질문 읽기 버튼)
     const acknowledgeQuestion = async (questionId: number) => {
+        if (!mentoringId || !questionId) {
+            console.error("🚨 [프론트 에러] 멘토링 ID 또는 질문 ID가 없습니다!", { mentoringId, questionId });
+            return;
+        }
+
         try {
-            await apiClient.post(`/api/mentorings/${mentoringId}/questions/${questionId}/acknowledge`);
+            console.log(`🚀 [API 요청] 질문 읽기 시작 (ID: ${questionId})`);
+            
+            const res = await apiClient.post(`/api/mentorings/${mentoringId}/questions/${questionId}/acknowledge`);
+            
             setIsReading(true);
+            console.log(`✅ [API 성공] 질문 상태가 ANSWERING으로 변경됨:`, res.data);
         } catch (err: any) {
-            console.error('질문 확인 실패', err);
+            console.error('❌ [API 실패] 질문 읽기 에러:', err.response?.data || err);
             alert(err?.response?.data?.message || '질문 확인에 실패했습니다.');
         }
     };
 
+    // [2] 답변 완료 시점 (답변 완료 버튼)
     const completeQuestion = async (questionId: number) => {
-        try {
-            await apiClient.post(`/api/mentorings/${mentoringId}/questions/${questionId}/complete`);
-            setIsReading(false);
+        if (!mentoringId || !questionId) {
+            console.error("🚨 [프론트 에러] 멘토링 ID 또는 질문 ID가 없습니다!", { mentoringId, questionId });
+            return;
+        }
 
+        try {
+            console.log(`🚀 [API 요청] 질문 완료 처리 시작 (ID: ${questionId})`);
+            
+            // 백엔드는 status가 'ANSWERING'일 때만 완료(complete)를 허락.
+            // 만약 멘토가 '질문 읽기'를 누르지 않고 바로 '답변 완료'를 눌렀을 경우를 대비해, 
+            // acknowledge를 강제로 한 번 찔러주고(에러는 무시) 바로 complete를 요청하도록 함.
+            await apiClient.post(`/api/mentorings/${mentoringId}/questions/${questionId}/acknowledge`).catch(() => {});
+            const res = await apiClient.post(`/api/mentorings/${mentoringId}/questions/${questionId}/complete`);
+            
+            setIsReading(false);
+            setCurrentIdx(0); 
+            setCompletedIds((prev) => [...prev, questionId]);
             setQuestions((prev) => prev.filter(q => q.id !== questionId));
+            
+            console.log(`✅ [API 성공] 질문 상태가 COMPLETED로 변경됨:`, res.data);
         } catch (err: any) {
-            console.error('질문 완료 처리 실패', err);
+            console.error('❌ [API 실패] 질문 완료 처리 에러:', err.response?.data || err);
             alert(err?.response?.data?.message || '질문 완료 처리에 실패했습니다.');
         }
     };
@@ -411,12 +418,22 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                                 </div>
                                 <p className="font-extrabold text-[16px] leading-snug">{currentQuestion?.content}</p>
                             </div>
+                            {/* 질문 카드 우측 버튼 영역 */}
                             <div className="flex flex-col gap-2 shrink-0 justify-center">
-                                <button onClick={() => setIsReading(true)} className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}>
+                                {/* onClick에 acknowledgeQuestion(답변 시작) 함수 연결 */}
+                                <button 
+                                    onClick={() => acknowledgeQuestion(Number(currentQuestion?.id))} 
+                                    className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}
+                                >
                                     <Volume2 className={`w-3.5 h-3.5 mr-1.5 ${isReading ? 'animate-pulse' : ''}`} />
                                     {isReading ? '읽는 중...' : '질문 읽기'}
                                 </button>
-                                <button onClick={handleNextQuestion} className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0] text-gray-700">
+                                
+                                {/* onClick에 completeQuestion(답변 완료) 함수 연결 */}
+                                <button 
+                                    onClick={() => completeQuestion(Number(currentQuestion?.id))} 
+                                    className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0] text-gray-700"
+                                >
                                     답변 완료
                                 </button>
                             </div>
@@ -430,7 +447,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                         </div>
                     )}
 
-                    {/* [2] 비디오 화면 영역 (조건부 렌더링 {currentQuestion &&} 제거) */}
+                    {/* [2] 비디오 화면 영역 */}
                     <div className="w-full aspect-[16/9] bg-[#1A1A1A] rounded-2xl relative overflow-hidden flex flex-col justify-between shadow-2xl border border-gray-800 shrink-0">
                         {isCameraOn ? (
                             <video ref={videoRef} className="absolute inset-0 w-full h-full object-cover" autoPlay playsInline muted />
@@ -442,11 +459,11 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                         )}
                         <div className="absolute inset-x-0 bottom-0 h-1/2 bg-gradient-to-t from-black/80 to-transparent pointer-events-none"></div>
 
-                        {/* 비디오 내부 상단 뱃지 (질문이 있을 때만 노출) */}
+                        {/* 비디오 내부 상단 뱃지 (질문이 존재하고, 질문 읽기 상태일 때만 노출) */}
                         <div className="relative w-full flex justify-center pt-4 z-10">
-                            {/* 현재 질문이 있을 때만 뱃지 렌더링 */}
-                            {currentQuestion && (
-                                <div className={`text-[11px] font-bold px-4 py-1.5 rounded-full ${currentQuestion.isPrivate ? 'bg-red-600 text-white' : 'bg-[#FFCC00] text-[#1A1A1A]'}`}>
+                            {/* 질문 읽기 버튼이 작동했을 때만 뱃지를 렌더링합니다 */}
+                            {isReading && currentQuestion && (
+                                <div className={`text-[11px] font-bold px-4 py-1.5 rounded-full backdrop-blur-md shadow-md animate-in fade-in duration-300 ${currentQuestion.isPrivate ? 'bg-red-600 text-white' : 'bg-[#FFCC00] text-[#1A1A1A]'}`}>
                                     {currentQuestion.isPrivate ? "비공개 질문 답변중" : "공개 질문 답변중"}
                                 </div>
                             )}

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -150,8 +150,14 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 unified.push(cq);
             }
         });
+        // 3. 유료 질문 우선 정렬 로직
+        // 결합된 배열(unified)을 유료와 무료로 분리.
+        const paidQuestions = unified.filter(q => q.isPaid);
+        const freeQuestions = unified.filter(q => !q.isPaid);
 
-        return unified;
+        // 유료 질문들을 무조건 배열의 맨 앞으로 보내고, 그 뒤에 무료 질문들을 붙임.
+        // 각각의 배열 내에서는 FIFO 유지.
+        return [...paidQuestions, ...freeQuestions];
     }, [questions, chats]);
 
     // 현재 인덱스에 해당하는 질문 가져오기 (결합된 완성형 큐 사용)
@@ -162,7 +168,9 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         if (questionQueue.length === 0) {
             setCurrentIdx(0);
         } else if (currentIdx >= questionQueue.length) {
-            setCurrentIdx(questionQueue.length - 1);
+            // 모든 질문을 다 본 상태(currentIdx === questionQueue.length)를 허용.
+            // 새치기 등으로 인해 인덱스가 전체 길이를 '초과'했을 때만 마지막 인덱스로 보정.
+            setCurrentIdx(questionQueue.length);
         }
     }, [questionQueue.length, currentIdx]);
 
@@ -373,7 +381,13 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 <div className={`flex flex-col transition-all duration-500 ${!isChatOpen ? 'flex-1 justify-center' : 'justify-start pt-2'}`}>
                     
                     {/* 질문 카드 영역 */}
-                    {currentQuestion ? (
+                    {isLoadingQuestions ? (
+                        // 1. 로딩 중 상태
+                        <div className="w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl bg-[#222222] text-white flex items-center justify-center min-h-[120px]">
+                            <div className="w-6 h-6 border-2 border-[#FFCC00]/30 border-t-[#FFCC00] rounded-full animate-spin"></div>
+                        </div>
+                    ) : currentQuestion ? (
+                        // 2. 대기 중인 질문이 있을 때
                         <div className={`w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl flex justify-between gap-4 transition-all duration-300 ${currentQuestion?.isPaid ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-[#F0F0F0] text-[#1A1A1A]'}`}>
                             <div className="flex flex-col gap-3 flex-1">
                                 <div className="flex items-center justify-between w-full">
@@ -406,48 +420,13 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                             </div>
                         </div>
                     ) : (
-                        // 대기 중인 질문이 없을 때의 빈 상태(Empty State) UI
+                        // 3. 대기 중인 질문이 없을 때의 빈 상태(Empty State) UI
                         <div className="w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-sm border border-gray-800 bg-[#1A1A1A] text-gray-400 flex flex-col items-center justify-center min-h-[120px]">
                             <MessageSquare className="w-6 h-6 mb-2 opacity-50" />
                             <p className="text-sm font-medium">현재 대기 중인 질문이 없습니다.</p>
                             <p className="text-xs text-gray-500 mt-1">채팅창에 올라온 질문이 이곳에 표시됩니다.</p>
                         </div>
                     )}
-
-                    {/* [1] 질문 카드 영역 */}
-                    {isLoadingQuestions ? (
-                        <div className="w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl bg-[#222222] text-white flex items-center justify-center h-24">
-                            <div className="w-6 h-6 border-2 border-[#FFCC00]/30 border-t-[#FFCC00] rounded-full animate-spin"></div>
-                        </div>
-                    ) : questions.length === 0 ? (
-                        <div className="w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl bg-[#222222] text-gray-400 flex items-center justify-center h-24">
-                            질문이 없습니다.
-                        </div>
-                    ) : currentQuestion ? (
-                        <div className={`w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl flex justify-between gap-4 ${currentQuestion.isPaid ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-[#F0F0F0] text-[#1A1A1A]'}`}>
-                            <div className="flex flex-col gap-3 flex-1">
-                                <div className="flex items-center justify-between w-full">
-                                    <div className="flex items-center gap-2">
-                                        <div className="w-8 h-8 bg-black/10 rounded-full flex items-center justify-center text-sm">{currentQuestion.avatar}</div>
-                                        <span className="font-bold text-[14px]">{currentQuestion.author}</span>
-                                    </div>
-                                    {currentQuestion.isPrivate && (
-                                        <div className="flex items-center gap-1 bg-red-600 text-white text-[10px] font-extrabold px-2 py-1 rounded-lg">
-                                            <Lock className="w-3 h-3" strokeWidth={3} /> 비공개 질문
-                                        </div>
-                                    )}
-                                </div>
-                                <p className="font-extrabold text-[16px] leading-snug">{currentQuestion.content}</p>
-                            </div>
-                            <div className="flex flex-col gap-2 shrink-0 justify-center">
-                                <button onClick={() => acknowledgeQuestion(currentQuestion.id)} className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}>
-                                    <Volume2 className={`w-3.5 h-3.5 mr-1.5 ${isReading ? 'animate-pulse' : ''}`} />
-                                    {isReading ? '읽는 중...' : '질문 읽기'}
-                                </button>
-                                <button onClick={() => completeQuestion(currentQuestion.id)} className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0]">답변 완료</button>
-                            </div>
-                        </div>
-                    ) : null}
 
                     {/* [2] 비디오 화면 영역 (조건부 렌더링 {currentQuestion &&} 제거) */}
                     <div className="w-full aspect-[16/9] bg-[#1A1A1A] rounded-2xl relative overflow-hidden flex flex-col justify-between shadow-2xl border border-gray-800 shrink-0">

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -95,9 +95,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
 
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } = useWebRtcSession(webRtcConfig);
 
-    const currentQuestion = questions[currentIdx];
-
-    // [질문 목록 로드]
+// [질문 목록 로드 - 초기 DB 데이터 반영]
     useEffect(() => {
         const fetchQuestions = async () => {
             if (!mentoringId) return;
@@ -107,13 +105,14 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                     params: { status: "BEFORE" }
                 });
                 if (response.data?.questions) {
-                    // API 응답에서 필요한 필드만 추출하여 Question 타입으로 변환
+                    // 팀원의 API 응답 데이터를 본인의 데이터 구조(type, avatar 등)와 호환되도록 매핑
                     const mappedQuestions = response.data.questions.map((q: any) => ({
                         id: q.questionId,
-                        isPaid: q.isPaid || false,
+                        type: q.isPaid ? "paid" : "free",
+                        isPaid: q.isPaid || false, // 💡 [추가 1] 타입스크립트 에러 해결
                         isPrivate: q.isPrivate || false,
                         author: q.user?.nickname || "익명멘티",
-                        avatar: "👤",
+                        avatar: q.isPaid ? "💎" : "👤",
                         content: q.content,
                     }));
                     setQuestions(mappedQuestions);
@@ -128,14 +127,49 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         fetchQuestions();
     }, [mentoringId]);
 
-    // 질문 목록(questions)의 길이가 줄어들 때 인덱스를 안전하게 가리키도록 동기화
+    // 💡 [하이브리드 큐 생성] DB의 기존 질문들과 실시간 채팅창의 질문들을 중복 없이 결합합니다.
+    const questionQueue = useMemo(() => {
+        // 1. 실시간 채팅 목록에서 질문들만 필터링하여 매핑
+        const chatQuestions = chats
+            .filter((chat) => chat.isQuestion || chat.type === 'paid')
+            .map((chat) => ({
+                id: chat.questionId || chat.id,
+                type: chat.type,
+                isPaid: chat.type === 'paid', // 💡 [추가 2] 타입스크립트 에러 해결
+                isPrivate: chat.isPrivate || false,
+                author: chat.author,
+                avatar: chat.type === 'paid' ? "💎" : "👤",
+                content: chat.content
+            }));
+
+        // 2. 초기 DB 질문 리스트(questions)를 기반으로 두고, 실시간 질문 중 중복되지 않은 것만 큐에 추가
+        const unified = [...questions];
+        chatQuestions.forEach((cq) => {
+            const isDuplicate = unified.some((q) => String(q.id) === String(cq.id));
+            if (!isDuplicate) {
+                unified.push(cq);
+            }
+        });
+
+        return unified;
+    }, [questions, chats]);
+
+    // 현재 인덱스에 해당하는 질문 가져오기 (결합된 완성형 큐 사용)
+    const currentQuestion = questionQueue[currentIdx];
+
+    // 질문 목록(questionQueue)의 길이가 줄어들거나 변경될 때 인덱스를 안전하게 가리키도록 동기화
     useEffect(() => {
-        if (questions.length === 0) {
+        if (questionQueue.length === 0) {
             setCurrentIdx(0);
-        } else if (currentIdx >= questions.length) {
-            setCurrentIdx(questions.length - 1);
+        } else if (currentIdx >= questionQueue.length) {
+            setCurrentIdx(questionQueue.length - 1);
         }
-    }, [questions.length, currentIdx]);
+    }, [questionQueue.length, currentIdx]);
+
+    // page.tsx의 컴포넌트 내부 적절한 위치에 추가해서 로그를 확인해보세요.
+    useEffect(() => {
+        console.log("현재 들어온 전체 채팅 목록:", chats);
+    }, [chats]);
 
     // [채팅 소켓 설정]
     useEffect(() => {
@@ -247,10 +281,13 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         }
     }, [chats, isChatOpen]);
 
+    // 💡 [수정 2] 다음 질문/답변 완료 버튼 로직 수정
     const handleNextQuestion = () => {
-        if (questions.length === 0) return;
-        setCurrentIdx((prev) => (prev + 1) % questions.length);
-        setIsReading(false);
+    // 💡 실시간 하이브리드 큐(questionQueue)의 범위를 벗어나지 않도록 안전하게 인덱스 증가
+        if (currentIdx < questionQueue.length) {
+            setCurrentIdx((prev) => prev + 1); // 인덱스를 올려 다음 질문으로 이동 (끝에 도달 시 빈 카드 노출)
+            setIsReading(false); // 새로운 질문을 읽기 위해 기존 읽기 상태 초기화
+        }
     };
 
     const acknowledgeQuestion = async (questionId: number) => {
@@ -334,6 +371,48 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
             <div className="flex-1 flex flex-col px-4 overflow-hidden relative">
                 {/* 상단 영역: 질문 카드 + 비디오 화면 */}
                 <div className={`flex flex-col transition-all duration-500 ${!isChatOpen ? 'flex-1 justify-center' : 'justify-start pt-2'}`}>
+                    
+                    {/* 질문 카드 영역 */}
+                    {currentQuestion ? (
+                        <div className={`w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-xl flex justify-between gap-4 transition-all duration-300 ${currentQuestion?.isPaid ? 'bg-[#FFCC00] text-[#1A1A1A]' : 'bg-[#F0F0F0] text-[#1A1A1A]'}`}>
+                            <div className="flex flex-col gap-3 flex-1">
+                                <div className="flex items-center justify-between w-full">
+                                    <div className="flex items-center gap-2">
+                                        <div className="w-8 h-8 bg-black/10 rounded-full flex items-center justify-center text-sm">
+                                            {currentQuestion?.avatar}
+                                        </div>
+                                        <span className="font-bold text-[14px]">{currentQuestion?.author}</span>
+                                        {/* 질문 순서 표시 */}
+                                        <span className="text-[11px] font-bold bg-black/5 px-2 py-1 rounded-md ml-1">
+                                            {currentIdx + 1} / {questionQueue.length}
+                                        </span>
+                                    </div>
+                                    {currentQuestion?.isPrivate && (
+                                        <div className="flex items-center gap-1 bg-red-600 text-white text-[10px] font-extrabold px-2 py-1 rounded-lg">
+                                            <Lock className="w-3 h-3" strokeWidth={3} /> 비공개 질문
+                                        </div>
+                                    )}
+                                </div>
+                                <p className="font-extrabold text-[16px] leading-snug">{currentQuestion?.content}</p>
+                            </div>
+                            <div className="flex flex-col gap-2 shrink-0 justify-center">
+                                <button onClick={() => setIsReading(true)} className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}>
+                                    <Volume2 className={`w-3.5 h-3.5 mr-1.5 ${isReading ? 'animate-pulse' : ''}`} />
+                                    {isReading ? '읽는 중...' : '질문 읽기'}
+                                </button>
+                                <button onClick={handleNextQuestion} className="px-3 py-2.5 rounded-xl text-[12px] font-bold bg-[#E0E0E0] hover:bg-[#D0D0D0] text-gray-700">
+                                    답변 완료
+                                </button>
+                            </div>
+                        </div>
+                    ) : (
+                        // 대기 중인 질문이 없을 때의 빈 상태(Empty State) UI
+                        <div className="w-full rounded-[24px] p-5 mb-4 shrink-0 shadow-sm border border-gray-800 bg-[#1A1A1A] text-gray-400 flex flex-col items-center justify-center min-h-[120px]">
+                            <MessageSquare className="w-6 h-6 mb-2 opacity-50" />
+                            <p className="text-sm font-medium">현재 대기 중인 질문이 없습니다.</p>
+                            <p className="text-xs text-gray-500 mt-1">채팅창에 올라온 질문이 이곳에 표시됩니다.</p>
+                        </div>
+                    )}
 
                     {/* [1] 질문 카드 영역 */}
                     {isLoadingQuestions ? (
@@ -384,12 +463,10 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
 
                         {/* 비디오 내부 상단 뱃지 (질문이 있을 때만 노출) */}
                         <div className="relative w-full flex justify-center pt-4 z-10">
-                            {currentQuestion ? (
+                            {/* 현재 질문이 있을 때만 뱃지 렌더링 */}
+                            {currentQuestion && (
                                 <div className={`text-[11px] font-bold px-4 py-1.5 rounded-full ${currentQuestion.isPrivate ? 'bg-red-600 text-white' : 'bg-[#FFCC00] text-[#1A1A1A]'}`}>
                                     {currentQuestion.isPrivate ? "비공개 질문 답변중" : "공개 질문 답변중"}
-                                </div>
-                            ) : (
-                                <div>
                                 </div>
                             )}
                         </div>

--- a/services/chat-service/src/socket/socketHandler.js
+++ b/services/chat-service/src/socket/socketHandler.js
@@ -3,6 +3,7 @@ import {
     getMentoringStatus,
     verifyChatJoinAccess,
 } from '../database/chatRepository.js';
+import axios from "axios";
 
 const activeConnections = new Map(); // userId(string) -> Set<socketId>
 const socketStates = new Map(); // socketId -> { userId, userName, mentoringId }
@@ -263,14 +264,45 @@ export async function handleConnection(socket, io) {
                 return;
             }
 
-            // 데이터베이스에 메시지 저장
-            const chatMessage = await saveChatMessage({
-                mentoringId: BigInt(state.mentoringId),
-                userId: BigInt(state.userId),
-                content,
+            // 1. Question Service(4003) 호출하여 질문 여부 판별
+            let isQuestion = false;
+            try {
+                const QUESTION_API_URL = process.env.QUESTION_SERVICE_URL || 'http://localhost:4003';
+                const mlResponse = await axios.post(`${QUESTION_API_URL}/api/question-detection/predict`, {
+                    text: content
+                });
+                const result = mlResponse.data;
+                isQuestion = result.prediction === 'question' || result.is_question === true || result.isQuestion === true;
+            } catch (mlError) {
+                console.error('⚠️ [Question Detector] ML API 에러:', mlError.message);
+            }
+
+            // 2. 무조건 MentoringChat 테이블에 채팅 내역 저장
+            const chatMessage = await prisma.mentoringChat.create({
+                data: {
+                    mentoringId: BigInt(state.mentoringId),
+                    userId: BigInt(state.userId),
+                    content: content
+                }
             });
 
-            // 실시간 브로드캐스트
+            // 💡 3. [핵심] 질문으로 판별되었다면 Question 테이블에도 복사본 생성!
+            let savedQuestion = null;
+            if (isQuestion) {
+                savedQuestion = await prisma.question.create({
+                    data: {
+                        content: content,
+                        isPaid: false,      // 채팅방 기본 질문이므로 무료(false)로 설정
+                        isPrivate: false,   // 공개 채팅방이므로 공개(false)로 설정
+                        userId: BigInt(state.userId),
+                        mentoringId: BigInt(state.mentoringId),
+                        // priorityScore(0), status(BEFORE), createdAt(now)는 schema.prisma의 @default 값 자동 적용
+                    }
+                });
+                console.log(`✅ [Question Saved] 질문 테이블 등록 완료 (ID: ${savedQuestion.questionId})`);
+            }
+
+            // 4. 실시간 브로드캐스트 (프론트엔드로 전송)
             io.to(roomName).emit('new_message', {
                 mentoringChatId: chatMessage.mentoringChatId.toString(),
                 mentoringId: chatMessage.mentoringId.toString(),
@@ -278,6 +310,8 @@ export async function handleConnection(socket, io) {
                 userName: state.userName,
                 content,
                 createdAt: chatMessage.createdAt,
+                isQuestion: isQuestion, // 프론트엔드 UI용
+                questionId: savedQuestion ? savedQuestion.questionId.toString() : null // 추후 질문 패널 연동용
             });
         } catch (error) {
             console.error('Error in send_message:', error);
@@ -305,27 +339,55 @@ export async function handleConnection(socket, io) {
                 return;
             }
 
-            // Prisma에서 메시지 히스토리 조회
-            const messages = await global.prisma.mentoringChat.findMany({
-                where: { mentoringId: BigInt(state.mentoringId) },
-                include: {
-                    user: {
-                        select: { userId: true, nickname: true },
+            const targetMentoringId = BigInt(state.mentoringId);
+
+            // 💡 [동적 매핑 1단계] 두 테이블을 동시에 병렬(Promise.all) 조회하여 성능 최적화
+            const [messages, questions] = await Promise.all([
+                // Prisma에서 메시지 히스토리 조회
+                global.prisma.mentoringChat.findMany({
+                    where: { mentoringId: targetMentoringId },
+                    include: {
+                        user: {
+                            select: { userId: true, nickname: true },
+                        },
                     },
-                },
-                orderBy: { createdAt: 'asc' },
-                take: limit,
-                skip: offset,
+                    orderBy: { createdAt: 'asc' },
+                    take: limit,
+                    skip: offset,
+                }),
+                // 동일한 멘토링 방의 질문 테이블 조회 (질문 여부 체크용)
+                global.prisma.question.findMany({
+                    where: { mentoringId: targetMentoringId },
+                    select: { questionId: true, content: true, userId: true }
+                })
+            ]);
+
+            // 💡 [동적 매핑 2단계] 빠른 비교를 위해 질문 데이터를 고유 키(작성자ID + 내용) 형태의 Map으로 변환
+            const questionLookupMap = new Map();
+            questions.forEach((q) => {
+                const lookupKey = `${q.userId.toString()}_${q.content.trim()}`;
+                questionLookupMap.set(lookupKey, q.questionId.toString());
             });
 
-            const formattedMessages = messages.map((msg) => ({
-                mentoringChatId: msg.mentoringChatId.toString(),
-                mentoringId: msg.mentoringId.toString(),
-                userId: msg.userId.toString(),
-                userName: msg.user.nickname,
-                content: msg.content,
-                createdAt: msg.createdAt,
-            }));
+            // 💡 [동적 매핑 3단계] 채팅 히스토리에 질문 데이터가 매칭되는지 확인 후 결과 조립
+            const formattedMessages = messages.map((msg) => {
+                const messageKey = `${msg.userId.toString()}_${msg.content.trim()}`;
+                
+                // Map에 해당 key가 존재한다면 질문 테이블에 등록된 데이터임
+                const matchedQuestionId = questionLookupMap.get(messageKey) || null;
+                const isQuestion = matchedQuestionId !== null;
+
+                return {
+                    mentoringChatId: msg.mentoringChatId.toString(),
+                    mentoringId: msg.mentoringId.toString(),
+                    userId: msg.userId.toString(),
+                    userName: msg.user.nickname,
+                    content: msg.content,
+                    createdAt: msg.createdAt,
+                    isQuestion: isQuestion,               // ⬅️ 프론트엔드 실시간 UI 하이라이트용 고유 플래그
+                    questionId: matchedQuestionId,       // ⬅️ 추후 확장될 질문 관리 및 모아보기 연동용 ID
+                };
+            });
 
             socket.emit('message_history', formattedMessages);
         } catch (error) {

--- a/services/core-api/src/routes/mentorings.js
+++ b/services/core-api/src/routes/mentorings.js
@@ -184,12 +184,6 @@ router.get('/:id/questions', requireUser, async (req, res, next) => {
                         nickname: true,
                     },
                 },
-                answerer: {
-                    select: {
-                        userId: true,
-                        nickname: true,
-                    },
-                },
             },
             orderBy: [
                 { createdAt: 'asc' },

--- a/services/core-api/src/routes/mentorings.js
+++ b/services/core-api/src/routes/mentorings.js
@@ -184,6 +184,12 @@ router.get('/:id/questions', requireUser, async (req, res, next) => {
                         nickname: true,
                     },
                 },
+                answerer: {
+                    select: {
+                        userId: true,
+                        nickname: true,
+                    },
+                },
             },
             orderBy: [
                 { createdAt: 'asc' },


### PR DESCRIPTION
## 연관된 이슈

#109 

## 작업 내용

- question-service의 질문 탐지(question detection) API와 프론트엔드 연결.
- 멘티 화면에 질문 답변 중(status: ANSWERING) 동안에만 렌더링되는 질문 카드 추가.
  - 비공개 질문은 렌더링 X, 공개 질문만 질문 카드에 표시됨.
  - 비공개/공개 질문 여부에 따라 비디오 영역 상단에 "비공개/공개 질문 답변 중" 배지 렌더링
- 유료 질문을 우선 표시하는 questionQueue 로직 설정.


## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

- 작업 내용들이 잘 실행되는지 확인 부탁드립니다.