### PR TITLE
[stt-service] stt(스크립트 생성) API 프론트엔드 연동

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -9,12 +9,14 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
   const router = useRouter();
   const { id } = use(params);
   const contentRef = useRef<HTMLDivElement>(null);
+  const [scriptList, setScriptList] = useState<any[]>([]);
 
   // API 연동 상태 관리
   const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  // 1. 초기 데이터 페치 (상태값 보관 역할)
   useEffect(() => {
     const fetchScriptData = async () => {
       setIsLoading(true);
@@ -22,7 +24,6 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
         const res = await apiClient.get(`/api/scripts/${id}`);
         const { mentoring, scripts } = res.data;
 
-        // 방어 로직이 적용된 날짜 포맷 변환
         const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
         const dateStr = d 
           ? `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`
@@ -33,51 +34,9 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
           date: dateStr,
         });
 
-        if (contentRef.current) {
-          const htmlContent = scripts.map((s: any) => {
-            const speakerName = s.speaker?.nickname || "알 수 없음";
-            const isMentor = s.speaker?.isHostMentor;
+        // DOM을 직접 찌르지 않고 React 상태에 데이터를 안전하게 기록합니다.
+        setScriptList(scripts || []);
 
-            // timestamp 출력 (존재할 경우)
-            const timestamp = s.content?.timestamp 
-              ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none">${s.content.timestamp}</span>` 
-              : "";
-
-            let textHTML = "";
-
-            // [1. 비공개 처리] 백엔드에서 내려준 비공개 메시지 출력
-            if (s.content?.isPrivate || s.isPrivate) {
-              textHTML = s.content?.text || "비공개 질문입니다.";
-              return `<div class="mb-4 text-gray-400 italic">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
-            }
-
-            // [2. 부분 마스킹 배열(pieces) 처리]
-            if (s.content?.pieces && Array.isArray(s.content.pieces)) {
-              textHTML = s.content.pieces.map((piece: any) => {
-                // 백엔드에서 치환된 텍스트('마스킹된 부분입니다.')를 노란색 span으로 감싸기
-                if (piece.isMasked) {
-                  return `<span style="background-color: #FFCC00">${piece.text || "마스킹된 부분입니다."}</span>`;
-                }
-                return piece.text || "";
-              }).join('');
-            } 
-            // [3. 통문장 마스킹 또는 구버전 데이터(message) 호환 처리]
-            else {
-              textHTML = s.content?.text || s.content?.message || "";
-              if (s.masked || s.isMasked || s.content?.isMasked) {
-                textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
-              }
-            }
-
-            // 발화자 구분 가독성을 위해 이름 색상 다르게 지정
-            const nameColor = isMentor ? "#D97706" : "#2563EB"; 
-
-            return `<div class="mb-4"><b style="color: ${nameColor};">[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
-          }).join('');
-
-          // 스크립트 데이터가 비어있을 경우 방어 코드
-          contentRef.current.innerHTML = htmlContent || "<p class='text-gray-400 text-sm'>대화 내용이 없습니다.</p>";
-        }
       } catch (err) {
         console.error("스크립트 열람 실패:", err);
         setError("스크립트를 불러오는 중 오류가 발생했습니다.");
@@ -90,6 +49,46 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
       fetchScriptData();
     }
   }, [id]);
+
+  // 2. 로딩이 종료되어 contentRef가 확실하게 DOM에 로드된 타이밍에 HTML 주입
+  useEffect(() => {
+    if (!isLoading && contentRef.current && scriptList.length > 0) {
+      const htmlContent = scriptList.map((s: any) => {
+        const timestamp = s.content?.timestamp 
+          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none">${s.content.timestamp}</span>` 
+          : "";
+
+        let textHTML = "";
+
+        // 비공개 처리 분기
+        if (s.content?.isPrivate || s.isPrivate) {
+          const privateText = s.content?.text || "비공개 질문입니다.";
+          return `<div class="text-gray-400 italic">🔒 <span>${privateText}</span>${timestamp}</div>`;
+        }
+
+        // 부분 마스킹 배열(pieces) 처리
+        if (s.content?.pieces && Array.isArray(s.content.pieces)) {
+          textHTML = s.content.pieces.map((piece: any) => {
+            if (piece.isMasked) {
+              return `<span style="background-color: #FFCC00">${piece.text || "마스킹된 부분입니다."}</span>`;
+            }
+            return piece.text || "";
+          }).join('');
+        } 
+        // 통문장 마스킹 처리
+        else {
+          textHTML = s.content?.text || s.content?.message || "";
+          if (s.masked || s.isMasked || s.content?.isMasked) {
+            textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+          }
+        }
+
+        return `<div><span>${textHTML}</span>${timestamp}</div>`;
+      }).join('');
+
+      contentRef.current.innerHTML = htmlContent;
+    }
+  }, [isLoading, scriptList]);
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -19,7 +19,7 @@ interface Question {
     content: string;
     status?: string;
     answerer?: { userId: number; nickname: string } | null;
-    clusterSize?: number; // 💡 추가: 묶인 질문의 개수
+    clusterSize?: number;
 }
 
 interface ChatMessage {
@@ -29,6 +29,13 @@ interface ChatMessage {
     content: string;
     isQuestion?: boolean;
     questionId?: string | null;
+}
+
+// STT 스크립트 반환 규격 인터페이스
+interface STTScript {
+    scriptId: string;
+    chunkIndex: number;
+    text: string;
 }
 
 // 1. 게이트웨이 컴포넌트: 정보가 준비될 때까지 로딩만 보여줌
@@ -82,12 +89,15 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
     const [questions, setQuestions] = useState<Question[]>([]);
     const [isLoadingQuestions, setIsLoadingQuestions] = useState(false);
     const [completedIds, setCompletedIds] = useState<number[]>([]);
-
-    // 💡 [추가] 클러스터링된 결과를 저장할 상태
     const [clusters, setClusters] = useState<any[]>([]);
     const [isClustering, setIsClustering] = useState(false);
 
-    // 이제 이 훅들은 컴포넌트가 마운트될 때 단 한 번, 올바른 userId로 실행됩니다.
+    // 실시간 텍스트 변환 내역들을 누적 보관할 런타임 상태
+    const [scriptSegments, setScriptSegments] = useState<STTScript[]>([]);
+    const chunkIndexRef = useRef<number>(0);
+    const recorderIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+    // 훅들은 컴포넌트가 마운트될 때 단 한 번, 올바른 userId로 실행됩니다.
     const mentoringOptions = useMemo(() => ({ role, userId }), [role, userId]);
     const { sessionData, isConnected, peerId, socket, endMentoring, isLoading, error } = useMentoringSession(mentoringOptions);
 
@@ -100,7 +110,124 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         isJoined: isConnected
     }), [socket, sessionData?.mentoringId, mentoringId, peerId]);
 
+    // useWebRtcSession에서 localStream과 마이크 상태 가져오기
     const { localStream, isCameraOn, isMicOn, setCameraOn, setMicOn, error: webRtcError } = useWebRtcSession(webRtcConfig);
+
+    // [STT 모니터링 강화] 하드웨어 오디오 스트림 추적 및 전송 로그 추가 파이프라인
+    useEffect(() => {
+        if (!localStream) {
+            console.warn("[🎙️ STT 모니터링] localStream이 존재하지 않아 대기 중입니다.");
+            return;
+        }
+        if (!isMicOn) {
+            console.log("[🎙️ STT 모니터링] 현재 멘토 마이크가 '음소거(Mic Off)' 상태입니다. 수집을 일시 중단합니다.");
+            return;
+        }
+        if (!userId || !mentoringId) {
+            console.warn("[🎙️ STT 모니터링] 인증 정보(userId, mentoringId)가 누락되었습니다.");
+            return;
+        }
+
+        const audioTracks = localStream.getAudioTracks();
+        if (audioTracks.length === 0) {
+            console.error("[🚨 STT 에러] 스트림 내에서 활성화된 마이크(Audio Track)를 찾을 수 없습니다 하드웨어를 확인하세요.");
+            return;
+        }
+
+        // 1. 마이크 활성화 상태 로그 파싱
+        const activeTrack = audioTracks[0];
+        console.log(`[✅ 마이크 인식 성공] 장치명: "${activeTrack.label}" | 상태: ${activeTrack.enabled ? "활성" : "비활성"}`);
+
+        const audioStream = new MediaStream(audioTracks);
+        const mediaRecorder = new MediaRecorder(audioStream, {
+            mimeType: "audio/webm;codecs=opus", 
+        });
+
+        mediaRecorder.onstart = () => {
+            console.log(`[🚀 레코더 시작] 청크 인덱스 [${chunkIndexRef.current}] 오디오 데이터 수집을 시작합니다.`);
+        };
+
+        mediaRecorder.ondataavailable = async (event) => {
+            // 2. 음성 데이터 추출 성공 로그
+            if (event.data && event.data.size > 0) {
+                const audioBlob = event.data;
+                const currentIndex = chunkIndexRef.current;
+                chunkIndexRef.current += 1;
+
+                console.log(`[📦 청크 패킹 완료] 인덱스: ${currentIndex} | 용량: ${(audioBlob.size / 1024).toFixed(2)} KB | 포맷: ${audioBlob.type}`);
+
+                const formData = new FormData();
+                formData.append("audio", audioBlob, `chunk_${currentIndex}.webm`);
+                formData.append("userId", String(userId));
+                formData.append("mentoringId", String(mentoringId));
+                formData.append("chunkIndex", String(currentIndex));
+
+                console.log(`[📡 전송 시도] stt-service(4004)로 청크 [${currentIndex}] 데이터 업로드를 시작합니다...`);
+                const startTime = performance.now(); // 네트워크 지연시간 계산용
+
+                try {
+                    const STT_SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4004"
+                    const response = await fetch(`${STT_SERVER_URL}/audio/stt/chunk`, {
+                        method: "POST",
+                        body: formData, 
+                    });
+
+                    const endTime = performance.now();
+                    const duration = ((endTime - startTime) / 1000).toFixed(2);
+
+                    // 3. 서버 도달 및 처리 완료 로그
+                    if (response.ok) {
+                        const data = await response.json();
+                        console.log(`[🎉 전송 및 STT 대성공] 청크 [${currentIndex}] 처리 완료 (${duration}초 소요)`);
+                        
+                        // 백엔드 stt.js 반환 스펙(data.text)에 맞추어 조건식과 데이터 구조 전면 교정
+                        if (data && typeof data.text === 'string' && data.text.trim() !== "") {
+                            console.log(`[📝 AI Whisper 변환 결과]: "${data.text}"`);
+                            
+                            // 하단 오버레이 자막 및 타임라인 배열 업데이트
+                            const newSegment: STTScript = {
+                                scriptId: data.scriptId || String(Date.now()),
+                                chunkIndex: currentIndex,
+                                text: data.text
+                            };
+
+                            setScriptSegments((prev) => {
+                                // 기존에 이미 존재하는 인덱스는 제외하고 순서대로 정렬 결합
+                                const filtered = prev.filter(p => p.chunkIndex !== currentIndex);
+                                return [...filtered, newSegment].sort((a, b) => a.chunkIndex - b.chunkIndex);
+                            });
+                        } else {
+                            console.log(`[🔇 음성 공백] 청크 [${currentIndex}] 구간에 인식된 발화(텍스트)가 없습니다.`);
+                        }
+                    } else {
+                        console.error(`[❌ 서버 처리 에러] 청크 [${currentIndex}] 전송은 되었으나 서버가 에러를 응답했습니다. 상태코드: ${response.status}`);
+                    }
+                } catch (error) {
+                    console.error(`[🚨 네트워크 통신 실패] 청크 [${currentIndex}]가 백엔드 서버(4004)에 도달하지 못했습니다. 서버가 켜져 있는지 확인하세요.`, error);
+                }
+            } else {
+                console.warn(`[⚠️ 데이터 유실 경고] 청크 [${chunkIndexRef.current}] 데이터 이벤트가 트리거되었으나 오디오 크기가 0바이트입니다.`);
+            }
+        };
+
+        mediaRecorder.start();
+
+        recorderIntervalRef.current = setInterval(() => {
+            if (mediaRecorder.state === "recording") {
+                console.log(`[⏱️ 15초 인터벌 도달] 현재 녹음 세션을 끊고 청크 [${chunkIndexRef.current}] 전송 프로세스를 유도합니다.`);
+                mediaRecorder.stop(); 
+                mediaRecorder.start();
+            }
+        }, 15000);
+
+        return () => {
+            console.log("[🔌 수집기 종료] 마이크 상태 변경 또는 컴포넌트 언마운트로 인해 오디오 리스너를 해제합니다.");
+            if (recorderIntervalRef.current) clearInterval(recorderIntervalRef.current);
+            if (mediaRecorder && mediaRecorder.state !== "inactive") {
+                mediaRecorder.stop();
+            }
+        };
+    }, [localStream, isMicOn, userId, mentoringId]);
 
     // [질문 목록 로드 - 초기 DB 데이터 반영]
     useEffect(() => {
@@ -135,13 +262,19 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         fetchQuestions();
     }, [mentoringId]);
 
-    // 💡 [추가] 완료되지 않은(활성화된) 질문들만 추출
+    // 완료되지 않은(활성화된) 질문들만 추출
     const activeQuestions = useMemo(() => {
         const completedStringIds = completedIds.map(id => String(id));
         return questions.filter(q => !completedStringIds.includes(String(q.id)));
     }, [questions, completedIds]);
 
-    // 💡 [추가] 활성화된 질문이 바뀔 때마다 클러스터링 API 호출 (1초 디바운스 적용)
+    // [STT 추가] 화면 하단 레이어에 바로 띄워줄 가장 최신의 라이브 자막 데이터 추출
+    const latestSubtitle = useMemo(() => {
+        if (scriptSegments.length === 0) return "";
+        return scriptSegments[scriptSegments.length - 1].text;
+    }, [scriptSegments]);
+
+    // 활성화된 질문이 바뀔 때마다 클러스터링 API 호출 (1초 디바운스 적용)
     useEffect(() => {
         if (activeQuestions.length === 0) {
             setClusters([]);
@@ -169,10 +302,6 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
 
                 if (response.ok) {
                     const data = await response.json();
-
-                    // 🚨 이 로그를 반드시 확인해보세요!
-                    console.log("🤖 AI 클러스터링 결과:", data.clusters);
-                    
                     setClusters(data.clusters || []);
                 }
             } catch (error) {
@@ -185,8 +314,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         return () => clearTimeout(timer);
     }, [activeQuestions]);
 
-    // [질문 큐 생성] 검증된 questions 상태(DB + 질문 소켓 이벤트)만 사용하여 정렬.
-    // 💡 [수정] 클러스터링 결과를 바탕으로 큐를 생성합니다.
+    // [질문 큐 생성] 검증된 questions 상태 및 클러스터링 결과를 바탕으로 큐를 생성합니다.
     const questionQueue = useMemo(() => {
         // 아직 클러스터링이 완료되지 않았거나 에러가 났다면 원본을 임시로 보여줍니다.
         if (clusters.length === 0 && activeQuestions.length > 0) {
@@ -616,6 +744,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                 {/* [3] 채팅 영역 (isChatOpen이 true일 때만 렌더링되도록 조건부 처리 추가) */}
                 {isChatOpen && (
                     <div className="flex-1 flex flex-col mt-4 animate-in fade-in slide-in-from-bottom-8 duration-500 overflow-hidden">
+                        
                         <div className="flex-1 overflow-y-auto space-y-4 custom-scrollbar pb-6 pr-2">
 
                             {/* 유료 질문을 제외한 순수 채팅 개수만 체크 */}

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -21,75 +21,96 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
   const [isLoading, setIsLoading] = useState(true);
   const [isPublishing, setIsPublishing] = useState(false);
 
+  const [scriptList, setScriptList] = useState<any[]>([]);
   const editorRef = useRef<HTMLDivElement>(null);
+
+  // 선언 전에 사용 오류(ts2448)를 방지하기 위해 updateUndoState 함수를 useEffect 위로 이동합니다.
+  const updateUndoState = () => {
+    if (typeof window === "undefined") return;
+    const historyStr = sessionStorage.getItem(`script_history_${id}`);
+    if (!historyStr) {
+      setCanUndo(false);
+      return;
+    }
+    try {
+      const history = JSON.parse(historyStr);
+      setCanUndo(history.length > 0);
+    } catch {
+      setCanUndo(false);
+    }
+  };
 
   // 1. 초기 데이터 로드
   useEffect(() => {
     const fetchScriptData = async () => {
       setIsLoading(true);
       try {
-        const res = await apiClient.get(`/api/scripts/${id}`);
-        const { mentoring, scripts } = res.data;
+        const STT_SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4004";
+        const res = await fetch(`${STT_SERVER_URL}/audio/stt/mentoring/${id}`);
+        
+        if (!res.ok) throw new Error(`STT 서비스 응답 실패: ${res.status}`);
+        const resultData = await res.json();
+        
+        const mentoring = resultData?.mentoring;
+        const scripts = resultData?.scripts || [];
 
-        const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
+        const d = mentoring?.startedAt ? new Date(mentoring.startedAt) : null;
         const dateStr = d 
           ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
           : "날짜 정보 없음";
 
-        setMentoringInfo({ title: mentoring.title, date: dateStr });
+        setMentoringInfo({ title: mentoring?.title || "라이브 멘토링 스크립트", date: dateStr });
+        
+        // DOM에 직접 꽂는 대신 안전하게 React 상태에 담아둡니다.
+        setScriptList(scripts);
 
-        if (editorRef.current) {
-          const htmlContent = scripts.map((s: any) => {
-            const scriptId = s.scriptId;
-            const speakerName = s.speaker?.nickname || "알 수 없음";
-            const isMentor = s.speaker?.isHostMentor;
-            
-            const timestamp = s.content?.timestamp 
-              ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none" contenteditable="false">${s.content.timestamp}</span>` 
-              : "";
-
-            let textHTML = "";
-
-            if (s.content?.isPrivate || s.isPrivate) {
-              textHTML = s.content?.text || "비공개 질문입니다.";
-              return `<div class="mb-4 text-gray-400 italic" contenteditable="false">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">${textHTML}</span></div>`;
-            }
-
-            if (s.content?.pieces && Array.isArray(s.content.pieces)) {
-              textHTML = s.content.pieces.map((piece: any) => {
-                const escapedText = (piece.text || "").replace(/\n/g, "<br>");
-                if (piece.isMasked) {
-                  return `<span style="background-color: #FFCC00">${escapedText}</span>`;
-                }
-                return escapedText;
-              }).join('');
-            } else {
-              textHTML = (s.content?.text || s.content?.message || "").replace(/\n/g, "<br>");
-              if (s.masked || s.isMasked || s.content?.isMasked) {
-                textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
-              }
-            }
-
-            const nameColor = isMentor ? "#D97706" : "#2563EB"; 
-
-            return `<div class="mb-4 script-block" data-script-id="${scriptId}">
-              <b style="color: ${nameColor};" contenteditable="false">[${speakerName}]</b>${timestamp}<br />
-              <span class="inline-block mt-0.5 script-content">${textHTML}</span>
-            </div>`;
-          }).join('');
-          
-          editorRef.current.innerHTML = htmlContent || "<p class='text-gray-400'>내용을 찾을 수 없습니다.</p>";
-        }
       } catch (error) {
-        console.error("데이터 로드 실패:", error);
+        console.error("🚨 에디터 데이터 로드 실패:", error);
       } finally {
         setIsLoading(false);
-        updateUndoState();
       }
     };
 
     if (id) fetchScriptData();
   }, [id]);
+
+  // 로딩이 끝나고 DOM(editorRef)이 생성된 타이밍을 포착해 데이터를 주입하는 렌더링
+  useEffect(() => {
+    if (!isLoading && editorRef.current && scriptList.length > 0) {
+      const htmlContent = scriptList.map((s: any) => {
+        const scriptId = s.scriptId || String(s.id);
+        const speakerName = s.user?.nickname || "알 수 없음";
+        const isMentor = s.user?.role === "MENTOR";
+        
+        const startTimeVal = s.content?.startTime;
+        const timestamp = startTimeVal !== null && startTimeVal !== undefined
+          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none" contenteditable="false">${parseFloat(startTimeVal).toFixed(1)}s</span>` 
+          : "";
+
+        const textContent = s.content?.text || s.text || String(s.content || "");
+
+        if (s.isPrivate === true || String(s.isPrivate) === "true") {
+          return `<div class="mb-4 text-gray-400 italic" contenteditable="false">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">비공개 구간 질문 및 답변입니다.</span></div>`;
+        }
+
+        let textHTML = textContent.replace(/\n/g, "<br>");
+        
+        if (s.isMasked === true || s.content?.isMasked === true) {
+          textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+        }
+
+        const nameColor = isMentor ? "#D97706" : "#2563EB"; 
+
+        return `<div class="mb-4 script-block" data-script-id="${scriptId}">
+          <b style="color: ${nameColor};" contenteditable="false">[${speakerName}]</b>${timestamp}<br />
+          <span class="inline-block mt-0.5 script-content">${textHTML}</span>
+        </div>`;
+      }).join('');
+
+      editorRef.current.innerHTML = htmlContent;
+      updateUndoState();
+    }
+  }, [isLoading, scriptList]);
 
   // 2. 스크립트 발행 (데이터 수집)
   const handlePublish = async () => {
@@ -180,7 +201,6 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     }
   };
 
-  const updateUndoState = () => setCanUndo(document.queryCommandEnabled('undo'));
   const applyMask = (color: string) => {
     if (editorRef.current) editorRef.current.focus();
     if (!document.execCommand('hiliteColor', false, color)) {

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -74,23 +74,24 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     if (id) fetchScriptData();
   }, [id]);
 
-  // 로딩이 끝나고 DOM(editorRef)이 생성된 타이밍을 포착해 데이터를 주입하는 렌더링
+  // 2. 렌더링 동기화 용 useEffect
   useEffect(() => {
     if (!isLoading && editorRef.current && scriptList.length > 0) {
       const htmlContent = scriptList.map((s: any) => {
         const scriptId = s.scriptId || String(s.id);
-        const speakerName = s.user?.nickname || "알 수 없음";
-        const isMentor = s.user?.role === "MENTOR";
         
+        // 타임스탬프 문장 뒤에 붙임.
         const startTimeVal = s.content?.startTime;
         const timestamp = startTimeVal !== null && startTimeVal !== undefined
           ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none" contenteditable="false">${parseFloat(startTimeVal).toFixed(1)}s</span>` 
           : "";
 
-        const textContent = s.content?.text || s.text || String(s.content || "");
+        const rawText = s.content?.text || s.text || String(s.content || "");
+        const textContent = rawText.trim(); 
 
+        // 비공개 라벨 처리 분기 (문장 끝에 타임스탬프 배치)
         if (s.isPrivate === true || String(s.isPrivate) === "true") {
-          return `<div class="mb-4 text-gray-400 italic" contenteditable="false">🔒 <b>[${speakerName}]</b>${timestamp}<br /><span class="inline-block mt-0.5">비공개 구간 질문 및 답변입니다.</span></div>`;
+          return `<div class="text-gray-400 italic script-block" data-script-id="${scriptId}" contenteditable="false"><span class="script-content">비공개 구간 질문 및 답변입니다.</span>${timestamp}</div>`;
         }
 
         let textHTML = textContent.replace(/\n/g, "<br>");
@@ -99,12 +100,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
         }
 
-        const nameColor = isMentor ? "#D97706" : "#2563EB"; 
-
-        return `<div class="mb-4 script-block" data-script-id="${scriptId}">
-          <b style="color: ${nameColor};" contenteditable="false">[${speakerName}]</b>${timestamp}<br />
-          <span class="inline-block mt-0.5 script-content">${textHTML}</span>
-        </div>`;
+        return `<div class="script-block" data-script-id="${scriptId}"><span class="script-content">${textHTML}</span>${timestamp}</div>`;
       }).join('');
 
       editorRef.current.innerHTML = htmlContent;

--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -163,6 +163,89 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
   }
 });
 
+// stt-service/routes/stt.js 내부의 GET 엔드포인트 수정
+router.get("/mentoring/:mentoringId", async (req, res) => {
+  try {
+    const { mentoringId } = req.params;
+    console.log(`[🔍 STT 조회 최종 가동] mentoringId: ${mentoringId}`);
+
+    // 1. 멘토링 정보 기본 조회
+    const mentoring = await prisma.mentoring.findUnique({
+      where: { mentoringId: BigInt(mentoringId) },
+    });
+
+    // 2. Script를 가져올 때 해당 스크립트를 말한 User 테이블 정보(nickname, role)를 직접 관계 조인(include)합니다.
+    const scripts = await prisma.script.findMany({
+      where: { mentoringId: BigInt(mentoringId) },
+      include: {
+        user: true // 데이터베이스 상의 실제 유저 정보를 그대로 가져옵니다.
+      },
+      orderBy: { scriptId: "asc" } 
+    });
+
+    console.log(`[📊 DB 조회 성공] 실제 데이터 ${scripts.length}개를 정규화 변환합니다.`);
+
+    // 3. 프론트엔드 page.tsx 완벽 호환 구조 변환
+    const serializedScripts = scripts.map(s => {
+      let textVal = "";
+      let startTimeVal = null;
+
+      // content 내장 JSON 오브젝트 안전 파싱
+      if (s.content && typeof s.content === 'object') {
+        textVal = s.content.text || "";
+        startTimeVal = s.content.startTime ?? s.content.timestamp ?? null;
+      } else if (typeof s.content === 'string') {
+        try {
+          const parsed = JSON.parse(s.content);
+          textVal = parsed.text || "";
+          startTimeVal = parsed.startTime ?? null;
+        } catch (e) {
+          textVal = s.content;
+        }
+      }
+
+      // DB에 실존하는 유저의 실제 nickname과 role을 추출하고, 없을 경우에만 예외 기본값을 부여합니다.
+      const realNickname = s.user?.nickname || "알 수 없음";
+      const realRole = s.user?.role || "MENTEE"; 
+
+      return {
+        scriptId: s.scriptId.toString(),
+        userId: s.userId.toString(),
+        mentoringId: s.mentoringId.toString(),
+        isPrivate: s.isPrivate || false,
+        isMasked: s.isMasked || false,
+        content: {
+          text: textVal,
+          startTime: startTimeVal,
+          chunkIndex: s.content?.chunkIndex || 0
+        },
+        // core-api 규격과 100% 일치하도록 user 객체 포맷 매핑
+        user: {
+          nickname: realNickname,
+          role: realRole // 이제 "MENTOR"가 정상적으로 전달됩니다.
+        }
+      };
+    });
+
+    return res.json({
+      success: true,
+      mentoring: {
+        mentoringId: mentoring ? mentoring.mentoringId.toString() : mentoringId,
+        title: mentoring?.title || "라이브 멘토링 스크립트",
+        startedAt: mentoring?.startedAt || new Date().toISOString()
+      },
+      scripts: serializedScripts
+    });
+
+  } catch (err) {
+    console.error("🚨 [STT 서비스 최종 핸들러 크래시]:", err);
+    return res.status(500).json({ 
+      success: false, 
+      error: err.message 
+    });
+  }
+});
+
 function detectCommand(text) {
   for (const cmd of COMMANDS) {
     if (cmd.keywords.every(k => text.includes(k)))


### PR DESCRIPTION
## 연관된 이슈

#127

## 작업 내용

- stt API와 프론트엔드를 연결하여 스크립트 생성 기능 구현
- 스크립트 편집, 스크립트 열람 뷰의 렌더링 수정

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

**리뷰 방법**
- 멘토링에 멘토로 접속하여 발화 후 멘토링 종료(COMPLETED)
- 마이페이지의 발행 전 스크립트를 클릭하여 편집 후 발행
- 발행된 스크립트 열람 화면에서 스크립트가 정상적으로 발행되었는지 확인