### PR TITLE
[stt-service] stt(스크립트 생성) API 프론트엔드(1:1 멘토링) 연동

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -12,7 +12,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
   const [scriptList, setScriptList] = useState<any[]>([]);
 
   // API 연동 상태 관리
-  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string } | null>(null);
+  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string; isGroup?: boolean } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -32,6 +32,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
         setMentoringInfo({
           title: mentoring.title,
           date: dateStr,
+          isGroup: mentoring.isGroup,
         });
 
         // DOM을 직접 찌르지 않고 React 상태에 데이터를 안전하게 기록합니다.
@@ -54,41 +55,82 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
   useEffect(() => {
     if (!isLoading && contentRef.current && scriptList.length > 0) {
       const htmlContent = scriptList.map((s: any) => {
-        const timestamp = s.content?.timestamp 
-          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none">${s.content.timestamp}</span>` 
+        
+        let parsedContent = s.content;
+        if (typeof parsedContent === 'string') {
+          try { parsedContent = JSON.parse(parsedContent); } 
+          catch { parsedContent = { text: parsedContent }; }
+        }
+
+        // 발행 데이터 구조 탐색.
+        const speakerName = s.speaker?.nickname || s.user?.nickname || s.speakerName || parsedContent?.speakerName;
+        const speakerRole = s.speaker?.role || s.user?.role || s.speakerRole || parsedContent?.speakerRole || "MENTEE";
+        
+        // startTime이 null일 경우를 대비해 createdAt(ISO 문자열)을 백업으로 사용합니다.
+        const rawTime = parsedContent?.startTime ?? s.startTime ?? parsedContent?.timestamp ?? s.timestamp ?? s.createdAt;
+
+        // 발화자(Speaker) 뱃지 렌더링
+        let speakerBadge = "";
+        if (mentoringInfo?.isGroup === false && speakerName) {
+          const isMentor = speakerRole === "MENTOR";
+          const roleColor = isMentor ? "text-[#FFCC00] bg-[#FFCC00]/10" : "text-blue-500 bg-blue-50";
+          const roleText = isMentor ? "멘토" : "멘티";
+          
+          speakerBadge = `<span class="text-[11px] font-bold ${roleColor} px-1.5 py-0.5 rounded ml-2 select-none inline-block align-middle">[${roleText}] ${speakerName}</span>`;
+        }
+
+        // 타임스탬프 렌더링
+        let timeString = "";
+        if (rawTime !== undefined && rawTime !== null) {
+          const numTime = Number(rawTime);
+          if (!isNaN(numTime)) {
+            if (numTime > 1000000000000) {
+              const date = new Date(numTime);
+              timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+            } else {
+              timeString = `${parseFloat(rawTime as string).toFixed(1)}s`;
+            }
+          } else if (typeof rawTime === 'string' && rawTime.includes('T')) {
+            // ISO 날짜 문자열(createdAt)인 경우 시:분:초 추출
+            const date = new Date(rawTime);
+            timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+          }
+        }
+        
+        const timestampBadge = timeString 
+          ? `<span class="text-[12px] text-amber-400 font-medium ml-2 select-none inline-block align-middle">${timeString}</span>` 
           : "";
+
+        // 비공개 및 마스킹 처리 후 최종 병합
+        if (parsedContent?.isPrivate || s.isPrivate) {
+          const privateText = parsedContent?.text || "비공개 질문입니다.";
+          return `<div class="mb-1.5 leading-relaxed text-gray-400 italic">🔒 <span>${privateText}</span>${speakerBadge}${timestampBadge}</div>`;
+        }
 
         let textHTML = "";
 
-        // 비공개 처리 분기
-        if (s.content?.isPrivate || s.isPrivate) {
-          const privateText = s.content?.text || "비공개 질문입니다.";
-          return `<div class="text-gray-400 italic">🔒 <span>${privateText}</span>${timestamp}</div>`;
-        }
-
-        // 부분 마스킹 배열(pieces) 처리
-        if (s.content?.pieces && Array.isArray(s.content.pieces)) {
-          textHTML = s.content.pieces.map((piece: any) => {
+        if (parsedContent?.pieces && Array.isArray(parsedContent.pieces)) {
+          textHTML = parsedContent.pieces.map((piece: any) => {
             if (piece.isMasked) {
               return `<span style="background-color: #FFCC00">${piece.text || "마스킹된 부분입니다."}</span>`;
             }
             return piece.text || "";
           }).join('');
-        } 
-        // 통문장 마스킹 처리
-        else {
-          textHTML = s.content?.text || s.content?.message || "";
-          if (s.masked || s.isMasked || s.content?.isMasked) {
+        } else {
+          textHTML = parsedContent?.text || parsedContent?.message || "";
+          if (s.masked || s.isMasked || parsedContent?.isMasked) {
             textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
           }
         }
 
-        return `<div><span>${textHTML}</span>${timestamp}</div>`;
+        textHTML = textHTML.replace(/\n/g, "<br>");
+
+        return `<div class="mb-1.5 leading-relaxed"><span>${textHTML}</span>${speakerBadge}${timestampBadge}</div>`;
       }).join('');
 
       contentRef.current.innerHTML = htmlContent;
     }
-  }, [isLoading, scriptList]);
+  }, [isLoading, scriptList, mentoringInfo]);
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">

--- a/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/1on1/[id]/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect, useMemo } from "react";
 import { Mic, MicOff, Volume2, VolumeX, Send, PhoneOff } from "lucide-react";
-import { io, Socket } from "socket.io-client"; // 💡 Socket.IO 추가
+import { io, Socket } from "socket.io-client";
 import { useMentoringSession } from "@/hooks/useMentoringSession";
 import { useWebRtcSession } from "@/hooks/useWebRtcSession";
 
@@ -12,12 +12,20 @@ interface ChatMessage {
   text: string;
 }
 
+// 음성 발화 데이터 관리 STT 인터페이스
+interface ScriptSegment {
+  scriptId: string;
+  chunkIndex: number;
+  text: string;
+  speakerName: string;
+  speakerRole: string;
+  timestamp: number;
+}
+
 export default function PrivateMentoringPage() {
   const [role, setRole] = useState<string>("MENTEE");
   const [userId, setUserId] = useState<number>(2);
-  const [userName, setUserName] = useState<string>("익명"); // 💡 유저 이름 상태 추가
-
-  // 💡 [추가] 상대방 닉네임을 담을 새로운 상태
+  const [userName, setUserName] = useState<string>("익명");
   const [opponentNickname, setOpponentNickname] = useState<string>("상대방 연결 대기 중...");
 
   const remoteAudioRef = useRef<HTMLAudioElement>(null);
@@ -28,10 +36,15 @@ export default function PrivateMentoringPage() {
   const [chatInput, setChatInput] = useState("");
   const [elapsedTime, setElapsedTime] = useState(0);
 
-  // 💡 실시간 채팅 상태
+  // 실시간 채팅 상태
   const [chatSocket, setChatSocket] = useState<Socket | null>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]); // 더미 데이터 제거
   const [isChatClosed, setIsChatClosed] = useState(false);
+
+  // 순수 음성 STT 스크립트 상태 배열
+  const [scriptSegments, setScriptSegments] = useState<ScriptSegment[]>([]);
+  const chunkIndexRef = useRef<number>(0);
+  const recorderIntervalRef = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     const storedRole = localStorage.getItem("userRole")?.toUpperCase();
@@ -48,20 +61,38 @@ export default function PrivateMentoringPage() {
   const { sessionData, isLoading, error, isConnected, peerId, socket, endMentoring } =
     useMentoringSession({ role, userId });
 
-  // 2. WebRTC 1:1 오디오 세션 연결
-  const { isMicOn, setMicOn, remoteStreams, isReady, error: webRtcError } =
-    useWebRtcSession({
-      socket,
-      mentoringId: sessionData?.mentoringId?.toString() || "",
-      peerId: peerId || "",
-      role,
-      mentoringType: "ONE_ON_ONE", // 💡 1:1 멘토링 타입 명시
-      isJoined: isConnected, // 💡 멘토링 세션에 실제로 연결된 상태를 WebRTC 훅에 전달
-    });
+  // 1:1 오디오 전용 방을 위한 비디오 트랙 에러 우회 처리
+  const webRtcArgs = useMemo(() => ({
+    socket,
+    mentoringId: sessionData?.mentoringId?.toString() || "",
+    peerId: peerId || "",
+    role,
+    mentoringType: "ONE_ON_ONE" as const, 
+    isJoined: isConnected, 
+  }), [socket, sessionData?.mentoringId, peerId, role, isConnected]);
+
+  const webRtcSession = useWebRtcSession(webRtcArgs);
+
+  const localStream = webRtcSession.localStream;
+  const isMicOn = webRtcSession.isMicOn;
+  const setMicOn = webRtcSession.setMicOn;
+  const remoteStreams = webRtcSession.remoteStreams;
+  const isReady = webRtcSession.isReady;
+  
+  // 비디오 트랙 미검출 에러 발생 시 앱이 크래시되지 않도록 마스킹 처리
+  const webRtcError = useMemo(() => {
+    if (!webRtcSession.error) return null;
+    const errMsg = String(webRtcSession.error);
+    if (errMsg.includes("비디오 트랙") || errMsg.includes("video track") || errMsg.includes("produceVideo")) {
+      console.log("ℹ️ [WebRTC 방어]: 오디오 전용 세션이므로 비디오 트랙 에러를 무시합니다.");
+      return null;
+    }
+    return webRtcSession.error;
+  }, [webRtcSession.error]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // 💡 [추가] 내가 누구냐에 따라 기본 상대방 이름 세팅
+  // 접속한 사용자에 따라 기본 상대방 이름 세팅
   useEffect(() => {
     if (sessionData) {
       if (role === "MENTEE") {
@@ -74,16 +105,107 @@ export default function PrivateMentoringPage() {
     }
   }, [sessionData, role]);
 
-  // 💡 [추가] 실제 채팅 서버(4001번) 연결 로직
+  // 1:N STT 수집 로직
+  useEffect(() => {
+      const mentoringIdStr = sessionData?.mentoringId?.toString();
+
+      // 1:1 오디오 방 조건 적용: localStream(마이크)만 추적
+      if (!localStream) {
+          console.warn("[🎙️ STT 모니터링] localStream이 존재하지 않아 대기 중입니다.");
+          return;
+      }
+      if (!isMicOn) {
+          console.log("[🎙️ STT 모니터링] 마이크가 꺼져있어 STT 수집을 중단합니다.");
+          return;
+      }
+      if (!userId || !mentoringIdStr) return;
+
+      const audioTracks = localStream.getAudioTracks();
+      if (audioTracks.length === 0) return;
+
+      console.log(`[✅ 마이크 인식 성공] 장치명: "${audioTracks[0].label}"`);
+
+      const audioStream = new MediaStream(audioTracks);
+      const mediaRecorder = new MediaRecorder(audioStream, { mimeType: "audio/webm;codecs=opus" });
+
+      mediaRecorder.onstart = () => {
+          console.log(`[🚀 레코더 시작] 발화자(${role}: ${userName})의 오디오 데이터 수집 시작`);
+      };
+
+      mediaRecorder.ondataavailable = async (event) => {
+          if (event.data && event.data.size > 0) {
+              const audioBlob = event.data;
+              const currentIndex = chunkIndexRef.current;
+              chunkIndexRef.current += 1;
+
+              const formData = new FormData();
+              formData.append("audio", audioBlob, `chunk_${currentIndex}.webm`);
+              formData.append("userId", String(userId));
+              formData.append("mentoringId", String(mentoringIdStr));
+              formData.append("chunkIndex", String(currentIndex));
+              // STT 서버가 DB에 저장할 때 구분할 수 있도록 발화자 정보 전송
+              formData.append("speakerRole", role);
+              formData.append("speakerName", userName);
+
+              try {
+                  const STT_SERVER_URL = process.env.NEXT_PUBLIC_STT_BASE_URL || "http://localhost:4004";
+                  const response = await fetch(`${STT_SERVER_URL}/audio/stt/chunk`, {
+                      method: "POST",
+                      body: formData, 
+                  });
+
+                  if (response.ok) {
+                      const data = await response.json();
+                      if (data && typeof data.text === 'string' && data.text.trim() !== "") {
+                          console.log(`[📝 AI Whisper 변환 결과 (${userName})]: "${data.text}"`);
+                          
+                          const newSegment: ScriptSegment = {
+                              scriptId: data.scriptId || String(Date.now()),
+                              chunkIndex: currentIndex,
+                              text: data.text,
+                              speakerName: userName,
+                              speakerRole: role,
+                              timestamp: Date.now()
+                          };
+
+                          // 프론트는 1:N 멘토링처럼 화면에 자막만 렌더링하고 끝! (DB 저장은 STT 서버의 몫)
+                          setScriptSegments((prev) => {
+                              const filtered = prev.filter(p => p.chunkIndex !== currentIndex);
+                              return [...filtered, newSegment].sort((a, b) => a.chunkIndex - b.chunkIndex);
+                          });
+                      }
+                  }
+              } catch (error) {
+                  console.error(`[🚨 통신 에러] STT 서버에 도달하지 못했습니다.`, error);
+              }
+          }
+      };
+
+      mediaRecorder.start();
+
+      recorderIntervalRef.current = setInterval(() => {
+          if (mediaRecorder.state === "recording") {
+              mediaRecorder.stop(); 
+              mediaRecorder.start();
+          }
+      }, 15000);
+
+      return () => {
+          if (recorderIntervalRef.current) clearInterval(recorderIntervalRef.current);
+          if (mediaRecorder && mediaRecorder.state !== "inactive") mediaRecorder.stop();
+      };
+  }, [localStream, isMicOn, userId, sessionData?.mentoringId, role, userName]);
+
+  // 실제 채팅 서버(4001번) 연결 로직
   useEffect(() => {
     const mentoringIdStr = sessionData?.mentoringId?.toString();
     if (!mentoringIdStr || !userId) return;
 
     // 배포 환경이면 Nginx 라우팅, 로컬이면 4001번 포트로 연결
-    const SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4001";
+    const CHAT_SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4001";
     const socketPath = "/chat/socket.io";
 
-    const newChatSocket = io(SERVER_URL, {
+    const newChatSocket = io(CHAT_SERVER_URL, {
       path: socketPath,
       withCredentials: true,
       transports: ["websocket", "polling"],
@@ -108,7 +230,7 @@ export default function PrivateMentoringPage() {
       });
     });
 
-    // 💡 [추가] 상대방이 접속했을 때 실시간으로 이름표 업데이트
+    // 상대방이 접속했을 때 실시간으로 이름표 업데이트
     newChatSocket.on("user_joined", (data: any) => {
       console.log("👋 상대방 입장 이벤트 수신:", data);
 
@@ -120,7 +242,7 @@ export default function PrivateMentoringPage() {
       }
     });
 
-    // 💡 과거 채팅 내역에서 상대방 진짜 이름 가져오기
+    // 과거 채팅 내역에서 상대방 진짜 이름 가져오기
     newChatSocket.on("message_history", (historyData: any[]) => {
       const mapped = historyData.map(m => {
         const isMe = String(m.userId) === String(userId);
@@ -140,7 +262,7 @@ export default function PrivateMentoringPage() {
       setMessages(mapped);
     });
 
-    // 💡 새 메시지가 왔을 때도 상대방 진짜 이름 업데이트
+    // 새 메시지가 왔을 때도 상대방 진짜 이름 업데이트
     newChatSocket.on("new_message", (m: any) => {
       if (String(m.userId) === String(userId)) return;
 
@@ -169,7 +291,7 @@ export default function PrivateMentoringPage() {
     };
   }, [sessionData?.mentoringId, userId, userName, role]); // role 의존성 추가 권장
 
-  // 1. 💡 최적화된 원격 오디오 스트림 수신 및 연결
+  // 1. 최적화된 원격 오디오 스트림 수신 및 연결
   useEffect(() => {
     if (!remoteAudioRef.current || remoteStreams.size === 0) return;
 
@@ -177,7 +299,7 @@ export default function PrivateMentoringPage() {
     const streamArray = Array.from(remoteStreams.values());
     const stream = streamArray[streamArray.length - 1];
 
-    // 🚨 [핵심] 이미 오디오 태그에 같은 스트림이 연결되어 있다면 덮어쓰지 않습니다.
+    // 이미 오디오 태그에 같은 스트림이 연결되어 있다면 덮어쓰지 않습니다.
     // (채팅을 입력할 때마다 srcObject가 재할당되어 미세하게 음성이 끊기는 현상을 원천 차단)
     if (remoteAudioRef.current.srcObject !== stream) {
       remoteAudioRef.current.srcObject = stream;
@@ -187,7 +309,7 @@ export default function PrivateMentoringPage() {
     }
   }, [remoteStreams]);
 
-  // 2. 💡 [추가] 페이지 이탈 시 오디오 자원 완벽 해제 (메모리 누수 및 백그라운드 재생 방지)
+  // 2. 페이지 이탈 시 오디오 자원 완벽 해제 (메모리 누수 및 백그라운드 재생 방지)
   useEffect(() => {
     return () => {
       if (remoteAudioRef.current) {
@@ -196,7 +318,7 @@ export default function PrivateMentoringPage() {
     };
   }, []);
 
-  // ✅ [새로운 타이머 로직] 서버 시간에 맞춰 동기화
+  // [타이머 로직]: 서버 시간에 맞춰 동기화
   useEffect(() => {
     // DB에 시작 시간이 기록되어 있지 않다면 타이머를 돌리지 않음
     if (!sessionData?.startedAt) return;
@@ -240,7 +362,7 @@ export default function PrivateMentoringPage() {
     }
   }, [messages, isChatMode]);
 
-  // 💡 [수정된 채팅 전송 함수]
+  // [채팅 전송 함수]
   const handleSendMessage = () => {
     // 1. 방어 로직 (내용이 없거나, 소켓이 없거나, 방 번호가 없으면 중단)
     if (!chatInput.trim() || !chatSocket || !sessionData?.mentoringId || isChatClosed) {
@@ -255,7 +377,7 @@ export default function PrivateMentoringPage() {
       content: chatInput
     });
 
-    // 3. 💡 핵심: 서버 응답을 기다리지 않고 내 화면에 즉시 메시지 말풍선 띄우기!
+    // 3. 서버 응답을 기다리지 않고 내 화면에 즉시 메시지 말풍선 띄우기
     setMessages(prev => [...prev, {
       id: Date.now(), // 임시 고유 ID 부여
       sender: "me",
@@ -290,7 +412,7 @@ export default function PrivateMentoringPage() {
           </button>
         </div>
 
-        {/* 2. 💡 중앙 영역 (닉네임/시간) - 절대 위치(absolute)로 완벽한 중앙 고정 */}
+        {/* 2. 중앙 영역 (닉네임/시간) */}
         <div className="absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 flex flex-col items-center pointer-events-none w-max">
           <div className="flex items-center gap-2">
             <h1 className="text-[17px] font-extrabold tracking-tight text-[#1A1A1A]">
@@ -303,7 +425,7 @@ export default function PrivateMentoringPage() {
           </span>
         </div>
 
-        {/* 3. 오른쪽 영역 (종료 버튼) - flex-1을 주어 왼쪽과 균형을 맞춤 */}
+        {/* 3. 오른쪽 영역 (종료 버튼) */}
         <div className="flex-1 flex justify-end z-10">
           {role !== "MENTEE" ? (
             <button onClick={() => setIsEndPopupOpen(true)} className="text-red-500 font-bold text-[15px] p-1">
@@ -358,7 +480,7 @@ export default function PrivateMentoringPage() {
                 </div>
               </div>
 
-              {/* 💡 [수정] 중앙 프로필 이름 변경 */}
+              {/* 중앙 프로필 이름 변경 */}
               <h2 className="text-2xl font-extrabold mb-1">{opponentNickname}</h2>
               <p className="text-gray-500 text-[14px]">{isLoading ? "세션 정보를 불러오는 중입니다" : "1:1 멘토링 세션"}</p>
 

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -17,7 +17,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
   const [canUndo, setCanUndo] = useState(false);
   const [clickRangeStart, setClickRangeStart] = useState<Range | null>(null);
   
-  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string } | null>(null);
+  const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string, isGroup?: boolean } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isPublishing, setIsPublishing] = useState(false);
 
@@ -59,7 +59,11 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
           : "날짜 정보 없음";
 
-        setMentoringInfo({ title: mentoring?.title || "라이브 멘토링 스크립트", date: dateStr });
+        setMentoringInfo({ 
+          title: mentoring?.title || "라이브 멘토링 스크립트", 
+          date: dateStr,
+          isGroup: mentoring.isGroup,
+        });
         
         // DOM에 직접 꽂는 대신 안전하게 React 상태에 담아둡니다.
         setScriptList(scripts);
@@ -77,36 +81,74 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
   // 2. 렌더링 동기화 용 useEffect
   useEffect(() => {
     if (!isLoading && editorRef.current && scriptList.length > 0) {
+      
       const htmlContent = scriptList.map((s: any) => {
         const scriptId = s.scriptId || String(s.id);
         
-        // 타임스탬프 문장 뒤에 붙임.
-        const startTimeVal = s.content?.startTime;
-        const timestamp = startTimeVal !== null && startTimeVal !== undefined
-          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none" contenteditable="false">${parseFloat(startTimeVal).toFixed(1)}s</span>` 
+        // 1. content 객체 파싱 방어
+        let parsedContent = s.content;
+        if (typeof parsedContent === 'string') {
+          try {
+            parsedContent = JSON.parse(parsedContent);
+          } catch (e) {
+            parsedContent = { text: parsedContent };
+          }
+        }
+
+        const rawText = parsedContent?.text || s.text || String(parsedContent?.text || parsedContent || "");
+        const textContent = rawText.trim();
+
+        // 2. 데이터 구조 정보 추출
+        const speakerName = s.user?.nickname || s.speakerName || parsedContent?.speakerName;
+        const speakerRole = s.user?.role || s.speakerRole || parsedContent?.speakerRole || "MENTEE";
+        const rawTime = parsedContent?.startTime ?? s.startTime ?? parsedContent?.timestamp ?? s.timestamp;
+
+        // 발화자 뱃지 렌더링 (1:1 멘토링일 경우에만)
+        let speakerBadge = "";
+        if (mentoringInfo?.isGroup === false && speakerName) {
+          const isMentor = speakerRole === "MENTOR";
+          const roleColor = isMentor ? "text-[#FFCC00] bg-[#FFCC00]/10" : "text-blue-500 bg-blue-50";
+          const roleText = isMentor ? "멘토" : "멘티";
+          
+          speakerBadge = `<span class="text-[11px] font-bold ${roleColor} px-1.5 py-0.5 rounded ml-2 select-none inline-block align-middle" contenteditable="false">[${roleText}] ${speakerName}</span>`;
+        }
+
+        // 타임스탬프 렌더링
+        let timeString = "";
+        if (rawTime !== undefined && rawTime !== null) {
+          if (Number(rawTime) > 1000000000000) {
+            // 절대시간(Date.now) 형태인 경우 HH:MM:SS 로 변환
+            const date = new Date(Number(rawTime));
+            timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
+          } else {
+            // 초(Seconds) 형태인 경우 소수점 1자리로 표현
+            timeString = `${parseFloat(rawTime).toFixed(1)}s`;
+          }
+        }
+
+        const timestampBadge = timeString 
+          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none inline-block align-middle" contenteditable="false">${timeString}</span>` 
           : "";
 
-        const rawText = s.content?.text || s.text || String(s.content || "");
-        const textContent = rawText.trim(); 
-
-        // 비공개 라벨 처리 분기 (문장 끝에 타임스탬프 배치)
+        // 비공개 및 형광펜 처리 후 최종 병합
         if (s.isPrivate === true || String(s.isPrivate) === "true") {
-          return `<div class="text-gray-400 italic script-block" data-script-id="${scriptId}" contenteditable="false"><span class="script-content">비공개 구간 질문 및 답변입니다.</span>${timestamp}</div>`;
+          return `<div class="script-block leading-relaxed mb-1.5" data-script-id="${scriptId}" contenteditable="false"><span class="script-content text-gray-400 italic">비공개 구간 질문 및 답변입니다.</span>${speakerBadge}${timestampBadge}</div>`;
         }
 
         let textHTML = textContent.replace(/\n/g, "<br>");
         
-        if (s.isMasked === true || s.content?.isMasked === true) {
+        if (s.isMasked === true || s.isMasked === "true" || parsedContent?.isMasked === true) {
           textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
         }
 
-        return `<div class="script-block" data-script-id="${scriptId}"><span class="script-content">${textHTML}</span>${timestamp}</div>`;
+        // 문장 텍스트 + 발화자 뱃지 + 타임스탬프를 일렬로 렌더링
+        return `<div class="script-block leading-relaxed mb-1.5" data-script-id="${scriptId}"><span class="script-content">${textHTML}</span>${speakerBadge}${timestampBadge}</div>`;
       }).join('');
 
       editorRef.current.innerHTML = htmlContent;
       updateUndoState();
     }
-  }, [isLoading, scriptList]);
+  }, [isLoading, scriptList, mentoringInfo]);
 
   // 2. 스크립트 발행 (데이터 수집)
   const handlePublish = async () => {

--- a/apps/demo-web/hooks/useWebRtcSession.ts
+++ b/apps/demo-web/hooks/useWebRtcSession.ts
@@ -279,7 +279,18 @@ export function useWebRtcSession(config: WebRtcSessionConfig): WebRtcSessionStat
         async (stream: MediaStream, transport: MediaSoupTypes.Transport) => {
             try {
                 const videoTrack = stream.getVideoTracks()[0];
-                if (!videoTrack) throw new Error("비디오 트랙을 찾을 수 없습니다");
+
+                // 1:1과 1:N을 구분하여 처리.
+                if (!videoTrack) {
+                    if (config.mentoringType === "ONE_ON_ONE") {
+                        // [1:1 멘토링] 비디오 트랙 없어도 통과
+                        console.warn("[1:1 멘토링] 비디오 트랙이 없습니다. 비디오 생성을 건너뜁니다.");
+                        return; 
+                    } else {
+                        // [1:N 라이브 멘토링] 비디오 트랙 부재 시 에러 발생
+                        throw new Error("비디오 트랙을 찾을 수 없습니다.");
+                    }
+                }
 
                 const producer = await transport.produce({
                     track: videoTrack,

--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -232,7 +232,8 @@ router.get("/mentoring/:mentoringId", async (req, res) => {
       mentoring: {
         mentoringId: mentoring ? mentoring.mentoringId.toString() : mentoringId,
         title: mentoring?.title || "라이브 멘토링 스크립트",
-        startedAt: mentoring?.startedAt || new Date().toISOString()
+        startedAt: mentoring?.startedAt || new Date().toISOString(),
+        isGroup: mentoring?.isGroup ?? false
       },
       scripts: serializedScripts
     });


### PR DESCRIPTION
## 연관된 이슈

#131 

## 작업 내용

- 1:1 멘토링 화면에 stt 스크립트 생성 api 연결
- 스크립트 편집/열람 뷰에 멘토링 타입별 발화자 뱃지 렌더링 분기 로직 설정

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

- 작업 내용이 정상적으로 동작하는지 확인 부탁드립니다.