### PR TITLE
feat(question-detection): 오탐 개선 및 모델 v2 재학습

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -249,8 +249,8 @@ jobs:
                     --network carpoolink-network \
                     --env-file /app/.env \
                     -e QUESTION_PRELOAD_KC_ELECTRA=true \
-                    -e QUESTION_TFIDF_ARTIFACT_DIR=/app/services/model/question_detection/tfidf_lr_rule_filter_off \
-                    -e QUESTION_KC_ELECTRA_DIR=/app/services/model/question_detection/kc_electra_question_detector \
+                    -e QUESTION_TFIDF_ARTIFACT_DIR=/app/services/model/question_detection/tfidf_lr_v2 \
+                    -e QUESTION_KC_ELECTRA_DIR=/app/services/model/question_detection/kc_electra_v2 \
                     -v /app/services/model/question_detection:/app/services/model/question_detection:ro \
                     ghcr.io/${{ env.REPO_OWNER }}/question-model-api:${{ github.sha }}
                   ;;

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -155,6 +155,12 @@ jobs:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+      - name: Read DVC file content
+        id: dvc_file
+        run: |
+          CONTENT=$(cat services/model/question_detection.dvc | base64 -w 0)
+          echo "question_detection_dvc=$CONTENT" >> $GITHUB_OUTPUT
+
       - name: Deploy Services to EC2
         uses: peterkimzz/aws-ssm-send-command@master
         with:
@@ -239,11 +245,23 @@ jobs:
                     ghcr.io/${{ env.REPO_OWNER }}/question-service:${{ github.sha }}
                   ;;
                 "question-model-api")
-                  if [ ! -d /app/services/model/question_detection ]; then
-                    echo "Missing /app/services/model/question_detection on EC2."
-                    echo "Upload or restore the DVC model artifacts before deploying question-model-api."
-                    exit 1
+                  # DVC 설치 (없으면)
+                  command -v dvc >/dev/null 2>&1 || pip3 install "dvc[s3]" -q
+
+                  # DVC 초기화 및 remote 설정 (없으면)
+                  if [ ! -f /app/.dvc/config ]; then
+                    cd /app && dvc init --no-scm
+                    dvc remote add -d carpoolink s3://capstone2026-carpoolink-dvc-kro
+                    dvc remote modify carpoolink region ap-northeast-2
                   fi
+
+                  # .dvc 파일 업데이트 (GitHub repo 기준)
+                  mkdir -p /app/services/model
+                  echo "${{ steps.dvc_file.outputs.question_detection_dvc }}" | base64 -d > /app/services/model/question_detection.dvc
+
+                  # S3에서 모델 동기화 (변경된 것만 다운로드)
+                  cd /app && dvc pull services/model/question_detection.dvc
+
                   docker run --restart always \
                     -d --name carpoolink-question-model-api \
                     --network carpoolink-network \

--- a/data/processed/question_detection/.gitignore
+++ b/data/processed/question_detection/.gitignore
@@ -2,3 +2,7 @@
 /valid.csv
 /test.csv
 /tfidf_ready
+/augmentation
+/electra_v2
+/tfidf_v2
+/tfidf_v2_ready

--- a/data/processed/question_detection/augmentation.dvc
+++ b/data/processed/question_detection/augmentation.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 02f0049be1c96b4d892ad5c3f0b5372b.dir
+  size: 8285525
+  nfiles: 4
+  hash: md5
+  path: augmentation

--- a/data/processed/question_detection/electra_v2.dvc
+++ b/data/processed/question_detection/electra_v2.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: dea77ae8ce2b3ab44843050b81651d47.dir
+  size: 61316134
+  nfiles: 3
+  hash: md5
+  path: electra_v2

--- a/data/processed/question_detection/tfidf_v2.dvc
+++ b/data/processed/question_detection/tfidf_v2.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 87ebdff5eb37d20bf49e8fa7494df136.dir
+  size: 205183764
+  nfiles: 3
+  hash: md5
+  path: tfidf_v2

--- a/data/processed/question_detection/tfidf_v2_ready.dvc
+++ b/data/processed/question_detection/tfidf_v2_ready.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 05f10016294592e70a8847eddf8fc1f3.dir
+  size: 399394296
+  nfiles: 3
+  hash: md5
+  path: tfidf_v2_ready

--- a/services/model/question_detection.dvc
+++ b/services/model/question_detection.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 1f600256ba640f66298e3fd0f1218903.dir
-  size: 2274623265
-  nfiles: 52
+- md5: 3890b053463baa7e38791dfee3bd908c.dir
+  size: 9657319931
+  nfiles: 142
   hash: md5
   path: question_detection

--- a/services/question-service/outputs/question_clustering.dvc
+++ b/services/question-service/outputs/question_clustering.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 66f150d5f0cd220d87d2c52520e2c0e4.dir
-  size: 63266178
-  nfiles: 90
+- md5: 0f92b3438a6a15c503e71dd210ef7728.dir
+  size: 296740730
+  nfiles: 91
   hash: md5
   path: question_clustering

--- a/services/question-service/outputs/question_clustering/.gitignore
+++ b/services/question-service/outputs/question_clustering/.gitignore
@@ -1,2 +1,0 @@
-/*
-!/.gitignore

--- a/services/question-service/outputs/question_detection/tfidf_lr_threshold.dvc
+++ b/services/question-service/outputs/question_detection/tfidf_lr_threshold.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: ab06a32b6471b479633410cdda68686f.dir
-  size: 93699585
-  nfiles: 12
+- md5: 9c5f4ecfdde881892b0f2c0c9248af2d.dir
+  size: 97197782
+  nfiles: 18
   hash: md5
   path: tfidf_lr_threshold

--- a/services/question-service/scripts/question-detection/build_retraining_datasets.py
+++ b/services/question-service/scripts/question-detection/build_retraining_datasets.py
@@ -1,0 +1,239 @@
+"""
+TF-IDF 및 KC-ELECTRA 재학습용 데이터셋을 구성합니다.
+
+[TF-IDF 데이터셋 구성]
+  train: 기존 SNS train (? 제거) + 3i4k + KorQuAD 20K
+  valid: 기존 SNS valid (? 제거)  — 평가 일관성 유지
+  test:  기존 SNS test  (? 제거)  — 평가 일관성 유지
+
+[KC-ELECTRA 데이터셋 구성]
+  train: 기존 SNS train 클래스 균형 샘플 (질문 25만 + 비질문 25만, ? 제거)
+         + 3i4k + KorQuAD 10K + LLM 멘토링 hard negative 519건
+  valid: 기존 SNS valid (? 제거)
+  test:  기존 SNS test  (? 제거)
+
+출력:
+  data/processed/question_detection/tfidf_v2/{train,valid,test}.csv
+  data/processed/question_detection/electra_v2/{train,valid,test}.csv
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DATA_ROOT = REPO_ROOT / "data"
+PROCESSED = DATA_ROOT / "processed" / "question_detection"
+AUGMENT   = PROCESSED / "augmentation"
+RAW_3I4K  = DATA_ROOT / "raw" / "3i4k" / "kor_3i4k" / "data"
+
+# KC-ELECTRA 기존 데이터 샘플 수 (클래스별)
+ELECTRA_BASE_PER_CLASS = 250_000
+RANDOM_SEED = 42
+
+# 3i4k 라벨 매핑: 2 → 질문(1), 나머지(1,3,4,5,6) → 비질문(0), 0 → 제외
+I4K_LABEL_MAP = {1: 0, 2: 1, 3: 0, 4: 0, 5: 0, 6: 0}
+
+
+# ─────────────────────────────────────────
+# 전처리
+# ─────────────────────────────────────────
+
+def remove_question_mark(text: str) -> str:
+    return str(text).replace("?", "").strip()
+
+
+def apply_qmark_removal(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    df["text"] = df["text"].astype(str).apply(remove_question_mark)
+    df = df[df["text"].str.len() >= 2].reset_index(drop=True)
+    return df
+
+
+# ─────────────────────────────────────────
+# 데이터 로드
+# ─────────────────────────────────────────
+
+def load_existing(split: str) -> pd.DataFrame:
+    path = PROCESSED / f"{split}.csv"
+    df = pd.read_csv(path, usecols=["text", "label"])
+    return apply_qmark_removal(df)
+
+
+def load_3i4k() -> pd.DataFrame:
+    frames = []
+    for fname in ["train-00000-of-00001.parquet", "test-00000-of-00001.parquet"]:
+        df = pd.read_parquet(RAW_3I4K / fname)
+        df = df[df["label"].isin(I4K_LABEL_MAP)].copy()
+        df["label"] = df["label"].map(I4K_LABEL_MAP)
+        df = df.rename(columns={"text": "text"})[["text", "label"]]
+        frames.append(df)
+    result = pd.concat(frames, ignore_index=True)
+    result = apply_qmark_removal(result)
+    return result.drop_duplicates(subset=["text"])
+
+
+def load_korquad(size: int) -> pd.DataFrame:
+    path = AUGMENT / "korquad_questions_all.csv"
+    df = pd.read_csv(path, usecols=["text", "label"]).sample(
+        min(size, len(pd.read_csv(path))), random_state=RANDOM_SEED
+    )
+    return apply_qmark_removal(df)
+
+
+def load_hard_negatives() -> pd.DataFrame:
+    path = AUGMENT / "mentoring_hard_negatives.csv"
+    df = pd.read_csv(path, usecols=["text", "label"])
+    return apply_qmark_removal(df)
+
+
+# ─────────────────────────────────────────
+# TF-IDF 데이터셋 빌드
+# ─────────────────────────────────────────
+
+def build_tfidf(output_dir: Path) -> None:
+    print("\n[TF-IDF] 데이터셋 구성 중...")
+
+    # valid / test: 기존 데이터 ? 제거만
+    for split in ["valid", "test"]:
+        df = load_existing(split)
+        _save(df, output_dir / f"{split}.csv", split)
+
+    # train: 기존 + 3i4k + KorQuAD 20K
+    base_train  = load_existing("train")
+    i4k         = load_3i4k()
+    korquad     = load_korquad(size=20_000)
+
+    train = pd.concat([base_train, i4k, korquad], ignore_index=True)
+    train = train.drop_duplicates(subset=["text"]).sample(
+        frac=1, random_state=RANDOM_SEED
+    ).reset_index(drop=True)
+
+    _save(train, output_dir / "train.csv", "train")
+
+    print(f"\n  [TF-IDF train 구성]")
+    print(f"    기존 SNS:   {len(base_train):>10,}건")
+    print(f"    3i4k:       {len(i4k):>10,}건")
+    print(f"    KorQuAD:    {len(korquad):>10,}건")
+    print(f"    ─────────────────────")
+    print(f"    합계:       {len(train):>10,}건")
+    q = (train["label"] == 1).sum()
+    print(f"    질문 비율:  {q/len(train)*100:.1f}%  ({q:,} / {len(train):,})")
+
+
+# ─────────────────────────────────────────
+# KC-ELECTRA 데이터셋 빌드
+# ─────────────────────────────────────────
+
+def build_electra(output_dir: Path) -> None:
+    print("\n[KC-ELECTRA] 데이터셋 구성 중...")
+
+    # valid / test: 기존 데이터 ? 제거만 (TF-IDF와 동일)
+    for split in ["valid", "test"]:
+        df = load_existing(split)
+        _save(df, output_dir / f"{split}.csv", split)
+
+    # ── 질문 소스 전체 합산 ──────────────────────────────────
+    i4k      = load_3i4k()
+    korquad  = load_korquad(size=10_000)
+    hard_neg = load_hard_negatives()
+
+    base_train  = load_existing("train")
+    q_base  = base_train[base_train["label"] == 1]   # SNS 질문 전체
+    nq_base = base_train[base_train["label"] == 0]   # SNS 비질문
+
+    # 질문: SNS 전체 + 3i4k 질문 + KorQuAD → 합산 후 총 질문 수 파악
+    all_questions = pd.concat(
+        [q_base,
+         i4k[i4k["label"] == 1],
+         korquad],
+        ignore_index=True,
+    ).drop_duplicates(subset=["text"])
+
+    # 비질문: 3i4k 비질문 + hard negative 먼저 확보
+    nq_fixed = pd.concat(
+        [i4k[i4k["label"] == 0],
+         hard_neg],
+        ignore_index=True,
+    ).drop_duplicates(subset=["text"])
+
+    # SNS 비질문에서 (질문 수 - 고정 비질문 수)만큼 추가 샘플링 → 전체 50:50
+    n_total_q  = len(all_questions)
+    n_nq_extra = max(0, n_total_q - len(nq_fixed))
+    nq_sns = nq_base.sample(min(n_nq_extra, len(nq_base)), random_state=RANDOM_SEED)
+
+    all_nonquestions = pd.concat(
+        [nq_fixed, nq_sns], ignore_index=True
+    ).drop_duplicates(subset=["text"])
+
+    train = pd.concat([all_questions, all_nonquestions], ignore_index=True)
+    train = train.drop_duplicates(subset=["text"]).sample(
+        frac=1, random_state=RANDOM_SEED
+    ).reset_index(drop=True)
+
+    _save(train, output_dir / "train.csv", "train")
+
+    q = (train["label"] == 1).sum()
+    nq = (train["label"] == 0).sum()
+    print(f"\n  [KC-ELECTRA train 구성]")
+    print(f"    질문 소스:")
+    print(f"      SNS 질문 전체:   {len(q_base):>10,}건")
+    print(f"      3i4k 질문:       {len(i4k[i4k['label']==1]):>10,}건")
+    print(f"      KorQuAD:         {len(korquad):>10,}건")
+    print(f"      → 질문 합계:     {q:>10,}건")
+    print(f"    비질문 소스:")
+    print(f"      3i4k 비질문:     {len(i4k[i4k['label']==0]):>10,}건")
+    print(f"      LLM hard neg:    {len(hard_neg):>10,}건")
+    print(f"      SNS 비질문 샘플: {len(nq_sns):>10,}건")
+    print(f"      → 비질문 합계:   {nq:>10,}건")
+    print(f"    ─────────────────────────────")
+    print(f"    합계:              {len(train):>10,}건")
+    print(f"    질문 비율:         {q/len(train)*100:.1f}%")
+
+
+# ─────────────────────────────────────────
+# 유틸
+# ─────────────────────────────────────────
+
+def _save(df: pd.DataFrame, path: Path, label: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df[["text", "label"]].to_csv(path, index=False, encoding="utf-8-sig")
+    q = (df["label"] == 1).sum()
+    print(f"  저장: {path.name}  {len(df):,}건  질문={q:,}({q/len(df)*100:.1f}%)")
+
+
+def print_qmark_check(df: pd.DataFrame, name: str) -> None:
+    remaining = df["text"].str.contains("?", regex=False).sum()
+    print(f"  ? 잔존 확인 [{name}]: {remaining}건 (0이어야 정상)")
+
+
+# ─────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tfidf-out",   default=str(PROCESSED / "tfidf_v2"))
+    parser.add_argument("--electra-out", default=str(PROCESSED / "electra_v2"))
+    parser.add_argument("--skip-tfidf",   action="store_true")
+    parser.add_argument("--skip-electra", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+
+    if not args.skip_tfidf:
+        build_tfidf(Path(args.tfidf_out))
+
+    if not args.skip_electra:
+        build_electra(Path(args.electra_out))
+
+    print("\n완료.")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/question-service/scripts/question-detection/generate_hard_negatives.py
+++ b/services/question-service/scripts/question-detection/generate_hard_negatives.py
@@ -1,0 +1,273 @@
+"""
+OpenAI API를 사용해 멘토링 채팅 hard negative(비질문) 데이터를 생성합니다.
+
+생성 카테고리 (총 8종):
+  1. 반응/감탄         : "아하 이해됐어요", "오 신기하네요"
+  2. 이해/확인 표현    : "방금 이해한 것 같아요", "아 그런 거군요"
+  3. 상황 서술         : "화면이 안 보여요", "소리가 잘 안 들려요"
+  4. 자기 상태 서술    : "이 부분이 어렵네요", "잘 모르겠어요"
+  5. 동의/공감         : "맞는 것 같아요", "저도 그렇게 생각해요"
+  6. 감사/응원         : "감사합니다", "열심히 들을게요"
+  7. 짧은 반응         : "네", "ㅎㅎ", "오케이", "ㅇㅇ"
+  8. 서술형 질문어 포함 : "이게 뭔지 이제 알겠어요", "어떻게 하는지 찾아봐야겠어요"
+     (질문어가 있지만 의문문이 아닌 케이스 — 가장 중요한 hard negative)
+
+출력:
+  data/processed/question_detection/augmentation/mentoring_hard_negatives.csv
+  컬럼: text, label(=0), category
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+from openai import OpenAI
+
+
+OUTPUT_DIR = (
+    Path(__file__).resolve().parent.parent.parent.parent.parent
+    / "data" / "processed" / "question_detection" / "augmentation"
+)
+
+# 카테고리별 생성 목표 수량 (합계 약 500건)
+CATEGORY_TARGETS = {
+    "반응_감탄":          60,
+    "이해_확인":          70,
+    "상황_서술":          60,
+    "자기_상태_서술":      70,
+    "동의_공감":          50,
+    "감사_응원":          40,
+    "짧은_반응":          50,
+    "서술형_질문어_포함":  100,  # 가장 중요, 많이 생성
+}
+
+# 카테고리별 프롬프트 정의
+CATEGORY_PROMPTS: dict[str, dict] = {
+    "반응_감탄": {
+        "description": "무언가를 듣거나 보고 나서 즉각적으로 나오는 감탄·놀람·흥미 표현",
+        "examples": [
+            "아하 이해됐어요!", "오 신기하네요", "헐 진짜요", "와 대박이다",
+            "오호 그렇군요", "아 그런 거구나", "헉 몰랐어요", "오케 이해했어요",
+            "와 너무 신기하네요", "아 맞다", "ㅎㅎ 재밌네요", "오 좋은데요",
+        ],
+        "avoid": "질문 형태(~나요?, ~인가요?, ~는지?)가 되면 안 됩니다. 순수한 감탄/반응 표현만.",
+    },
+    "이해_확인": {
+        "description": "강의 내용을 이해했음을 표현하거나, 방금 이해가 된 순간을 표현하는 발화",
+        "examples": [
+            "방금 이해됐어요", "아 이제 알겠어요", "그게 그런 의미였군요",
+            "이해했습니다", "아 그렇게 하면 되는 거군요", "이제 이해가 가네요",
+            "아 맞다 그거였구나", "오 이제 연결이 되네요", "그래서 그랬던 거군요",
+            "아하 그래서 그렇게 하는 거였군요", "이제 말씀하시는 게 이해가 가요",
+        ],
+        "avoid": "이해를 '요청'하는 표현(설명해 주세요, 다시 말해줘)은 제외. 이해 '완료'를 표현하는 것만.",
+    },
+    "상황_서술": {
+        "description": "현재 발생한 기술적 상황이나 자신의 상태를 서술하는 발화. 해결을 요청하지 않음.",
+        "examples": [
+            "화면이 안 보여요", "소리가 잘 안 들려요", "인터넷이 잠깐 끊겼어요",
+            "화면이 멈췄어요", "로딩이 느리네요", "슬라이드가 안 넘어가네요",
+            "방금 잠깐 끊겼어요", "화면 공유가 안 되네요", "버퍼링이 심하네요",
+            "영상이 끊기네요", "마이크가 안 되나봐요", "연결이 불안정하네요",
+        ],
+        "avoid": "~해주세요, ~해줄 수 있나요 같은 요청문은 제외. 상황을 서술만 하는 것.",
+    },
+    "자기_상태_서술": {
+        "description": "수강생이 자신의 이해도·감정·어려움을 서술하는 발화. 해결 요청 없음.",
+        "examples": [
+            "이 부분이 좀 어렵네요", "잘 모르겠어요", "아직 헷갈려요",
+            "이해하려고 노력 중이에요", "열심히 따라가고 있어요",
+            "이 개념이 아직 낯설어요", "복잡하게 느껴지네요",
+            "조금 더 생각해봐야 할 것 같아요", "메모하면서 듣고 있어요",
+            "처음 들어보는 내용이라 집중해서 듣고 있어요",
+            "이 부분은 다시 찾아봐야겠어요",
+        ],
+        "avoid": "질문 형태나 해결 요청은 제외. '~모르겠어요'(서술)는 OK, '~알려주세요'(요청)는 NG.",
+    },
+    "동의_공감": {
+        "description": "강사나 다른 수강생의 말에 동의하거나 공감을 표현하는 발화",
+        "examples": [
+            "맞는 것 같아요", "저도 그렇게 생각해요", "그게 더 나을 것 같아요",
+            "동의해요", "그렇죠", "저도요", "공감돼요",
+            "저도 그 부분이 그랬어요", "맞아요 저도 그렇게 느꼈어요",
+            "역시 그게 맞는 것 같네요", "저도 비슷한 경험이 있어요",
+        ],
+        "avoid": "동의를 구하는 질문(~맞죠?, ~그렇죠?)는 제외. 동의 '표명'만.",
+    },
+    "감사_응원": {
+        "description": "강사에게 감사 인사를 전하거나, 강의에 긍정적 반응을 보이는 발화",
+        "examples": [
+            "감사합니다", "정말 도움이 됐어요", "좋은 강의 감사해요",
+            "열심히 듣겠습니다", "잘 배우고 있어요", "이해하기 쉽게 설명해 주시네요",
+            "오늘도 좋은 강의 감사합니다", "이렇게 자세히 설명해 주셔서 감사해요",
+            "많이 배우고 가요", "도움이 많이 됐어요", "다음에도 기대돼요",
+        ],
+        "avoid": "질문 형태는 제외.",
+    },
+    "짧은_반응": {
+        "description": "실시간 채팅에서 자주 나오는 1~6글자 이내의 짧은 반응 발화",
+        "examples": [
+            "네", "ㅎㅎ", "ㅋㅋ", "오", "아", "오케이", "알겠어요",
+            "넵", "웅", "ㅇㅇ", "감사해요", "ㅎㅎㅎ", "맞아요",
+            "진짜요", "대박", "오케", "넹",
+        ],
+        "avoid": "6글자 초과 제외. ? 포함 제외.",
+    },
+    "서술형_질문어_포함": {
+        "description": (
+            "가장 중요한 카테고리. '왜', '어떻게', '뭔지', '언제' 같은 질문어가 포함되어 있지만 "
+            "의문문이 아니라 서술문인 발화. 이런 표현이 질문으로 오탐될 수 있어서 "
+            "모델이 반드시 구분할 수 있어야 합니다."
+        ),
+        "examples": [
+            "이게 뭔지 이제 알겠어요",
+            "어떻게 하는지 찾아봐야겠어요",
+            "왜 그런지 이유를 알게 됐어요",
+            "언제 쓰는 건지 이제 이해됐어요",
+            "어디에 쓰는 건지 감이 오네요",
+            "왜 이렇게 되는지 이제 납득이 가요",
+            "어떻게 작동하는지 대충 알 것 같아요",
+            "뭘 해야 하는지 이제 알겠어요",
+            "누가 만든 건지 방금 찾아봤어요",
+            "얼마나 걸리는지 생각해보고 있었어요",
+            "이게 왜 필요한지 이제 이해가 돼요",
+            "어떤 경우에 쓰는지 감이 잡혔어요",
+        ],
+        "avoid": (
+            "의문문이 되면 안 됩니다. '이게 뭔가요?'(의문문) → NG. "
+            "'이게 뭔지 알겠어요'(서술문) → OK. "
+            "문장 끝이 서술어(-어요, -네요, -겠어요, -같아요 등)로 끝나야 합니다."
+        ),
+    },
+}
+
+
+SYSTEM_PROMPT = """당신은 한국어 NLP 훈련 데이터 생성 전문가입니다.
+멘토링 플랫폼의 실시간 라이브 강의 채팅창에서 수강생이 보내는 실제 발화를 생성합니다.
+
+[중요 규칙]
+1. 생성하는 모든 발화는 반드시 '비질문'이어야 합니다 — 의문문, 간접 의문문, 요청문 모두 제외
+2. 각 발화는 한 줄에 하나씩, 번호나 기호 없이 텍스트만 출력하세요
+3. 다양한 길이와 표현 방식을 사용하세요 (너무 획일적이면 안 됩니다)
+4. 실제 채팅에서 쓸 법한 자연스러운 한국어로 작성하세요
+5. 중복되는 표현은 최대한 피하세요
+6. ? 를 절대 사용하지 마세요"""
+
+
+def build_user_prompt(category: str, config: dict, target_count: int) -> str:
+    return f"""카테고리: {category}
+설명: {config['description']}
+
+예시 (참고용, 그대로 복사하지 말고 다양하게 변형하세요):
+{chr(10).join(f'- {e}' for e in config['examples'])}
+
+주의사항: {config['avoid']}
+
+위 조건에 맞는 발화를 {target_count}개 생성하세요.
+한 줄에 하나씩, 번호 없이, 텍스트만 출력하세요."""
+
+
+def call_openai(client: OpenAI, category: str, config: dict, target_count: int, model: str) -> list[str]:
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": build_user_prompt(category, config, target_count)},
+        ],
+        temperature=1.0,
+        max_tokens=target_count * 40,
+    )
+    raw = response.choices[0].message.content or ""
+    lines = [line.strip() for line in raw.splitlines()]
+    # 번호/기호 제거, 빈 줄 제거, ? 포함된 줄 제거
+    results = []
+    for line in lines:
+        line = line.lstrip("0123456789.-) ").strip()
+        if not line:
+            continue
+        if "?" in line:
+            continue
+        results.append(line)
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="멘토링 채팅 Hard Negative 생성")
+    parser.add_argument("--output-dir", type=str, default=str(OUTPUT_DIR))
+    parser.add_argument("--model", type=str, default="gpt-4o-mini", help="OpenAI 모델")
+    parser.add_argument("--env-file", type=str, default=None, help=".env 파일 경로 (미지정 시 환경변수 사용)")
+    parser.add_argument("--dry-run", action="store_true", help="API 호출 없이 프롬프트만 출력")
+    return parser.parse_args()
+
+
+def load_api_key(env_file: str | None) -> str:
+    if env_file:
+        for line in Path(env_file).read_text(encoding="utf-8").splitlines():
+            if line.startswith("OPENAI_API_KEY="):
+                return line.split("=", 1)[1].strip()
+    api_key = os.environ.get("OPENAI_API_KEY", "")
+    if not api_key:
+        raise ValueError("OPENAI_API_KEY가 설정되어 있지 않습니다. --env-file 옵션을 사용하세요.")
+    return api_key
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.dry_run:
+        print("=== DRY RUN: 프롬프트 미리보기 ===\n")
+        for category, config in CATEGORY_PROMPTS.items():
+            target = CATEGORY_TARGETS[category]
+            print(f"[{category}] 목표: {target}건")
+            print(build_user_prompt(category, config, target))
+            print("-" * 60)
+        return
+
+    api_key = load_api_key(args.env_file)
+    client = OpenAI(api_key=api_key)
+
+    all_rows: list[dict] = []
+    total_target = sum(CATEGORY_TARGETS.values())
+    print(f"총 {total_target}건 생성 시작 (모델: {args.model})\n")
+
+    for i, (category, config) in enumerate(CATEGORY_PROMPTS.items(), 1):
+        target = CATEGORY_TARGETS[category]
+        print(f"[{i}/{len(CATEGORY_PROMPTS)}] {category} ({target}건 목표)...", end=" ", flush=True)
+
+        try:
+            texts = call_openai(client, category, config, target, args.model)
+            print(f"{len(texts)}건 생성됨")
+            for text in texts:
+                all_rows.append({"text": text, "label": 0, "category": category})
+        except Exception as e:
+            print(f"실패: {e}")
+
+        if i < len(CATEGORY_PROMPTS):
+            time.sleep(1)
+
+    df = pd.DataFrame(all_rows)
+    df = df.drop_duplicates(subset=["text"]).reset_index(drop=True)
+
+    output_path = output_dir / "mentoring_hard_negatives.csv"
+    df.to_csv(output_path, index=False, encoding="utf-8-sig")
+
+    print(f"\n=== 생성 완료 ===")
+    print(f"총 {len(df):,}건 저장: {output_path}")
+    print("\n카테고리별 생성 수:")
+    print(df["category"].value_counts().to_string())
+    print("\n샘플 (카테고리별 2개):")
+    for cat in df["category"].unique():
+        samples = df[df["category"] == cat]["text"].head(2).tolist()
+        print(f"\n  [{cat}]")
+        for s in samples:
+            print(f"    {s}")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/question-service/scripts/question-detection/prepare_korquad.py
+++ b/services/question-service/scripts/question-detection/prepare_korquad.py
@@ -1,0 +1,122 @@
+"""
+KorQuAD v1 에서 질문 데이터를 추출하여 학습용 CSV로 저장합니다.
+
+출력:
+  - korquad_questions_tfidf.csv   : TF-IDF용 20,000건  (label=1)
+  - korquad_questions_electra.csv : KC-ELECTRA용 10,000건 (label=1)
+  - korquad_questions_all.csv     : 전체 (중복 제거)
+
+전처리:
+  - ? 제거 (학습 시 ? 의존도 제거 전략)
+  - 공백 정리
+  - 너무 짧은 질문 (10자 미만) 제거
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+from datasets import load_dataset
+
+
+OUTPUT_DIR = Path(__file__).resolve().parent.parent.parent.parent.parent / "data" / "processed" / "question_detection" / "augmentation"
+
+TFIDF_SIZE = 20_000
+ELECTRA_SIZE = 10_000
+MIN_CHAR_LEN = 10
+RANDOM_SEED = 42
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="KorQuAD 질문 데이터 추출 및 전처리")
+    parser.add_argument("--output-dir", type=str, default=str(OUTPUT_DIR))
+    parser.add_argument("--tfidf-size", type=int, default=TFIDF_SIZE)
+    parser.add_argument("--electra-size", type=int, default=ELECTRA_SIZE)
+    parser.add_argument("--min-len", type=int, default=MIN_CHAR_LEN)
+    parser.add_argument("--seed", type=int, default=RANDOM_SEED)
+    return parser.parse_args()
+
+
+def load_korquad() -> pd.DataFrame:
+    print("[1/4] KorQuAD v1 로드 중...")
+    ds = load_dataset("squad_kor_v1")
+    train_df = pd.DataFrame(ds["train"])
+    valid_df = pd.DataFrame(ds["validation"])
+    df = pd.concat([train_df, valid_df], ignore_index=True)
+    print(f"  총 {len(df):,}건 로드 완료")
+    return df
+
+
+def preprocess(df: pd.DataFrame, min_len: int) -> pd.DataFrame:
+    print("[2/4] 전처리 중...")
+    questions = df["question"].dropna().astype(str)
+
+    # ? 제거 후 공백 정리
+    questions = questions.str.replace("?", "", regex=False).str.strip()
+
+    # 너무 짧은 텍스트 제거
+    mask = questions.str.len() >= min_len
+    questions = questions[mask].drop_duplicates().reset_index(drop=True)
+
+    print(f"  전처리 후: {len(questions):,}건 (원본 {len(df):,}건에서 {len(df)-len(questions):,}건 제거)")
+
+    has_qmark = questions.str.contains("?", regex=False)
+    print(f"  ? 잔존 여부 확인: {has_qmark.sum()}건 (0이어야 정상)")
+
+    return pd.DataFrame({"text": questions, "label": 1})
+
+
+def sample_and_save(df: pd.DataFrame, output_dir: Path, tfidf_size: int, electra_size: int, seed: int) -> None:
+    print("[3/4] 샘플링 및 저장 중...")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # 전체 저장
+    all_path = output_dir / "korquad_questions_all.csv"
+    df.to_csv(all_path, index=False, encoding="utf-8-sig")
+    print(f"  전체 저장: {all_path} ({len(df):,}건)")
+
+    # TF-IDF용
+    tfidf_size = min(tfidf_size, len(df))
+    tfidf_df = df.sample(tfidf_size, random_state=seed)
+    tfidf_path = output_dir / "korquad_questions_tfidf.csv"
+    tfidf_df.to_csv(tfidf_path, index=False, encoding="utf-8-sig")
+    print(f"  TF-IDF용 저장: {tfidf_path} ({len(tfidf_df):,}건)")
+
+    # KC-ELECTRA용
+    electra_size = min(electra_size, len(df))
+    electra_df = df.sample(electra_size, random_state=seed)
+    electra_path = output_dir / "korquad_questions_electra.csv"
+    electra_df.to_csv(electra_path, index=False, encoding="utf-8-sig")
+    print(f"  KC-ELECTRA용 저장: {electra_path} ({len(electra_df):,}건)")
+
+
+def print_summary(df: pd.DataFrame) -> None:
+    print("\n[4/4] 데이터 요약")
+    print(f"  총 질문 수: {len(df):,}건")
+    print(f"  평균 길이: {df['text'].str.len().mean():.1f}자")
+    print(f"  최소 길이: {df['text'].str.len().min()}자")
+    print(f"  최대 길이: {df['text'].str.len().max()}자")
+    print("\n  어미 패턴 상위 10 (끝 3글자):")
+    endings = df["text"].str[-3:].value_counts().head(10)
+    for ending, cnt in endings.items():
+        print(f"    {ending}  {cnt:,}건")
+    print("\n  샘플 10개:")
+    for text in df["text"].sample(10, random_state=42).tolist():
+        print(f"    {text}")
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = Path(args.output_dir)
+
+    df = load_korquad()
+    df = preprocess(df, args.min_len)
+    sample_and_save(df, output_dir, args.tfidf_size, args.electra_size, args.seed)
+    print_summary(df)
+    print("\n완료.")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/question-service/scripts/question-detection/preprocess_question_detection_for_tfidf.py
+++ b/services/question-service/scripts/question-detection/preprocess_question_detection_for_tfidf.py
@@ -77,8 +77,8 @@ def normalize_for_tfidf(text: str) -> str:
     text = re.sub(r"[|]+", " ", text)
 
     # 한글/영문/숫자/기본 문장부호만 남기고 나머지는 공백 처리
-    # 질문 판별에 중요한 ?, ! 는 유지
-    text = re.sub(r"[^0-9a-z가-힣\s?!.,]", " ", text)
+    # ? 제거: 모델이 ?에 의존하지 않고 문장 구조로 질문을 판별하도록
+    text = re.sub(r"[^0-9a-z가-힣\s!.,]", " ", text)
 
     # 공백 정리
     text = re.sub(r"\s+", " ", text).strip()

--- a/services/question-service/scripts/question-detection/question_detection_inference.py
+++ b/services/question-service/scripts/question-detection/question_detection_inference.py
@@ -113,6 +113,8 @@ def route_to_kc_electra(
         return True, "rule_question_requires_confirmation"
 
     if rule_label is None:
+        if tfidf_score < tfidf_threshold:
+            return False, "rule_uncertain_tfidf_negative"
         return True, "rule_uncertain"
 
     return False, "tfidf_direct_decision"

--- a/services/question-service/scripts/question-detection/question_detection_rules.py
+++ b/services/question-service/scripts/question-detection/question_detection_rules.py
@@ -159,6 +159,8 @@ NON_QUESTION_END_PATTERNS = [
     r"웃기네[.!]?$",
     r"처음\s*들어봐[.!]?$",
     r"처음\s*봤어[.!]?$",
+    r"듯[이]?[.!]?$",
+    r"네요[.!]?$",
 ]
 
 SPECIAL_ONLY_PATTERN = r"^[\W_]+$"
@@ -253,7 +255,7 @@ def classify_question_by_rules(text: str) -> tuple[int | None, str]:
         return 0, "rule_statement_ending"
 
     if (
-        features["is_very_short_text"]
+        features["is_short_text"]
         and features["has_reaction_like"]
         and not features["has_question_mark"]
     ):

--- a/services/question-service/src/lib/questionDetectorClient.js
+++ b/services/question-service/src/lib/questionDetectorClient.js
@@ -22,7 +22,7 @@ const DEFAULT_TFIDF_ARTIFACT_DIR = path.join(
     'services',
     'model',
     'question_detection',
-    'tfidf_lr_rule_filter_off',
+    'tfidf_lr_v2',
 );
 
 const DEFAULT_KC_ELECTRA_DIR = path.join(
@@ -30,7 +30,7 @@ const DEFAULT_KC_ELECTRA_DIR = path.join(
     'services',
     'model',
     'question_detection',
-    'kc_electra_question_detector',
+    'kc_electra_v2',
 );
 
 function getPythonExecutable() {


### PR DESCRIPTION
## 연관된 이슈

#163

## 작업 내용

라이브 멘토링 채팅에서 비질문 발화가 질문으로 오탐되던 문제를 수정하고, 물음표 의존도를 낮추는 방향으로 질문 탐지 모델을 재학습했습니다.

규칙 개선

- rule_short_reaction 기준 완화 (3자 → 6자), 서술형 어미 비질문 패턴 추가 (듯$, 네요$)

모델 재학습 (v2)

- 전처리에서 ? 제거로 물음표 의존도 제거
- KorQuAD / 3i4k / LLM 생성 hard negative 519건으로 학습 데이터 보강
- KC-ELECTRA v2: 질문/비질문 50:50 클래스 균형 적용
- TF-IDF v2: class_weight 제거 후 재학습

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 점 작성