### PR TITLE
스크립트 수정 및 조회, 질문 카드 순서 관련 수정

### DIFF
--- a/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/[id]/page.tsx
@@ -25,7 +25,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
         const { mentoring, scripts } = res.data;
 
         const d = mentoring.startedAt ? new Date(mentoring.startedAt) : null;
-        const dateStr = d 
+        const dateStr = d
           ? `${d.getFullYear()}년 ${d.getMonth() + 1}월 ${d.getDate()}일`
           : "날짜 미상";
 
@@ -54,77 +54,57 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
   // 2. 로딩이 종료되어 contentRef가 확실하게 DOM에 로드된 타이밍에 HTML 주입
   useEffect(() => {
     if (!isLoading && contentRef.current && scriptList.length > 0) {
+
+      // 백엔드가 이미 정렬해서 줬으므로, scriptList를 그대로 순방향 매핑합니다.
       const htmlContent = scriptList.map((s: any) => {
-        
-        let parsedContent = s.content;
-        if (typeof parsedContent === 'string') {
-          try { parsedContent = JSON.parse(parsedContent); } 
-          catch { parsedContent = { text: parsedContent }; }
-        }
+        const parsedContent = s.content;
+        const speakerName = s.speaker?.nickname;
+        const speakerRole = s.speaker?.role || "MENTEE";
 
-        // 발행 데이터 구조 탐색.
-        const speakerName = s.speaker?.nickname || s.user?.nickname || s.speakerName || parsedContent?.speakerName;
-        const speakerRole = s.speaker?.role || s.user?.role || s.speakerRole || parsedContent?.speakerRole || "MENTEE";
-        
-        // startTime이 null일 경우를 대비해 createdAt(ISO 문자열)을 백업으로 사용합니다.
-        const rawTime = parsedContent?.startTime ?? s.startTime ?? parsedContent?.timestamp ?? s.timestamp ?? s.createdAt;
+        const rawTime = parsedContent?.startTime ?? s.createdAt;
 
-        // 발화자(Speaker) 뱃지 렌더링
+        // 발화자 뱃지 구성
         let speakerBadge = "";
         if (mentoringInfo?.isGroup === false && speakerName) {
           const isMentor = speakerRole === "MENTOR";
           const roleColor = isMentor ? "text-[#FFCC00] bg-[#FFCC00]/10" : "text-blue-500 bg-blue-50";
           const roleText = isMentor ? "멘토" : "멘티";
-          
           speakerBadge = `<span class="text-[11px] font-bold ${roleColor} px-1.5 py-0.5 rounded ml-2 select-none inline-block align-middle">[${roleText}] ${speakerName}</span>`;
         }
 
-        // 타임스탬프 렌더링
+        // 타임스탬프 계산
         let timeString = "";
-        if (rawTime !== undefined && rawTime !== null) {
+        if (rawTime) {
           const numTime = Number(rawTime);
-          if (!isNaN(numTime)) {
-            if (numTime > 1000000000000) {
-              const date = new Date(numTime);
-              timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
-            } else {
-              timeString = `${parseFloat(rawTime as string).toFixed(1)}s`;
-            }
-          } else if (typeof rawTime === 'string' && rawTime.includes('T')) {
-            // ISO 날짜 문자열(createdAt)인 경우 시:분:초 추출
+          if (!isNaN(numTime) && numTime < 1000000000000) {
+            timeString = `${parseFloat(rawTime).toFixed(1)}s`;
+          } else {
             const date = new Date(rawTime);
             timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
           }
         }
-        
-        const timestampBadge = timeString 
-          ? `<span class="text-[12px] text-amber-400 font-medium ml-2 select-none inline-block align-middle">${timeString}</span>` 
+        const timestampBadge = timeString
+          ? `<span class="text-[12px] text-amber-400 font-medium ml-2 select-none inline-block align-middle">${timeString}</span>`
           : "";
 
-        // 비공개 및 마스킹 처리 후 최종 병합
-        if (parsedContent?.isPrivate || s.isPrivate) {
-          const privateText = parsedContent?.text || "비공개 질문입니다.";
+        // 1. 비공개 인가 권한 처리 구간
+        if (s.isPrivate) {
+          const privateText = parsedContent?.pieces?.[0]?.text || "비공개 질문입니다.";
           return `<div class="mb-1.5 leading-relaxed text-gray-400 italic">🔒 <span>${privateText}</span>${speakerBadge}${timestampBadge}</div>`;
         }
 
+        // 2. 가공된 pieces 기반 메인 렌더링
         let textHTML = "";
-
         if (parsedContent?.pieces && Array.isArray(parsedContent.pieces)) {
           textHTML = parsedContent.pieces.map((piece: any) => {
             if (piece.isMasked) {
-              return `<span style="background-color: #FFCC00">${piece.text || "마스킹된 부분입니다."}</span>`;
+              return `<span style="background-color: #FFCC00">${piece.text}</span>`;
             }
             return piece.text || "";
           }).join('');
-        } else {
-          textHTML = parsedContent?.text || parsedContent?.message || "";
-          if (s.masked || s.isMasked || parsedContent?.isMasked) {
-            textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
-          }
         }
 
         textHTML = textHTML.replace(/\n/g, "<br>");
-
         return `<div class="mb-1.5 leading-relaxed"><span>${textHTML}</span>${speakerBadge}${timestampBadge}</div>`;
       }).join('');
 
@@ -134,7 +114,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
-      
+
       {/* 멘티 뷰 CSS 로직 (마스킹된 텍스트 글자색 투명화 및 블라인드 처리) */}
       <style>{`
         .mentee-view-container span[style*="rgb(255, 204, 0)"], 
@@ -150,8 +130,8 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
 
       {/* 헤더 */}
       <header className="flex items-center px-5 py-4 border-b border-gray-100 shrink-0 bg-white z-10">
-        <button 
-          onClick={() => router.back()} 
+        <button
+          onClick={() => router.back()}
           className="p-1 -ml-1 hover:bg-gray-100 rounded-full transition-colors"
         >
           <ChevronLeft className="w-6 h-6 text-[#1A1A1A]" strokeWidth={2.5} />
@@ -161,7 +141,7 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
 
       {/* 스크립트 본문 영역 */}
       <div className="flex-1 overflow-y-auto px-6 py-8 bg-white custom-scrollbar pb-20">
-        
+
         {isLoading ? (
           <div className="flex flex-col items-center justify-center py-32 gap-3">
             <Loader2 className="w-8 h-8 text-[#FFCC00] animate-spin" />
@@ -175,18 +155,18 @@ export default function PublishedScriptPage({ params }: { params: Promise<{ id: 
         ) : (
           <>
             <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Mentoring ID: {id}</p>
-            
+
             <h2 className="text-3xl font-extrabold text-[#1A1A1A] leading-tight mb-8">
               {mentoringInfo?.title}
               <span className="block text-[15px] font-medium text-gray-400 mt-2 tracking-normal">{mentoringInfo?.date}</span>
             </h2>
 
             {/* 편집 기능이 제거된 순수 텍스트 컨테이너 (포인터 이벤트 막음) */}
-            <div 
+            <div
               ref={contentRef}
               className="mentee-view-container text-[16px] leading-[1.9] text-gray-700 whitespace-pre-wrap tracking-tight p-6 bg-[#FAFAFA] border border-gray-100 rounded-2xl pointer-events-none shadow-sm"
             />
-            
+
             <p className="text-center text-gray-400 text-[12px] mt-8 font-medium">
               보안을 위해 일부 텍스트가 블라인드 처리되었습니다.
             </p>

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -343,6 +343,13 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         // 클러스터링 결과가 아직 없거나 대기 중일 때의 예외 방어 정렬
         if (clusters.length === 0 && activeQuestions.length > 0) {
             return [...activeQuestions].sort((a, b) => {
+                // 답변 중인 질문은 최상단 고정
+                const readingId = currentQuestionRef.current?.id;
+                if (isReading && readingId) {
+                    if (a.id === readingId) return -1;
+                    if (b.id === readingId) return 1;
+                }
+
                 if (a.isPaid && !b.isPaid) return -1;
                 if (!a.isPaid && b.isPaid) return 1;
 
@@ -367,6 +374,13 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
 
         // 최종 하이브리드 정렬 실행
         return mappedQueue.sort((a, b) => {
+            // 규칙 0: 답변 중인 질문은 최상단 고정
+            const readingId = currentQuestionRef.current?.id;
+            if (isReading && readingId) {
+                if (a.id === readingId) return -1;
+                if (b.id === readingId) return 1;
+            }
+
             // 규칙 1: 유료 질문이 무조건 최상단 노출
             if (a.isPaid && !b.isPaid) return -1;
             if (!a.isPaid && b.isPaid) return 1;
@@ -376,7 +390,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
             const scoreB = questionRankings[String(b.id)] || 0;
             return scoreB - scoreA;
         });
-    }, [clusters, activeQuestions, questionRankings]);
+    }, [clusters, activeQuestions, questionRankings, isReading]);
 
     // 현재 인덱스에 해당하는 질문 가져오기 (결합된 완성형 큐 사용)
     const currentQuestion = questionQueue[currentIdx];
@@ -401,6 +415,15 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         if (!isReading) {
             setCurrentIdx(0);
             return;
+        }
+
+        // 답변 중(isReading === true)일 때, 현재 질문의 id가 큐 내에서 몇 번째인지 추적
+        if (currentQuestionRef.current) {
+            const trackedIdx = questionQueue.findIndex(q => q.id === currentQuestionRef.current!.id);
+            if (trackedIdx !== -1 && trackedIdx !== currentIdx) {
+                setCurrentIdx(trackedIdx);
+                return;
+            }
         }
 
         // 3. 만약 질문을 읽으며 답변 중인데 큐가 변해서 인덱스가 범위를 초과했다면 안전하게 마지막 카드로 보정

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -12,11 +12,11 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
   const [isMenteeView, setIsMenteeView] = useState(false);
   const [isPublishPopupOpen, setIsPublishPopupOpen] = useState(false);
-  
+
   const [editMode, setEditMode] = useState<"drag" | "click">("drag");
   const [canUndo, setCanUndo] = useState(false);
   const [clickRangeStart, setClickRangeStart] = useState<Range | null>(null);
-  
+
   const [mentoringInfo, setMentoringInfo] = useState<{ title: string; date: string, isGroup?: boolean } | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isPublishing, setIsPublishing] = useState(false);
@@ -47,24 +47,24 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       try {
         const STT_SERVER_URL = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:4004";
         const res = await fetch(`${STT_SERVER_URL}/audio/stt/mentoring/${id}`);
-        
+
         if (!res.ok) throw new Error(`STT 서비스 응답 실패: ${res.status}`);
         const resultData = await res.json();
-        
+
         const mentoring = resultData?.mentoring;
         const scripts = resultData?.scripts || [];
 
         const d = mentoring?.startedAt ? new Date(mentoring.startedAt) : null;
-        const dateStr = d 
+        const dateStr = d
           ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
           : "날짜 정보 없음";
 
-        setMentoringInfo({ 
-          title: mentoring?.title || "라이브 멘토링 스크립트", 
+        setMentoringInfo({
+          title: mentoring?.title || "라이브 멘토링 스크립트",
           date: dateStr,
           isGroup: mentoring.isGroup,
         });
-        
+
         // DOM에 직접 꽂는 대신 안전하게 React 상태에 담아둡니다.
         setScriptList(scripts);
 
@@ -79,69 +79,69 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
   }, [id]);
 
   // 2. 렌더링 동기화 용 useEffect
+
   useEffect(() => {
     if (!isLoading && editorRef.current && scriptList.length > 0) {
-      
+
       const htmlContent = scriptList.map((s: any) => {
         const scriptId = s.scriptId || String(s.id);
-        
-        // 1. content 객체 파싱 방어
+
         let parsedContent = s.content;
         if (typeof parsedContent === 'string') {
-          try {
-            parsedContent = JSON.parse(parsedContent);
-          } catch (e) {
-            parsedContent = { text: parsedContent };
-          }
+          try { parsedContent = JSON.parse(parsedContent); } catch (e) { parsedContent = { text: parsedContent }; }
         }
 
-        const rawText = parsedContent?.text || s.text || String(parsedContent?.text || parsedContent || "");
-        const textContent = rawText.trim();
-
-        // 2. 데이터 구조 정보 추출
         const speakerName = s.user?.nickname || s.speakerName || parsedContent?.speakerName;
         const speakerRole = s.user?.role || s.speakerRole || parsedContent?.speakerRole || "MENTEE";
         const rawTime = parsedContent?.startTime ?? s.startTime ?? parsedContent?.timestamp ?? s.timestamp;
 
-        // 발화자 뱃지 렌더링 (1:1 멘토링일 경우에만)
+        // 발화자 뱃지 및 타임스탬프 렌더링 로직 (기존 코드 유지)
         let speakerBadge = "";
         if (mentoringInfo?.isGroup === false && speakerName) {
           const isMentor = speakerRole === "MENTOR";
           const roleColor = isMentor ? "text-[#FFCC00] bg-[#FFCC00]/10" : "text-blue-500 bg-blue-50";
           const roleText = isMentor ? "멘토" : "멘티";
-          
           speakerBadge = `<span class="text-[11px] font-bold ${roleColor} px-1.5 py-0.5 rounded ml-2 select-none inline-block align-middle" contenteditable="false">[${roleText}] ${speakerName}</span>`;
         }
 
-        // 타임스탬프 렌더링
         let timeString = "";
         if (rawTime !== undefined && rawTime !== null) {
           if (Number(rawTime) > 1000000000000) {
-            // 절대시간(Date.now) 형태인 경우 HH:MM:SS 로 변환
             const date = new Date(Number(rawTime));
             timeString = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}:${String(date.getSeconds()).padStart(2, '0')}`;
           } else {
-            // 초(Seconds) 형태인 경우 소수점 1자리로 표현
             timeString = `${parseFloat(rawTime).toFixed(1)}s`;
           }
         }
+        const timestampBadge = timeString ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none inline-block align-middle" contenteditable="false">${timeString}</span>` : "";
 
-        const timestampBadge = timeString 
-          ? `<span class="text-[12px] text-gray-400 font-medium ml-2 select-none inline-block align-middle" contenteditable="false">${timeString}</span>` 
-          : "";
-
-        // 비공개 및 형광펜 처리 후 최종 병합
+        // 비공개 처리 (기존 코드 유지)
         if (s.isPrivate === true || String(s.isPrivate) === "true") {
           return `<div class="script-block leading-relaxed mb-1.5" data-script-id="${scriptId}" contenteditable="false"><span class="script-content text-gray-400 italic">비공개 구간 질문 및 답변입니다.</span>${speakerBadge}${timestampBadge}</div>`;
         }
 
-        let textHTML = textContent.replace(/\n/g, "<br>");
-        
-        if (s.isMasked === true || s.isMasked === "true" || parsedContent?.isMasked === true) {
-          textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+        // 핵심 수정: textHTML 조립 분기 처리
+        let textHTML = "";
+
+        if (Array.isArray(parsedContent?.pieces)) {
+          // 1. 이미 발행을 거쳐 pieces 세부 마스킹 데이터 구조를 가진 경우
+          textHTML = parsedContent.pieces.map((p: any) => {
+            const escapedText = p.text.replace(/\n/g, "<br>");
+            if (p.isMasked === true || p.isMasked === "true") {
+              return `<span style="background-color: #FFCC00">${escapedText}</span>`;
+            }
+            return escapedText;
+          }).join("");
+        } else {
+          // 2. 발행 전 단일 문자열 text 구조인 경우
+          const rawText = parsedContent?.text || s.text || String(parsedContent || "");
+          textHTML = rawText.trim().replace(/\n/g, "<br>");
+
+          if (s.isMasked === true || s.isMasked === "true" || parsedContent?.isMasked === true) {
+            textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+          }
         }
 
-        // 문장 텍스트 + 발화자 뱃지 + 타임스탬프를 일렬로 렌더링
         return `<div class="script-block leading-relaxed mb-1.5" data-script-id="${scriptId}"><span class="script-content">${textHTML}</span>${speakerBadge}${timestampBadge}</div>`;
       }).join('');
 
@@ -157,17 +157,17 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
     try {
       const scriptBlocks = editorRef.current.querySelectorAll('.script-block');
-      
+
       const payloadMap = new Map<string, { text: string; isMasked: boolean }[]>();
 
       scriptBlocks.forEach((block) => {
         const scriptId = block.getAttribute('data-script-id');
         const contentNode = block.querySelector('.script-content');
-        
+
         if (!scriptId || !contentNode) return;
 
         const pieces: { text: string; isMasked: boolean }[] = [];
-        
+
         const parseNode = (node: Node, isCurrentlyMasked: boolean) => {
           if (node.nodeType === Node.TEXT_NODE) {
             if (node.textContent) {
@@ -218,11 +218,11 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       });
 
       await apiClient.patch(`/api/scripts/${id}/publish`, { scripts: payloadScripts });
-      
+
       alert("성공적으로 발행되었습니다!");
       setIsPublishPopupOpen(false);
-      router.push('/mypage/scripts'); 
-      
+      router.push('/mypage/scripts');
+
     } catch (error: any) {
       console.error("스크립트 발행 실패:", error);
       alert(error.response?.data?.message || "발행에 실패했습니다. 다시 시도해주세요.");
@@ -274,7 +274,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
     } else {
       const newRange = document.createRange();
       const cmp = clickRangeStart.compareBoundaryPoints(Range.START_TO_START, currentCaret);
-      
+
       if (cmp <= 0) {
         newRange.setStart(clickRangeStart.startContainer, clickRangeStart.startOffset);
         newRange.setEnd(currentCaret.endContainer, currentCaret.endOffset);
@@ -282,7 +282,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
         newRange.setStart(currentCaret.startContainer, currentCaret.startOffset);
         newRange.setEnd(clickRangeStart.endContainer, clickRangeStart.endOffset);
       }
-      
+
       sel.removeAllRanges();
       sel.addRange(newRange);
       setClickRangeStart(null);
@@ -293,7 +293,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
   return (
     <main className="flex flex-col w-full h-[100dvh] bg-white text-[#1A1A1A] font-sans overflow-hidden relative">
-      
+
       <style>{`
         .editor-container { outline: none; }
         .editor-container ::selection { background-color: rgba(59, 130, 246, 0.4) !important; color: inherit; }
@@ -314,7 +314,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           </button>
           <h1 className="text-[17px] font-extrabold tracking-tight">스크립트 편집 & 리뷰</h1>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <span className="text-[12px] font-bold text-gray-500">멘티 뷰 보기</span>
           <button onClick={() => setIsMenteeView(!isMenteeView)} className={`w-11 h-6 rounded-full p-1 transition-colors duration-300 ${isMenteeView ? 'bg-[#FFCC00]' : 'bg-gray-200'}`}>
@@ -334,7 +334,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
             <MousePointer2 className="w-3.5 h-3.5" /> 원클릭
           </button>
         </div>
-        
+
         <div className="flex items-center gap-2">
           <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹">
             <EyeOff className="w-4 h-4" />
@@ -363,7 +363,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
               <span className="block text-[15px] font-medium text-gray-400 mt-2 tracking-normal">{mentoringInfo?.date}</span>
             </h2>
 
-            <div 
+            <div
               ref={editorRef}
               contentEditable={!isMenteeView}
               suppressContentEditableWarning
@@ -380,8 +380,8 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       </div>
 
       <div className="w-full px-5 py-4 bg-white border-t border-gray-100 flex shrink-0 pb-safe z-20">
-        <button 
-          onClick={() => setIsPublishPopupOpen(true)} 
+        <button
+          onClick={() => setIsPublishPopupOpen(true)}
           disabled={isPublishing}
           className={`flex-1 bg-[#FFCC00] text-[#1A1A1A] font-extrabold text-[16px] py-4 rounded-2xl transition-colors flex items-center justify-center gap-2 shadow-sm
             ${isPublishing ? 'opacity-60 cursor-not-allowed' : 'hover:bg-[#E6B800] active:scale-[0.98]'}
@@ -403,14 +403,14 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
               발행 시 멘티에게 알림이 전송되며<br />더 이상 스크립트를 <b>수정할 수 없습니다.</b>
             </p>
             <div className="flex gap-3 w-full">
-              <button 
+              <button
                 disabled={isPublishing}
-                onClick={() => setIsPublishPopupOpen(false)} 
+                onClick={() => setIsPublishPopupOpen(false)}
                 className="flex-1 bg-[#F2F4F6] text-gray-600 font-bold py-3.5 rounded-xl transition-all hover:bg-gray-200 active:scale-95"
               >
                 취소
               </button>
-              <button 
+              <button
                 disabled={isPublishing}
                 onClick={handlePublish}
                 className="flex-1 bg-[#FFCC00] text-[#1A1A1A] font-bold py-3.5 rounded-xl shadow-sm transition-all hover:bg-[#E6B800] active:scale-95 flex justify-center items-center"

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -73,6 +73,8 @@ services:
       context: ../..
       dockerfile: services/media-server/Dockerfile
     container_name: carpoolink-media-server
+    env_file:
+      - ../../.env
     environment:
       NODE_ENV: ${NODE_ENV:-development}
       MEDIA_SERVER_PORT: 4002
@@ -86,6 +88,7 @@ services:
         condition: service_healthy
     volumes:
       - ../../services/media-server:/app/services/media-server
+      - ../../.env:/app/.env
       - /app/services/media-server/node_modules
     networks:
       - carpoolink-network

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -70,53 +70,35 @@ function canViewPrivateScript(script, viewerUserId) {
 function getVisibleContent(script, viewerUserId) {
     if (!canViewPrivateScript(script, viewerUserId)) {
         return {
-            visible: true,
-            masked: false,
-            content: {
-                isPrivate: true,
-                text: '비공개 질문입니다.',
-            },
+            isPrivate: true,
+            pieces: [{ text: '비공개 질문 및 답변입니다.', isMasked: false }],
         };
     }
 
     const content = script.content;
 
     if (content && Array.isArray(content.pieces)) {
-        const isMaskedParagraph = content.pieces.some(p => p.isMasked);
-
         return {
-            visible: true,
-            masked: isMaskedParagraph,
-            content: {
-                pieces: content.pieces.map(piece => {
-                    if (piece.isMasked) {
-                        return {
-                            ...piece,
-                            text: '마스킹된 부분입니다.',
-                        };
-                    }
-                    return piece;
-                })
-            }
+            isPrivate: script.isPrivate || false,
+            pieces: content.pieces.map(piece => ({
+                text: piece.text || '',
+                isMasked: piece.isMasked || false
+            }))
         };
     }
 
     if (hasMaskedFlag(script.content)) {
         // 마스킹된 단락은 멘토/멘티 모두 원문 비노출
         return {
-            visible: true,
-            masked: true,
-            content: {
-                isMasked: true,
-                text: '마스킹된 단락입니다.',
-            },
+            isPrivate: script.isPrivate || false,
+            pieces: [{ text: content?.text || '마스킹된 단락입니다.', isMasked: true }]
         };
     }
 
+    // 4. 일반 raw 텍스트 상태인 경우 정규화
     return {
-        visible: true,
-        masked: false,
-        content: script.content,
+        isPrivate: script.isPrivate || false,
+        pieces: [{ text: content?.text || String(content || ''), isMasked: false }]
     };
 }
 
@@ -125,14 +107,17 @@ function mapScriptParagraph(script, viewerUserId) {
     const visibility = getVisibleContent(script, viewerUserId);
 
     return {
-        scriptId: script.scriptId,
+        scriptId: script.scriptId.toString(),
         isPrivate: script.isPrivate,
         createdAt: script.createdAt,
-        content: visibility.content,
+        content: {
+            pieces: visibility.pieces,
+            startTime: script.content?.startTime ?? null // 타임스탬프 백업 복원
+        },
         speaker: {
-            userId: script.userId,
-            nickname: script.user?.nickname ?? null,
-            role: script.user?.role ?? null,
+            userId: script.userId.toString(),
+            nickname: script.user?.nickname ?? '알 수 없음',
+            role: script.user?.role ?? 'MENTEE',
             isHostMentor: script.userId === script.mentoring.userId,
         },
     };
@@ -225,7 +210,7 @@ router.get('/:mentoringId', requireUser, async (req, res, next) => {
                     include: {
                         user: true,
                     },
-                    orderBy: [{ createdAt: 'asc' }, { scriptId: 'asc' }],
+                    orderBy: [{ scriptId: 'asc' }, { createdAt: 'asc' }],
                 },
             },
         });

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -238,7 +238,7 @@ router.get('/:mentoringId', requireUser, async (req, res, next) => {
         const scripts = mentoring.scripts
             .map((script) => mapScriptParagraph({ ...script, mentoring }, req.user.userId))
             .filter(Boolean)
-            .sort((left, right) => new Date(left.createdAt) - new Date(right.createdAt));
+            .sort((left, right) => new Number(left.scriptId) - new Number(right.scriptId));
 
         res.json(
             serialize({

--- a/services/stt-service/package.json
+++ b/services/stt-service/package.json
@@ -6,7 +6,7 @@
     "main": "src/server.js",
     "scripts": {
         "start": "node src/server.js",
-        "dev": "nodemon --exec \"node --env-file=../../.env --env-file=.env\" src/server.js"
+        "dev": "nodemon --exec \"node --env-file=../../.env\" src/server.js"
     },
     "dependencies": {
         "@carpoolink/database": "*",

--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -206,7 +206,7 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
   }
 });
 
-// stt-service/routes/stt.js 내부의 GET 엔드포인트 수정
+// 전체 스크립트 조회 api
 router.get("/mentoring/:mentoringId", async (req, res) => {
   try {
     const { mentoringId } = req.params;
@@ -232,22 +232,33 @@ router.get("/mentoring/:mentoringId", async (req, res) => {
     const serializedScripts = scripts.map(s => {
       let textVal = "";
       let startTimeVal = null;
+      let piecesVal = null;
 
       // content 내장 JSON 오브젝트 안전 파싱
+      let contentObj = null;
       if (s.content && typeof s.content === 'object') {
-        textVal = s.content.text || "";
-        startTimeVal = s.content.startTime ?? s.content.timestamp ?? null;
+        contentObj = s.content;
       } else if (typeof s.content === 'string') {
         try {
-          const parsed = JSON.parse(s.content);
-          textVal = parsed.text || "";
-          startTimeVal = parsed.startTime ?? null;
+          contentObj = JSON.parse(s.content);
         } catch (e) {
           textVal = s.content;
         }
       }
 
-      // DB에 실존하는 유저의 실제 nickname과 role을 추출하고, 없을 경우에만 예외 기본값을 부여합니다.
+      if (contentObj) {
+        // 1. 이미 발행되어 pieces 배열이 존재하는 경우
+        if (Array.isArray(contentObj.pieces)) {
+          piecesVal = contentObj.pieces;
+          // 프론트 초기 렌더링 호환을 위해 textVal도 병합 추출
+          textVal = contentObj.pieces.map(p => p.text).join("");
+        } else {
+          // 2. 발행 전 최초 STT raw 데이터 규격인 경우
+          textVal = contentObj.text || "";
+        }
+        startTimeVal = contentObj.startTime ?? contentObj.timestamp ?? null;
+      }
+
       const realNickname = s.user?.nickname || "알 수 없음";
       const realRole = s.user?.role || "MENTEE";
 
@@ -256,16 +267,17 @@ router.get("/mentoring/:mentoringId", async (req, res) => {
         userId: s.userId.toString(),
         mentoringId: s.mentoringId.toString(),
         isPrivate: s.isPrivate || false,
-        isMasked: s.isMasked || false,
+        // 단락 단위 마스킹 플래그 혹은 pieces 내부 마스킹 포함 여부 검사
+        isMasked: s.isMasked || (piecesVal ? piecesVal.some(p => p.isMasked) : false),
         content: {
           text: textVal,
           startTime: startTimeVal,
-          chunkIndex: s.content?.chunkIndex || 0
+          chunkIndex: contentObj?.chunkIndex || 0,
+          pieces: piecesVal // 프론트엔드로 pieces 배열 전달 보장
         },
-        // core-api 규격과 100% 일치하도록 user 객체 포맷 매핑
         user: {
           nickname: realNickname,
-          role: realRole // 이제 "MENTOR"가 정상적으로 전달됩니다.
+          role: realRole
         }
       };
     });
@@ -298,6 +310,7 @@ function detectCommand(text) {
   return null;
 }
 
+// 멘토링 종료 시 stt 세션 상태를 정리하는 api
 router.post('/session/:mentoringId/end', (req, res) => {
   privateState.delete(String(req.params.mentoringId));
   console.log('[STT] 세션 정리됨:', req.params.mentoringId, '| 남은 세션:', privateState.size);


### PR DESCRIPTION
## 연관된 이슈

#155 

## 작업 내용

스크립트 수정/발행와 조회시의 req, res 포맷을 일치시켰습니다.
질문에 답변 중일 때 랭킹이 변하는 상황에서 질문이 밀리는 것 같아 답변 중인 질문은 큐의 첫번째로 고정하도록 수정했습니다. 

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항