### PR TITLE
fix(front): remove completed question cards from queue

### DIFF
--- a/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
+++ b/apps/demo-web/app/mentoring/live/mentor/[id]/page.tsx
@@ -342,17 +342,23 @@ function MentorLiveContent({ mentoringId, role, userId, userName }: { mentoringI
         }
 
         // 클러스터 결과를 순회하며 화면에 띄울 대표 질문 객체 생성
-        const mappedQueue = clusters.map(cluster => {
-            const repId = Number(cluster.representative_question_id);
-            const originalQ = activeQuestions.find(q => q.id === repId) || activeQuestions[0];
+        const mappedQueue = clusters
+            .map(cluster => {
+                const repId = Number(cluster.representative_question_id);
+                const originalQ = activeQuestions.find(q => q.id === repId);
 
-            return {
-                ...originalQ,
-                id: repId,
-                content: cluster.representative_question, // AI 정제 텍스트
-                clusterSize: cluster.member_questions?.length || 1,
-            } as Question;
-        });
+                if (!originalQ) {
+                    return null;
+                }
+
+                return {
+                    ...originalQ,
+                    id: originalQ.id,
+                    content: cluster.representative_question, // AI 정제 텍스트
+                    clusterSize: cluster.member_questions?.length || 1,
+                } as Question;
+            })
+            .filter((q): q is Question => q !== null);
 
         // 최종 하이브리드 정렬 실행
         return mappedQueue.sort((a, b) => {


### PR DESCRIPTION
## 연관된 이슈

#180 

## 작업 내용

- 답변 완료된 질문 카드가 클러스터 기반 질문 큐에서 다시 생성되지 않도록 수정했습니다.
- 클러스터 대표 질문이 현재 활성 질문 목록에 없으면 해당 클러스터 카드를 큐에서 제외합니다.


## 체크 리스트
- [ ] 코드가 정상적으로 컴파일되나요?
- [ ] (추가한 기능이 있는 경우) 추가한 기능이 정상적으로 작동하나요?
- [ ] merge할 브랜치의 위치를 확인했나요?

## 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 점 작성