### PR TITLE
스크립트 및 일대일 멘토링 ui 및 마스킹 문제 수정

### DIFF
--- a/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/1on1_list/page.tsx
@@ -104,6 +104,23 @@ const getPrimaryAction = (person: MentoringPerson, userRole: string | null) => {
   };
 };
 
+const formatKoreanDateTime = (dateString: string | null | undefined): string => {
+  if (!dateString) return "일정 미정";
+
+  const date = new Date(dateString);
+
+  // 유효하지 않은 날짜인 경우 예외 처리
+  if (isNaN(date.getTime())) return "일정 미정";
+
+  const year = date.getFullYear();
+  const month = date.getMonth() + 1;
+  const day = date.getDate();
+  const hours = date.getHours();
+  const minutes = date.getMinutes();
+
+  return `${year}년 ${month}월 ${day}일 ${hours}시 ${minutes}분`;
+};
+
 export default function OneOnOneListPage() {
   const router = useRouter();
   const [userRole, setUserRole] = useState<string | null>(null);
@@ -145,7 +162,7 @@ export default function OneOnOneListPage() {
           const mentoringId = Number(item.mentoringId);
           const counterpartName = item.counterpartName || item.counterpart?.nickname || item.host?.nickname || "이름 없음";
 
-          const schedule = item.startedAt || item.scheduledAt || "일정 미정";
+          const schedule = item.startedAt || item.scheduledAt || null;
           const status = String(item.status || item.rawStatus || "COMPLETE").toUpperCase();
 
           return {
@@ -263,7 +280,7 @@ export default function OneOnOneListPage() {
                 </div>
                 <div className="bg-gray-50 p-3 rounded-xl mb-4 text-[13px]">
                   <div className="flex gap-2 mb-1"><span className="font-bold text-gray-500 w-20">멘토링 제목</span><span>{person.title}</span></div>
-                  <div className="flex gap-2"><span className="font-bold text-gray-500 w-14">일정</span><span className="font-bold">{person.lastMentoring}</span></div>
+                  <div className="flex gap-2"><span className="font-bold text-gray-500 w-20">일정</span><span className="font-bold">{formatKoreanDateTime(person.lastMentoring)}</span></div>
                 </div>
                 <div className="flex gap-2">
                   <button onClick={() => setActiveMessage(person)} className="flex-1 py-2.5 bg-gray-100 rounded-xl font-bold text-[14px] hover:bg-gray-200 transition-colors cursor-pointer">메시지</button>

--- a/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mentoring_list/live_list/page.tsx
@@ -131,7 +131,7 @@ function LiveListContent() {
         hasCamera: true,
         hasMicrophone: true,
       }, {
-        headers:{
+        headers: {
           'x-user-id': currentUserId // 미디어 서버가 요구하는 필수 식별값 추가
         }
       });
@@ -257,7 +257,7 @@ function LiveListContent() {
                   <div className="w-1.5 h-1.5 bg-white rounded-full animate-pulse" /> LIVE
                 </div>
                 <div className="absolute bottom-3 right-3 bg-black/70 text-white text-[12px] font-bold px-2.5 py-1 rounded-[8px] flex items-center gap-1.5">
-                  <Users className="w-3.5 h-3.5" /> {stream.participantCount}명 시청 중
+                  <Users className="w-3.5 h-3.5" /> {stream.participantCount}명 시청
                 </div>
               </div>
 

--- a/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
+++ b/apps/demo-web/app/(with-nav)/mypage/scripts/page.tsx
@@ -8,7 +8,8 @@ import apiClient from "@/lib/apiClient";
 
 type ScriptItem = {
   id: number;
-  mentorName: string;
+  counterpartName: string;
+  counterpartRole: "MENTOR" | "MENTEE";
   topic: string;
   date: string;
   isPublished: boolean;
@@ -70,9 +71,13 @@ function ScriptListContent() {
             ? `${d.getFullYear()}. ${String(d.getMonth() + 1).padStart(2, '0')}. ${String(d.getDate()).padStart(2, '0')}`
             : "날짜 미상";
 
+          const name = m.counterpart?.nickname || m.host?.nickname || "이름 없음";
+          const role = m.counterpart?.role === "MENTOR" ? "MENTOR" : "MENTEE";
+
           return {
             id: Number(m.mentoringId),
-            mentorName: m.host?.nickname || "알 수 없음",
+            counterpartName: name,
+            counterpartRole: role,
             topic: m.title,
             date: dateStr,
             isGroup: m.isGroup,
@@ -220,7 +225,10 @@ function ScriptListContent() {
                       </div>
                     )}
                     <div className="flex flex-col">
-                      <span className="text-[13px] font-bold text-gray-400">{script.mentorName} 멘토</span>
+                      <span className="text-[13px] font-bold text-gray-400">
+                        {script.counterpartRole === "MENTOR" ? "멘토" : "멘티"}
+                        <span className="text-gray-700 ml-1">{script.counterpartName}</span>
+                      </span>
                       <h3 className="text-[16px] font-bold leading-snug mt-0.5">{script.topic}</h3>
                     </div>
                   </div>

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -628,7 +628,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                         method: "POST",
                         headers: { "Content-Type": "application/json" },
                         body: JSON.stringify({
-                            userId: String(userId),
+                            userId: String(question.userId),
                             mentoringId: String(mentoringId),
                             text: scriptText,
                             isPrivate: question.isPrivate

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -912,7 +912,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                                         className={`px-3 py-2.5 rounded-xl text-[12px] font-bold flex items-center justify-center transition-all ${isReading ? 'bg-red-500 text-white shadow-lg' : 'bg-[#1A1A1A] text-[#FFCC00]'}`}
                                     >
                                         <Volume2 className={`w-3.5 h-3.5 mr-1.5 ${isReading ? 'animate-pulse' : ''}`} />
-                                        {isReading ? '읽는 중...' : '질문 읽기'}
+                                        {isReading ? '읽는 중...' : '질문 듣기'}
                                     </button>
                                     <button
                                         onClick={() => completeQuestion(Number(currentQuestion?.id))}
@@ -985,7 +985,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                             <div className="flex gap-2">
                                 {currentQuestion && (
                                     <>
-                                        <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">다음 질문</button>
+                                        <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">질문 읽기</button>
                                         <button onClick={() => completeQuestion(currentQuestion.id)} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">답변 완료</button>
                                         <button onClick={() => acknowledgeQuestion(currentQuestion)} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full text-center active:scale-95 transition-transform">질문 다시 읽기</button>
                                     </>

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -961,7 +961,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                     {/* [2] 비디오 화면 영역 */}
                     <div className="w-full aspect-[16/9] bg-[#1A1A1A] rounded-2xl relative overflow-hidden flex flex-col justify-between shadow-2xl border border-gray-800 shrink-0">
                         {isCameraOn ? (
-                            <video ref={videoRef} className="absolute inset-0 w-full h-full object-cover" autoPlay playsInline muted />
+                            <video ref={videoRef} className="absolute inset-0 w-full h-full object-cover scale-x-[-1]" autoPlay playsInline muted />
                         ) : (
                             <div className="absolute inset-0 w-full h-full flex flex-col items-center justify-center bg-[#1A1A1A]">
                                 <VideoOff className="w-8 h-8 text-gray-500 mb-2" />

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -985,9 +985,9 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                             <div className="flex gap-2">
                                 {currentQuestion && (
                                     <>
-                                        <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">질문 읽기</button>
+                                        <button onClick={handleNextQuestion} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">질문 듣기</button>
                                         <button onClick={() => completeQuestion(currentQuestion.id)} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full">답변 완료</button>
-                                        <button onClick={() => acknowledgeQuestion(currentQuestion)} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full text-center active:scale-95 transition-transform">질문 다시 읽기</button>
+                                        <button onClick={() => acknowledgeQuestion(currentQuestion)} className="bg-[#FFCC00] text-[#1A1A1A] text-[11px] font-bold px-3 py-2 rounded-full text-center active:scale-95 transition-transform">질문 다시 듣기</button>
                                     </>
                                 )}
                             </div>

--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -857,7 +857,7 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
                     </div>
                     <div className="flex items-center text-gray-400 text-sm font-medium">
                         <Users className="w-4 h-4 mr-1.5" />
-                        {onlineUserCount}
+                        {onlineUserCount - 1}
                     </div>
                 </div>
             </header>

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useRef, use } from "react";
 import { useRouter } from "next/navigation";
-import { ChevronLeft, Undo2, Send, Bell, MousePointer2, Grab, Eraser, EyeOff, Loader2 } from "lucide-react";
+import { ChevronLeft, Undo2, Send, Bell, Info, Grab, Eraser, EyeOff, Loader2, X } from "lucide-react";
 
 import apiClient from "@/lib/apiClient";
 
@@ -326,24 +326,15 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       <div className={`flex items-center justify-between px-5 py-3 border-b border-gray-100 border-dashed bg-[#FAFAFA] shrink-0 transition-all duration-300 overflow-hidden
         ${isMenteeView ? 'max-h-0 opacity-0 py-0' : 'max-h-20 opacity-100'}
       `}>
-        <div className="flex bg-gray-200/60 p-1 rounded-xl">
-          <button onClick={() => setEditMode("drag")} className={`px-4 py-1.5 text-[13px] font-bold rounded-lg transition-all flex items-center gap-1.5 ${editMode === "drag" ? 'bg-[#FFCC00] text-[#1A1A1A] shadow-sm' : 'text-gray-500'}`}>
-            <Grab className="w-3.5 h-3.5" /> 드래그
-          </button>
-          <button onClick={() => setEditMode("click")} className={`px-4 py-1.5 text-[13px] font-bold rounded-lg transition-all flex items-center gap-1.5 ${editMode === "click" ? 'bg-[#FFCC00] text-[#1A1A1A] shadow-sm' : 'text-gray-500'}`}>
-            <MousePointer2 className="w-3.5 h-3.5" /> 원클릭
-          </button>
+        <div className="`px-4 py-1.5 text-[13px] rounded-lg transition-all flex items-center gap-1.5 text-gray-500">
+          <Info className="w-4 h-4" />민감한 정보는 드래그하여 가릴 수 있습니다.
         </div>
 
         <div className="flex items-center gap-2">
-          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹">
-            <EyeOff className="w-4 h-4" />
-          </button>
-          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('erase')} className="bg-gray-100 text-[#1A1A1A] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹 해제">
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('mask')} className="bg-gray-100 text-gray-500 text-[12px] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹">
             <Eraser className="w-4 h-4" />
           </button>
-          <div className="h-4 w-[1px] bg-gray-300 mx-1" />
-          <button onMouseDown={(e) => e.preventDefault()} onClick={handleUndo} disabled={!canUndo} className={`p-2 rounded-lg transition-colors ${canUndo ? 'text-gray-700 hover:bg-gray-200' : 'text-gray-300 cursor-not-allowed'}`} title="실행 취소">
+          <button onMouseDown={(e) => e.preventDefault()} onClick={() => handleAction('erase')} className="bg-gray-100 text-gray-500 text-[12px] active:bg-gray-300 p-2 rounded-lg transition-colors shadow-sm" title="선택된 영역 마스킹 해제">
             <Undo2 className="w-4 h-4" />
           </button>
         </div>
@@ -357,7 +348,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           </div>
         ) : (
           <>
-            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase">Mentoring ID: {id}</p>
+            <p className="text-[11px] font-bold text-gray-400 tracking-wider mb-2 uppercase"></p>
             <h2 className="text-[26px] font-extrabold text-[#1A1A1A] leading-tight mb-8">
               {mentoringInfo?.title}
               <span className="block text-[15px] font-medium text-gray-400 mt-2 tracking-normal">{mentoringInfo?.date}</span>

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -221,6 +221,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
       // 이하 변환 및 전송 로직 (기존과 동일)
       const payloadScripts = Array.from(payloadMap.entries()).map(([scriptId, rawPieces]) => {
+        // 1. 연속된 동일 마스킹 블록 병합 (기존 로직 유지)
         const mergedPieces = rawPieces.reduce((acc, current) => {
           if (acc.length > 0 && acc[acc.length - 1].isMasked === current.isMasked) {
             acc[acc.length - 1].text += current.text;
@@ -230,9 +231,28 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           return acc;
         }, [] as { text: string; isMasked: boolean }[]);
 
+        // 2. 💡 [핵심 수정] 원본 데이터(scriptList)에서 현재 scriptId와 일치하는 원본 스크립트 찾기
+        const originalScript = scriptList.find(
+          (s) => String(s.scriptId || s.id) === String(scriptId)
+        );
+
+        // 3. 기존 content 객체 파싱 및 보존 처리
+        let originalContent = originalScript?.content || {};
+        if (typeof originalContent === 'string') {
+          try {
+            originalContent = JSON.parse(originalContent);
+          } catch (e) {
+            originalContent = {};
+          }
+        }
+
+        // 4. 기존 속성(startTime, chunkIndex, endTime 등)은 유지하고, pieces만 업데이트하여 payload 조립
         return {
           scriptId: scriptId,
-          content: { pieces: mergedPieces }
+          content: {
+            ...originalContent,
+            pieces: mergedPieces
+          }
         };
       });
 

--- a/apps/demo-web/app/script/[id]/page.tsx
+++ b/apps/demo-web/app/script/[id]/page.tsx
@@ -128,7 +128,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           textHTML = parsedContent.pieces.map((p: any) => {
             const escapedText = p.text.replace(/\n/g, "<br>");
             if (p.isMasked === true || p.isMasked === "true") {
-              return `<span style="background-color: #FFCC00">${escapedText}</span>`;
+              return `<span class="masked-piece" style="background-color: #FFCC00; display: inline;">${escapedText}</span>`;
             }
             return escapedText;
           }).join("");
@@ -138,7 +138,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
           textHTML = rawText.trim().replace(/\n/g, "<br>");
 
           if (s.isMasked === true || s.isMasked === "true" || parsedContent?.isMasked === true) {
-            textHTML = `<span style="background-color: #FFCC00">${textHTML}</span>`;
+            textHTML = `<span class="masked-piece" style="background-color: #FFCC00; display: inline;">${textHTML}</span>`;
           }
         }
 
@@ -157,7 +157,6 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
     try {
       const scriptBlocks = editorRef.current.querySelectorAll('.script-block');
-
       const payloadMap = new Map<string, { text: string; isMasked: boolean }[]>();
 
       scriptBlocks.forEach((block) => {
@@ -168,6 +167,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
 
         const pieces: { text: string; isMasked: boolean }[] = [];
 
+        // 💡 [핵심 수정] 노드 탐색 함수 개선
         const parseNode = (node: Node, isCurrentlyMasked: boolean) => {
           if (node.nodeType === Node.TEXT_NODE) {
             if (node.textContent) {
@@ -177,21 +177,39 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
             const el = node as HTMLElement;
             const tag = el.tagName.toUpperCase();
 
-            // 엔터를 막았기 때문에 BR 태그가 생길 일은 없지만, 기존 데이터 호환을 위해 남겨둠
             if (tag === 'BR') {
               pieces.push({ text: '\n', isMasked: isCurrentlyMasked });
               return;
             }
 
-            const bg = el.style.backgroundColor;
-            const isNodeMasked = bg.includes('rgb(255, 204, 0)') || bg.includes('#FFCC00') || bg.includes('#ffcc00');
-            const effectiveMask = isCurrentlyMasked || isNodeMasked;
+            // 1. 클래스명으로 마스킹 여부 체크
+            const hasMaskClass = el.classList.contains('masked-piece');
+
+            // 2. 인라인 스타일 배경색 추출 및 공백 제거 검사
+            const bg = (el.style.backgroundColor || '').replace(/\s+/g, '').toLowerCase();
+            const hasMaskColor =
+              bg.includes('rgb(255,204,0)') ||
+              bg.includes('#ffcc00') ||
+              bg.includes('rgba(255,204,0'); // 알파 채널 대비
+
+            // 부모가 마스킹 상태이거나, 현재 요소가 마스킹 클래스/컬러를 가졌다면 true
+            const effectiveMask = isCurrentlyMasked || hasMaskClass || hasMaskColor;
 
             el.childNodes.forEach(child => parseNode(child, effectiveMask));
           }
         };
 
-        contentNode.childNodes.forEach(child => parseNode(child, false));
+        // 💡 여기서 추가로 체크! 
+        // 만약 .script-content(텍스트 감싸는 영역) 자체나 최상위 블록에 마스킹 스타일이 입혀졌을 경우를 대비합니다.
+        const contentBg = (contentNode as HTMLElement).style?.backgroundColor || '';
+        const normalizedContentBg = contentBg.replace(/\s+/g, '').toLowerCase();
+        const isContentBlockMasked =
+          normalizedContentBg.includes('rgb(255,204,0)') ||
+          normalizedContentBg.includes('#ffcc00') ||
+          (contentNode as HTMLElement).classList.contains('masked-piece');
+
+        // 탐색 시작 시 기본 마스킹 상태를 위에서 검사한 결과로 설정합니다.
+        contentNode.childNodes.forEach(child => parseNode(child, isContentBlockMasked));
 
         if (!payloadMap.has(scriptId)) {
           payloadMap.set(scriptId, pieces);
@@ -201,6 +219,7 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
         }
       });
 
+      // 이하 변환 및 전송 로직 (기존과 동일)
       const payloadScripts = Array.from(payloadMap.entries()).map(([scriptId, rawPieces]) => {
         const mergedPieces = rawPieces.reduce((acc, current) => {
           if (acc.length > 0 && acc[acc.length - 1].isMasked === current.isMasked) {
@@ -297,12 +316,12 @@ export default function ScriptEditPage({ params }: { params: Promise<{ id: strin
       <style>{`
         .editor-container { outline: none; }
         .editor-container ::selection { background-color: rgba(59, 130, 246, 0.4) !important; color: inherit; }
-        .editor-container span[style*="background-color"] { border-radius: 3px; padding: 2px 0; }
+        .editor-container span[style*="background-color"], .editor-container .masked-piece { background-color: rgb(255, 204, 0) !important; border-radius: 3px; padding: 2px 0; }
         .editor-container span[style*="transparent"], .editor-container span[style*="rgba(0, 0, 0, 0)"] { background-color: transparent !important; }
         
         .editor-container.mentee-view span[style*="rgb(255, 204, 0)"], 
         .editor-container.mentee-view span[style*="#FFCC00"], 
-        .editor-container.mentee-view span[style*="#ffcc00"] {
+        .editor-container.mentee-view .masked-piece {
           color: transparent !important; background-color: #FFCC00 !important; user-select: none;
         }
       `}</style>

--- a/services/core-api/src/routes/mentorings.js
+++ b/services/core-api/src/routes/mentorings.js
@@ -145,7 +145,7 @@ router.get('/group', async (req, res, next) => {
                             ? mentoring.hostMentor.mentorProfile.fields.map(f => f.fieldName)
                             : [],
                     },
-                    participantCount: mentoring._count.participants + 1,
+                    participantCount: mentoring._count.participants,
                 })),
             })
         );
@@ -701,7 +701,7 @@ router.post('/:id/recommendations', requireUser, async (req, res, next) => {
         // 4. DB 조회: STT 스크립트 추출 (최근 3개)
         const recentScripts = await prisma.script.findMany({
             where: { mentoringId },
-            orderBy: { createdAt: 'desc' }, 
+            orderBy: { createdAt: 'desc' },
             take: 3,
         });
 
@@ -709,14 +709,14 @@ router.post('/:id/recommendations', requireUser, async (req, res, next) => {
         const formattedScripts = recentScripts
             .reverse() // 최신순으로 가져왔으므로 다시 시간순으로 정렬
             // 스키마에 따라 content 또는 text 필드 사용 (여기서는 content로 가정)
-            .map(s => `멘토 (음성인식): ${s.content?.text || s.content || ''}`) 
+            .map(s => `멘토 (음성인식): ${s.content?.text || s.content || ''}`)
             .join('\n');
 
         const formattedChats = Array.isArray(chats)
             ? chats.map(c => `${c.author}: ${c.content}`).join('\n')
             : '';
 
-        const excludeText = excludeQuestions.length > 0 
+        const excludeText = excludeQuestions.length > 0
             ? `\n[주의 및 지시사항]\n아래 질문들은 이전에 이미 추천된 질문입니다. 반드시 아래 내용과 겹치지 않는 완전히 새로운 질문을 생성하세요:\n${excludeQuestions.map(q => `- ${q}`).join('\n')}`
             : '';
 
@@ -762,7 +762,7 @@ ${excludeText}
 
     } catch (error) {
         console.error('🚨 Core API - AI 추천 중계 실패:', error?.response?.data || error.message);
-        
+
         if (error.response) {
             return res.status(error.response.status).json({
                 message: error.response.data?.message || '추천 서비스 통신 오류',

--- a/services/core-api/src/routes/mentorings.js
+++ b/services/core-api/src/routes/mentorings.js
@@ -580,7 +580,7 @@ router.get('/one-on-one', requireUser, async (req, res, next) => {
                 ? mentoring.participants.find((p) => p.userId !== currentUserId)?.user
                 : mentoring.hostMentor;
             const normalizedStatus = mentoring.status === 'COMPLETED' ? 'COMPLETE' : mentoring.status;
-            const counterpartRole = isHost ? 'MENTEE' : 'MENTOR';
+            const counterpartRole = isHost ? 'MENTOR' : 'MENTEE';
 
             return {
                 mentoringId: mentoring.mentoringId,

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -129,11 +129,12 @@ router.get('/', requireUser, async (req, res, next) => {
     try {
         // 스크립트 유형 (전체/1:N/1:1)
         const type = parseType(req.query.type);
+        const currentUserId = req.user.userId;
 
         // 조건에 맞는 멘토링 목록 조회
         const mentorings = await prisma.mentoring.findMany({
             where: {
-                ...buildParticipatedMentoringWhere(req.user.userId, type),
+                ...buildParticipatedMentoringWhere(currentUserId, type),
                 scripts: {
                     some: {},
                 },
@@ -146,6 +147,16 @@ router.get('/', requireUser, async (req, res, next) => {
                         },
                     },
                 },
+                participants: {
+                    include: {
+                        user: {
+                            select: {
+                                userId: true,
+                                nickname: true,
+                            }
+                        }
+                    }
+                },
                 _count: {
                     select: {
                         scripts: true,
@@ -157,20 +168,39 @@ router.get('/', requireUser, async (req, res, next) => {
 
         res.json(
             serialize({
-                mentorings: mentorings.map((mentoring) => ({
-                    mentoringId: mentoring.mentoringId,
-                    title: mentoring.title,
-                    startedAt: mentoring.startedAt,
-                    endedAt: mentoring.endedAt ?? null,
-                    isGroup: mentoring.isGroup,
-                    isScriptPublished: mentoring.isScriptPublished,
-                    host: {
-                        userId: mentoring.hostMentor.userId,
-                        nickname: mentoring.hostMentor.nickname,
-                        mentorId: mentoring.hostMentor.mentorProfile?.mentorId ?? null,
-                    },
-                    scriptCount: mentoring._count.scripts,
-                })),
+                mentorings: mentorings.map((mentoring) => {
+                    const isUserHost = mentoring.hostMentor.userId === currentUserId;
+
+                    // 일대일(1:1)이고 내가 호스트라면 상대방은 첫 번째 참여자(멘티)
+                    // 그 외(내가 멘티이거나 1:N)라면 상대방은 호스트(멘토)
+                    const isOneOnOne = !mentoring.isGroup;
+                    const counterpartUser = (isOneOnOne && isUserHost && mentoring.participants?.[0]?.user)
+                        ? mentoring.participants[0].user
+                        : mentoring.hostMentor;
+
+                    return {
+                        mentoringId: mentoring.mentoringId,
+                        title: mentoring.title,
+                        startedAt: mentoring.startedAt,
+                        endedAt: mentoring.endedAt ?? null,
+                        isGroup: mentoring.isGroup,
+                        isScriptPublished: mentoring.isScriptPublished,
+
+                        // 기존 host 객체는 유지하되, 프론트엔드 뷰에 맞춰 counterpart 객체를 추가
+                        host: {
+                            userId: mentoring.hostMentor.userId,
+                            nickname: mentoring.hostMentor.nickname,
+                            mentorId: mentoring.hostMentor.mentorProfile?.mentorId ?? null,
+                        },
+                        counterpart: {
+                            userId: counterpartUser.userId,
+                            nickname: counterpartUser.nickname,
+                            // 내가 멘토인 경우 상대는 멘티이므로 role 판별에 쓸 수 있게 보냅니다.
+                            role: isUserHost ? "MENTEE" : "MENTOR"
+                        },
+                        scriptCount: mentoring._count.scripts,
+                    };
+                }),
             })
         );
     } catch (error) {

--- a/services/core-api/src/routes/scripts.js
+++ b/services/core-api/src/routes/scripts.js
@@ -82,16 +82,17 @@ function getVisibleContent(script, viewerUserId) {
             isPrivate: script.isPrivate || false,
             pieces: content.pieces.map(piece => ({
                 text: piece.text || '',
-                isMasked: piece.isMasked || false
+                isMasked: !!piece.isMasked
             }))
         };
     }
 
     if (hasMaskedFlag(script.content)) {
         // 마스킹된 단락은 멘토/멘티 모두 원문 비노출
+        const rawText = content?.text || (typeof content === 'string' ? content : '');
         return {
             isPrivate: script.isPrivate || false,
-            pieces: [{ text: content?.text || '마스킹된 단락입니다.', isMasked: true }]
+            pieces: [{ text: rawText || '마스킹된 단락입니다.', isMasked: true }]
         };
     }
 
@@ -177,7 +178,7 @@ router.get('/', requireUser, async (req, res, next) => {
     }
 });
 
-// [GET] /scripts/{mentoringId} - 해당 멘토링의 스크립트 전문 조회
+// [GET] /scripts/{mentoringId} - 해당 멘토링의 발행 완료된 스크립트 전문 조회
 router.get('/:mentoringId', requireUser, async (req, res, next) => {
     try {
         let mentoringId;

--- a/services/stt-service/src/routes/stt.js
+++ b/services/stt-service/src/routes/stt.js
@@ -199,7 +199,7 @@ router.post("/upload", upload.single("audio"), async (req, res) => {
   }
 });
 
-// 전체 스크립트 조회 api
+// 스크립트 발행 전 수정을 위한 전체 스크립트 조회 api
 router.get("/mentoring/:mentoringId", async (req, res) => {
   try {
     const { mentoringId } = req.params;


### PR DESCRIPTION
## 연관된 이슈

#166 

## 작업 내용

- 스크립트 수정 화면에서 원클릭 기능 제거
- 마스킹/마스킹취소 버튼 아이콘을 텍스트로 대체
- 단락 전체 마스킹이 안되는 문제 해결
- 비공개 질문이 전체 마스킹이 되어 저장되는 문제 해결
- 스크립트 조회시 비공개 질문과 답변 시작과 끝에 표시 추가
- 일대다 멘토링 멘토 화면에서 음성 명령 버튼 업데이트 (질문 듣기 / 다시 듣기 / 답변 완료)
- 일대일 멘토링 혹은 스크립트 목록 화면에서 멘토일 때 멘티의 이름이 보이도록 수정
- 멘토링 인원수에서 멘토 빼기
- 멘토 카메라 좌우 반전

## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 점 작성