### PR TITLE
fix/question model API DVC deploy 수정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -198,6 +198,31 @@ jobs:
                 continue
               }
 
+              if [ "$SERVICE" = "question-model-api" ]; then
+                DVC_PY=/tmp/dvc-venv/bin/python
+
+                if [ ! -x "$DVC_PY" ]; then
+                  python3 -m venv /tmp/dvc-venv || {
+                    apt-get update
+                    apt-get install -y python3-venv
+                    python3 -m venv /tmp/dvc-venv
+                  }
+                  "$DVC_PY" -m pip install --upgrade pip
+                  "$DVC_PY" -m pip install "dvc[s3]"
+                fi
+
+                if [ ! -f /app/.dvc/config ]; then
+                  cd /app && "$DVC_PY" -m dvc init --no-scm
+                  "$DVC_PY" -m dvc remote add -d carpoolink s3://capstone2026-carpoolink-dvc-kro
+                  "$DVC_PY" -m dvc remote modify carpoolink region ap-northeast-2
+                fi
+
+                mkdir -p /app/services/model
+                echo "${{ steps.dvc_file.outputs.question_detection_dvc }}" | base64 -d > /app/services/model/question_detection.dvc
+
+                cd /app && "$DVC_PY" -m dvc pull services/model/question_detection.dvc -j 1 --no-run-cache --force
+              fi
+
               # 2. 기존 컨테이너 정리
               docker stop carpoolink-$SERVICE 2>/dev/null || true
               docker rm carpoolink-$SERVICE 2>/dev/null || true
@@ -245,23 +270,6 @@ jobs:
                     ghcr.io/${{ env.REPO_OWNER }}/question-service:${{ github.sha }}
                   ;;
                 "question-model-api")
-                  # DVC 설치 (없으면)
-                  command -v dvc >/dev/null 2>&1 || pip3 install "dvc[s3]" -q
-
-                  # DVC 초기화 및 remote 설정 (없으면)
-                  if [ ! -f /app/.dvc/config ]; then
-                    cd /app && dvc init --no-scm
-                    dvc remote add -d carpoolink s3://capstone2026-carpoolink-dvc-kro
-                    dvc remote modify carpoolink region ap-northeast-2
-                  fi
-
-                  # .dvc 파일 업데이트 (GitHub repo 기준)
-                  mkdir -p /app/services/model
-                  echo "${{ steps.dvc_file.outputs.question_detection_dvc }}" | base64 -d > /app/services/model/question_detection.dvc
-
-                  # S3에서 모델 동기화 (변경된 것만 다운로드)
-                  cd /app && dvc pull services/model/question_detection.dvc
-
                   docker run --restart always \
                     -d --name carpoolink-question-model-api \
                     --network carpoolink-network \


### PR DESCRIPTION
## 연관된 이슈

#167 

## 작업 내용

- question-model-api 배포 전에 DVC 모델 동기화를 먼저 수행하도록 배포 순서를 변경했습니다.
- EC2 시스템 Python에 직접 dvc[s3]를 설치하지 않고, /tmp/dvc-venv`가상환경을 생성해 DVC를 실행하도록 수정했습니다.
- /app/.dvc/config가 없을 경우 dvc init --no-scm 및 S3 remote 설정을 자동으로 수행하도록 했습니다.
- GitHub Actions에서 읽은 최신 services/model/question_detection.dvc 내용을 EC2의 /app/services/model/question_detection.dvc에 반영하도록 했습니다.
- 서버에서 검증된 방식으로 모델을 동기화하도록 dvc pull 명령에 -j 1 --no-run-cache --force 옵션을 적용했습니다.
- DVC pull이 성공한 뒤에만 기존 question-model-api 컨테이너를 중지/삭제하고 새 컨테이너를 실행하도록 변경했습니다.
- 기존 case 내부에 있던 pip3 install "dvc[s3]" 및 일반 dvc pull 로직을 제거했습니다.

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 점 작성